### PR TITLE
feature: add stubs for all buildings

### DIFF
--- a/game/src/buildings/__tests__/bakery.test.ts
+++ b/game/src/buildings/__tests__/bakery.test.ts
@@ -5,7 +5,12 @@ import { GameStatePlaying, PlayerColor } from '../../types'
 import { bakery } from '../bakery'
 
 describe('buildings/bakery', () => {
-  describe('use', () => {
+  describe('bakery', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = bakery()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('bakes bread using wood, then converts to coins', () => {
       expect.assertions(3)
       const s0 = initialState

--- a/game/src/buildings/__tests__/bathhouse.test.ts
+++ b/game/src/buildings/__tests__/bathhouse.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { bathhouse } from '../bathhouse'
 
 describe('buildings/bathhouse', () => {
-  describe('use', () => {
+  describe('bathhouse', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = bathhouse()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/bathhouse.test.ts
+++ b/game/src/buildings/__tests__/bathhouse.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/bathhouse', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/buildersMarket.test.ts
+++ b/game/src/buildings/__tests__/buildersMarket.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { buildersMarket } from '../buildersMarket'
 
 describe('buildings/buildersMarket', () => {
-  describe('use', () => {
+  describe('buildersMarket', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = buildersMarket()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/buildersMarket.test.ts
+++ b/game/src/buildings/__tests__/buildersMarket.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/buildersMarket', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/calefacotory.test.ts
+++ b/game/src/buildings/__tests__/calefacotory.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/calefactory', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/calefactory.test.ts
+++ b/game/src/buildings/__tests__/calefactory.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { calefactory } from '../calefactory'
 
 describe('buildings/calefactory', () => {
-  describe('use', () => {
+  describe('calefactory', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = calefactory()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/castle.test.ts
+++ b/game/src/buildings/__tests__/castle.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { castle } from '../castle'
 
 describe('buildings/castle', () => {
-  describe('use', () => {
+  describe('castle', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = castle()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/castle.test.ts
+++ b/game/src/buildings/__tests__/castle.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/castle', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/chamberOfWonders.test.ts
+++ b/game/src/buildings/__tests__/chamberOfWonders.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { chamberOfWonders } from '../chamberOfWonders'
 
 describe('buildings/chamberOfWonders', () => {
-  describe('use', () => {
+  describe('chamberOfWonders', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = chamberOfWonders()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/chamberOfWonders.test.ts
+++ b/game/src/buildings/__tests__/chamberOfWonders.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/chamberOfWonders', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/clayMound.test.ts
+++ b/game/src/buildings/__tests__/clayMound.test.ts
@@ -1,11 +1,14 @@
-import { config } from '../../commands/config'
-import { start } from '../../commands/start'
 import { reducer, initialState } from '../../reducer'
-import { BuildingEnum, GameStatePlaying, PlayerColor, ResourceEnum } from '../../types'
+import { GameStatePlaying } from '../../types'
 import { clayMound } from '../clayMound'
 
 describe('buildings/clayMound', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = clayMound()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       expect.assertions(7)
       const s0 = initialState

--- a/game/src/buildings/__tests__/cloisterChapterHouse.test.ts
+++ b/game/src/buildings/__tests__/cloisterChapterHouse.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/cloisterChapterHouse', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/cloisterChapterHouse.test.ts
+++ b/game/src/buildings/__tests__/cloisterChapterHouse.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterChapterHouse } from '../cloisterChapterHouse'
 
 describe('buildings/cloisterChapterHouse', () => {
-  describe('use', () => {
+  describe('cloisterChapterHouse', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterChapterHouse()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/cloisterChurch.test.ts
+++ b/game/src/buildings/__tests__/cloisterChurch.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterChurch } from '../cloisterChurch'
 
 describe('buildings/cloisterChurch', () => {
-  describe('use', () => {
+  describe('cloisterChurch', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterChurch()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/cloisterChurch.test.ts
+++ b/game/src/buildings/__tests__/cloisterChurch.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/cloisterChurch', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/cloisterCourtyard.test.ts
+++ b/game/src/buildings/__tests__/cloisterCourtyard.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterCourtyard } from '../cloisterCourtyard'
 
 describe('buildings/cloisterCourtyard', () => {
-  describe('use', () => {
+  describe('cloisterCourtyard', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterCourtyard()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '3', 'france', 'short'])!

--- a/game/src/buildings/__tests__/cloisterGarden.test.ts
+++ b/game/src/buildings/__tests__/cloisterGarden.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterGarden } from '../cloisterGarden'
 
 describe('buildings/cloisterGarden', () => {
-  describe('use', () => {
+  describe('cloisterGarden', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterGarden()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'short'])!

--- a/game/src/buildings/__tests__/cloisterLibrary.test.ts
+++ b/game/src/buildings/__tests__/cloisterLibrary.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/cloisterLibrary', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/cloisterLibrary.test.ts
+++ b/game/src/buildings/__tests__/cloisterLibrary.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterLibrary } from '../cloisterLibrary'
 
 describe('buildings/cloisterLibrary', () => {
-  describe('use', () => {
+  describe('cloisterLibrary', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterLibrary()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/cloisterOffice.test.ts
+++ b/game/src/buildings/__tests__/cloisterOffice.test.ts
@@ -1,11 +1,14 @@
-import { config } from '../../commands/config'
-import { start } from '../../commands/start'
 import { reducer, initialState } from '../../reducer'
-import { BuildingEnum, GameStatePlaying, PlayerColor, ResourceEnum } from '../../types'
+import { GameStatePlaying } from '../../types'
 import { clayMound } from '../clayMound'
 
 describe('buildings/clayMound', () => {
-  describe('use', () => {
+  describe('clayMound', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = clayMound()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       expect.assertions(7)
       const s0 = initialState

--- a/game/src/buildings/__tests__/cloisterWorkshop.test.ts
+++ b/game/src/buildings/__tests__/cloisterWorkshop.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterWorkshop } from '../cloisterWorkshop'
 
 describe('buildings/cloisterWorkshop', () => {
-  describe('use', () => {
+  describe('cloisterWorkshop', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterWorkshop()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/cloisterWorkshop.test.ts
+++ b/game/src/buildings/__tests__/cloisterWorkshop.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/cloisterWorkshop', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/dormitory.test.ts
+++ b/game/src/buildings/__tests__/dormitory.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/dormitory', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/dormitory.test.ts
+++ b/game/src/buildings/__tests__/dormitory.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { dormitory } from '../dormitory'
 
 describe('buildings/dormitory', () => {
-  describe('use', () => {
+  describe('dormitory', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = dormitory()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/estate.test.ts
+++ b/game/src/buildings/__tests__/estate.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { estate } from '../estate'
 
 describe('buildings/estate', () => {
-  describe('use', () => {
+  describe('estate', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = estate()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/estate.test.ts
+++ b/game/src/buildings/__tests__/estate.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/estate', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/farmyard.test.ts
+++ b/game/src/buildings/__tests__/farmyard.test.ts
@@ -1,11 +1,16 @@
 import { config } from '../../commands/config'
 import { start } from '../../commands/start'
-import { reducer, initialState } from '../../reducer'
-import { BuildingEnum, PlayerColor, ResourceEnum } from '../../types'
+import { initialState } from '../../reducer'
+import { GameStatePlaying, PlayerColor } from '../../types'
 import { farmyard } from '../farmyard'
 
 describe('buildings/farmyard', () => {
-  describe('use', () => {
+  describe('farmyard', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = farmyard()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       expect.assertions(8)
       const s0 = initialState

--- a/game/src/buildings/__tests__/financedEstate.test.ts
+++ b/game/src/buildings/__tests__/financedEstate.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/financedEstate', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/financedEstate.test.ts
+++ b/game/src/buildings/__tests__/financedEstate.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { financedEstate } from '../financedEstate'
 
 describe('buildings/financedEstate', () => {
-  describe('use', () => {
+  describe('financedEstate', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = financedEstate()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/forgersWorkshop.test.ts
+++ b/game/src/buildings/__tests__/forgersWorkshop.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { forgersWorkshop } from '../forgersWorkshop'
 
 describe('buildings/forgersWorkshop', () => {
-  describe('use', () => {
+  describe('forgersWorkshop', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = forgersWorkshop()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/forgersWorkshop.test.ts
+++ b/game/src/buildings/__tests__/forgersWorkshop.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/forgersWorkshop', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/fuelMerchant.test.ts
+++ b/game/src/buildings/__tests__/fuelMerchant.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { fuelMerchant } from '../fuelMerchant'
 
-describe('buildings/cloisterCourtyard', () => {
-  describe('use', () => {
+describe('buildings/fuelMerchant', () => {
+  describe('fuelMerchant', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = fuelMerchant()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'short'])!

--- a/game/src/buildings/__tests__/grainStorage.test.ts
+++ b/game/src/buildings/__tests__/grainStorage.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { cloisterCourtyard } from '../cloisterCourtyard'
 
 describe('buildings/cloisterCourtyard', () => {
-  describe('use', () => {
+  describe('cloisterCourtyard', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = cloisterCourtyard()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'short'])!

--- a/game/src/buildings/__tests__/grapevine.test.ts
+++ b/game/src/buildings/__tests__/grapevine.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { grapevine } from '../grapevine'
 
 describe('buildings/grapevine', () => {
-  describe('use', () => {
+  describe('grapevine', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = grapevine()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/grapevine.test.ts
+++ b/game/src/buildings/__tests__/grapevine.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/grapevine', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/harborPromenade.test.ts
+++ b/game/src/buildings/__tests__/harborPromenade.test.ts
@@ -1,8 +1,14 @@
 import { initialState, reducer } from '../../reducer'
 import { GameStatePlaying, NextUseClergy } from '../../types'
+import { harborPromenade } from '../harborPromenade'
 
-describe('buildings/carpentry', () => {
-  describe('use', () => {
+describe('buildings/harborPromenade', () => {
+  describe('harborPromenade', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = harborPromenade()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/harborPromenade.test.ts
+++ b/game/src/buildings/__tests__/harborPromenade.test.ts
@@ -1,0 +1,31 @@
+import { initialState, reducer } from '../../reducer'
+import { GameStatePlaying, NextUseClergy } from '../../types'
+
+describe('buildings/carpentry', () => {
+  describe('use', () => {
+    it('goes through a happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'G', 'B', 'W'])! as GameStatePlaying
+      expect(s2.activePlayerIndex).toBe(0)
+      expect(s2.players[0].color).toBe('W')
+      expect(s2.players[1].color).toBe('B')
+      expect(s2.players[2].color).toBe('G')
+      expect(s2.players[3].color).toBe('R')
+      expect(s2.nextUse).toBe(NextUseClergy.Any)
+      s2.players[0].wood = 2
+      s2.players[0].clay = 1
+      const s3 = reducer(s2, ['BUILD', 'F10', '3', '1'])! as GameStatePlaying
+      expect(s3).toMatchObject({
+        nextUse: NextUseClergy.OnlyPrior,
+        usableBuildings: ['F10'],
+      })
+      // const s4 = reducer(s3, ['USE', 'F10', '0', '1'])! as GameStatePlaying
+      // expect(s4).toMatchObject({
+      //   usableBuildings: [],
+      //   nextUse: NextUseClergy.None,
+      // })
+      // expect(s4.players[0].landscape[0][1]).toStrictEqual(['P'])
+    })
+  })
+})

--- a/game/src/buildings/__tests__/hospice.test.ts
+++ b/game/src/buildings/__tests__/hospice.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/hospice', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/hospice.test.ts
+++ b/game/src/buildings/__tests__/hospice.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { hospice } from '../hospice'
 
 describe('buildings/hospice', () => {
-  describe('use', () => {
+  describe('hospice', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = hospice()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/houseOfTheBrotherhood.test.ts
+++ b/game/src/buildings/__tests__/houseOfTheBrotherhood.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/houseOfTheBrotherhood', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/houseOfTheBrotherhood.test.ts
+++ b/game/src/buildings/__tests__/houseOfTheBrotherhood.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { houseOfTheBrotherhood } from '../houseOfTheBrotherhood'
 
 describe('buildings/houseOfTheBrotherhood', () => {
-  describe('use', () => {
+  describe('houseOfTheBrotherhood', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = houseOfTheBrotherhood()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/inn.test.ts
+++ b/game/src/buildings/__tests__/inn.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { inn } from '../inn'
 
 describe('buildings/inn', () => {
-  describe('use', () => {
+  describe('inn', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = inn()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/inn.test.ts
+++ b/game/src/buildings/__tests__/inn.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/inn', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/market.test.ts
+++ b/game/src/buildings/__tests__/market.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { market } from '../market'
 
 describe('buildings/market', () => {
-  describe('use', () => {
+  describe('market', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = market()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'short'])!

--- a/game/src/buildings/__tests__/palace.test.ts
+++ b/game/src/buildings/__tests__/palace.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/palace', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/palace.test.ts
+++ b/game/src/buildings/__tests__/palace.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { palace } from '../palace'
 
 describe('buildings/palace', () => {
-  describe('use', () => {
+  describe('palace', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = palace()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/peatCoalKiln.test.ts
+++ b/game/src/buildings/__tests__/peatCoalKiln.test.ts
@@ -6,6 +6,11 @@ import { peatCoalKiln } from '../peatCoalKiln'
 
 describe('buildings/peatCoalKiln', () => {
   describe('peatCoalKiln', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = peatCoalKiln()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       expect.assertions(4)
       const s0 = initialState

--- a/game/src/buildings/__tests__/pilgrimageSite.test.ts
+++ b/game/src/buildings/__tests__/pilgrimageSite.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/pilgrimmageSite', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/pilgrimageSite.test.ts
+++ b/game/src/buildings/__tests__/pilgrimageSite.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { pilgrimmageSite } from '../pilgrimageSite'
 
 describe('buildings/pilgrimmageSite', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = pilgrimmageSite()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/printingOffice.test.ts
+++ b/game/src/buildings/__tests__/printingOffice.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/printingOffice', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/printingOffice.test.ts
+++ b/game/src/buildings/__tests__/printingOffice.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { printingOffice } from '../printingOffice'
 
 describe('buildings/printingOffice', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = printingOffice()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/priory.test.ts
+++ b/game/src/buildings/__tests__/priory.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { BuildingEnum, Clergy, GameStatePlaying, LandEnum, NextUseClergy, PlayerColor } from '../../types'
+import { priory } from '../priory'
 
 describe('buildings/proiry', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = priory()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('using priory allows usage of many buildings except itself', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '3', 'france', 'short'])!

--- a/game/src/buildings/__tests__/quarry.test.ts
+++ b/game/src/buildings/__tests__/quarry.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { quarry } from '../quarry'
 
 describe('buildings/quarry', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = quarry()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/quarry.test.ts
+++ b/game/src/buildings/__tests__/quarry.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/quarry', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/sacristy.test.ts
+++ b/game/src/buildings/__tests__/sacristy.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/sacristy', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/sacristy.test.ts
+++ b/game/src/buildings/__tests__/sacristy.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { sacristy } from '../sacristy'
 
 describe('buildings/sacristy', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = sacristy()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/shippingCompany.test.ts
+++ b/game/src/buildings/__tests__/shippingCompany.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { shippingCompany } from '../shippingCompany'
 
 describe('buildings/shippingCompany', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = shippingCompany()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/shippingCompany.test.ts
+++ b/game/src/buildings/__tests__/shippingCompany.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/shippingCompany', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/shipyard.test.ts
+++ b/game/src/buildings/__tests__/shipyard.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { shipyard } from '../shipyard'
 
 describe('buildings/shipyard', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = shipyard()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/shipyard.test.ts
+++ b/game/src/buildings/__tests__/shipyard.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/shipyard', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/slaughterhouse.test.ts
+++ b/game/src/buildings/__tests__/slaughterhouse.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { slaughterhouse } from '../slaughterhouse'
 
 describe('buildings/slaughterhouse', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = slaughterhouse()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/slaughterhouse.test.ts
+++ b/game/src/buildings/__tests__/slaughterhouse.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/slaughterhouse', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/stoneMerchant.test.ts
+++ b/game/src/buildings/__tests__/stoneMerchant.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { stoneMerchant } from '../stoneMerchant'
 
 describe('buildings/stoneMerchant', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = stoneMerchant()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'short'])!

--- a/game/src/buildings/__tests__/townEstate.test.ts
+++ b/game/src/buildings/__tests__/townEstate.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/townEstate', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/__tests__/townEstate.test.ts
+++ b/game/src/buildings/__tests__/townEstate.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { townEstate } from '../townEstate'
 
 describe('buildings/townEstate', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = townEstate()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/windmill.test.ts
+++ b/game/src/buildings/__tests__/windmill.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { BuildingEnum, GameStatePlaying } from '../../types'
+import { windmill } from '../windmill'
 
 describe('buildings/cloisterCourtyard', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = windmill()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('goes through a happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '1', 'france', 'long'])!

--- a/game/src/buildings/__tests__/winery.test.ts
+++ b/game/src/buildings/__tests__/winery.test.ts
@@ -1,8 +1,14 @@
 import { reducer, initialState } from '../../reducer'
 import { GameStatePlaying } from '../../types'
+import { winery } from '../winery'
 
 describe('buildings/winery', () => {
   describe('use', () => {
+    it('retains undefined state', () => {
+      const s0: GameStatePlaying | undefined = undefined
+      const s1 = winery()(s0)
+      expect(s1).toBeUndefined()
+    })
     it('baseline happy path', () => {
       const s0 = initialState
       const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!

--- a/game/src/buildings/__tests__/winery.test.ts
+++ b/game/src/buildings/__tests__/winery.test.ts
@@ -1,0 +1,13 @@
+import { reducer, initialState } from '../../reducer'
+import { GameStatePlaying } from '../../types'
+
+describe('buildings/winery', () => {
+  describe('use', () => {
+    it('baseline happy path', () => {
+      const s0 = initialState
+      const s1 = reducer(s0, ['CONFIG', '4', 'france', 'long'])!
+      const s2 = reducer(s1, ['START', '42', 'R', 'B', 'G', 'W'])! as GameStatePlaying
+      expect(s2).toBeDefined()
+    })
+  })
+})

--- a/game/src/buildings/bathhouse.ts
+++ b/game/src/buildings/bathhouse.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const bathhouse = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/buildersMarket.ts
+++ b/game/src/buildings/buildersMarket.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const buildersMarket = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/calefactory.ts
+++ b/game/src/buildings/calefactory.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const calefactory = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/castle.ts
+++ b/game/src/buildings/castle.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const castle = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/chamberOfWonders.ts
+++ b/game/src/buildings/chamberOfWonders.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const chamberOfWonders = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/cloisterChapterHouse.ts
+++ b/game/src/buildings/cloisterChapterHouse.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const cloisterChapterHouse = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/cloisterChurch.ts
+++ b/game/src/buildings/cloisterChurch.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const cloisterChurch = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/cloisterLibrary.ts
+++ b/game/src/buildings/cloisterLibrary.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const cloisterLibrary = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/cloisterWorkshop.ts
+++ b/game/src/buildings/cloisterWorkshop.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const cloisterWorkshop = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/dormitory.ts
+++ b/game/src/buildings/dormitory.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const dormitory = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/estate.ts
+++ b/game/src/buildings/estate.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const estate = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/financedEstate.ts
+++ b/game/src/buildings/financedEstate.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const financedEstate = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/forgersWorkshop.ts
+++ b/game/src/buildings/forgersWorkshop.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const forgersWorkshop = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/grapevine.ts
+++ b/game/src/buildings/grapevine.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const grapevine = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/harborPromenade.ts
+++ b/game/src/buildings/harborPromenade.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const harborPromenade = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/hospice.ts
+++ b/game/src/buildings/hospice.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const hospice = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/houseOfTheBrotherhood.ts
+++ b/game/src/buildings/houseOfTheBrotherhood.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const houseOfTheBrotherhood = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/inn.ts
+++ b/game/src/buildings/inn.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const inn = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/palace.ts
+++ b/game/src/buildings/palace.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const palace = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/pilgrimageSite.ts
+++ b/game/src/buildings/pilgrimageSite.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const pilgrimmageSite = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/printingOffice.ts
+++ b/game/src/buildings/printingOffice.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const printingOffice = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/quarry.ts
+++ b/game/src/buildings/quarry.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const quarry = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/sacristy.ts
+++ b/game/src/buildings/sacristy.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const sacristy = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/shippingCompany.ts
+++ b/game/src/buildings/shippingCompany.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const shippingCompany = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/shipyard.ts
+++ b/game/src/buildings/shipyard.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const shipyard = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/slaughterhouse.ts
+++ b/game/src/buildings/slaughterhouse.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const slaughterhouse = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/townEstate.ts
+++ b/game/src/buildings/townEstate.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const townEstate = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/buildings/winery.ts
+++ b/game/src/buildings/winery.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'ramda'
+import { GameStatePlaying } from '../types'
+
+const buildingStub = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return state
+}
+
+export const winery = () =>
+  pipe(
+    //
+    buildingStub,
+    buildingStub,
+    buildingStub
+  )

--- a/game/src/commands/use.ts
+++ b/game/src/commands/use.ts
@@ -2,18 +2,46 @@ import { pipe } from 'ramda'
 import { match, P } from 'ts-pattern'
 import { getPlayer, isLayBrother, isPrior, setPlayer } from '../board/player'
 import { bakery } from '../buildings/bakery'
+import { bathhouse } from '../buildings/bathhouse'
+import { buildersMarket } from '../buildings/buildersMarket'
+import { calefactory } from '../buildings/calefactory'
+import { castle } from '../buildings/castle'
+import { chamberOfWonders } from '../buildings/chamberOfWonders'
 import { clayMound } from '../buildings/clayMound'
+import { cloisterChapterHouse } from '../buildings/cloisterChapterHouse'
+import { cloisterChurch } from '../buildings/cloisterChurch'
 import { cloisterCourtyard } from '../buildings/cloisterCourtyard'
 import { cloisterGarden } from '../buildings/cloisterGarden'
+import { cloisterLibrary } from '../buildings/cloisterLibrary'
 import { cloisterOffice } from '../buildings/cloisterOffice'
+import { cloisterWorkshop } from '../buildings/cloisterWorkshop'
+import { dormitory } from '../buildings/dormitory'
+import { estate } from '../buildings/estate'
 import { farmyard } from '../buildings/farmyard'
+import { financedEstate } from '../buildings/financedEstate'
+import { forgersWorkshop } from '../buildings/forgersWorkshop'
 import { fuelMerchant } from '../buildings/fuelMerchant'
 import { grainStorage } from '../buildings/grainStorage'
+import { grapevine } from '../buildings/grapevine'
+import { harborPromenade } from '../buildings/harborPromenade'
+import { hospice } from '../buildings/hospice'
+import { houseOfTheBrotherhood } from '../buildings/houseOfTheBrotherhood'
+import { inn } from '../buildings/inn'
 import { market } from '../buildings/market'
+import { palace } from '../buildings/palace'
 import { peatCoalKiln } from '../buildings/peatCoalKiln'
+import { pilgrimmageSite } from '../buildings/pilgrimageSite'
+import { printingOffice } from '../buildings/printingOffice'
 import { priory } from '../buildings/priory'
+import { quarry } from '../buildings/quarry'
+import { sacristy } from '../buildings/sacristy'
+import { shippingCompany } from '../buildings/shippingCompany'
+import { shipyard } from '../buildings/shipyard'
+import { slaughterhouse } from '../buildings/slaughterhouse'
 import { stoneMerchant } from '../buildings/stoneMerchant'
+import { townEstate } from '../buildings/townEstate'
 import { windmill } from '../buildings/windmill'
+import { winery } from '../buildings/winery'
 import { BuildingEnum, GameStatePlaying, NextUseClergy, Tile } from '../types'
 
 const checkBuildingUsable =
@@ -117,21 +145,51 @@ export const use = (building: BuildingEnum, params: string[]) =>
       building,
       params,
     ])
-      .with([BuildingFarmyard, [P.select()]], farmyard)
+      .with([BuildingEnum.Bakery, [P._]], ([_, params]) => bakery(params[0]))
+      .with([BuildingEnum.Bathhouse, []], bathhouse)
+      .with([BuildingEnum.BuildersMarket, []], buildersMarket)
+      .with([BuildingEnum.Calefactory, []], calefactory)
+      .with([BuildingEnum.Castle, []], castle)
+      .with([BuildingEnum.ChamberOfWonders, []], chamberOfWonders)
       .with([BuildingClaymound, [P._]], [BuildingClaymound, []], ([_, params]) => clayMound(params[0]))
+      .with([BuildingEnum.CloisterChapterHouse, []], cloisterChapterHouse)
+      .with([BuildingEnum.CloisterChurch, []], cloisterChurch)
+      .with([BuildingEnum.CloisterCourtyard, [P._, P._]], ([_, params]) => cloisterCourtyard(params[0], params[1]))
+      .with([BuildingEnum.CloisterGarden, []], cloisterGarden)
+      .with([BuildingEnum.CloisterLibrary, []], cloisterLibrary)
       .with([BuildingCloisterOffice, [P._]], [BuildingCloisterOffice, []], ([_, params]) => cloisterOffice(params[0]))
+      .with([BuildingEnum.CloisterWorkshop, []], cloisterWorkshop)
+      .with([BuildingEnum.Dormitory, []], dormitory)
+      .with([BuildingEnum.Estate, []], estate)
+      .with([BuildingFarmyard, [P.select()]], farmyard)
+      .with([BuildingEnum.FinancedEstate, []], financedEstate)
+      .with([BuildingEnum.ForgersWorkshop, []], forgersWorkshop)
+      .with([BuildingEnum.FuelMerchant, [P._]], ([_, params]) => fuelMerchant(params[0]))
+      .with([BuildingEnum.GrainStorage, []], grainStorage)
+      .with([BuildingEnum.GrapevineA, []], grapevine)
+      .with([BuildingEnum.GrapevineB, []], grapevine)
+      .with([BuildingEnum.HarborPromenade, []], harborPromenade)
+      .with([BuildingEnum.Hospice, []], hospice)
+      .with([BuildingEnum.HouseOfTheBrotherhood, []], houseOfTheBrotherhood)
+      .with([BuildingEnum.Inn, []], inn)
+      .with([BuildingEnum.Market, [P._]], ([_, params]) => market(params[0]))
+      .with([BuildingEnum.Palace, []], palace)
       .with([BuildingEnum.PeatCoalKiln, []], [BuildingEnum.PeatCoalKiln, [P._]], ([_, params]) =>
         peatCoalKiln(params[0])
       )
-      .with([BuildingEnum.CloisterCourtyard, [P._, P._]], ([_, params]) => cloisterCourtyard(params[0], params[1]))
-      .with([BuildingEnum.Bakery, [P._]], ([_, params]) => bakery(params[0]))
-      .with([BuildingEnum.GrainStorage, []], grainStorage)
-      .with([BuildingEnum.FuelMerchant, [P._]], ([_, params]) => fuelMerchant(params[0]))
-      .with([BuildingEnum.Windmill, [P._]], ([_, params]) => windmill(params[0]))
-      .with([BuildingEnum.Market, [P._]], ([_, params]) => market(params[0]))
-      .with([BuildingEnum.CloisterGarden, []], cloisterGarden)
-      .with([BuildingEnum.StoneMerchant, [P._]], ([_, params]) => stoneMerchant(params[0]))
+      .with([BuildingEnum.PilgrimageSite, []], pilgrimmageSite)
+      .with([BuildingEnum.PrintingOffice, []], printingOffice)
       .with([BuildingEnum.Priory, []], priory)
+      .with([BuildingEnum.QuarryA, []], quarry)
+      .with([BuildingEnum.QuarryB, []], quarry)
+      .with([BuildingEnum.Sacristy, []], sacristy)
+      .with([BuildingEnum.ShippingCompany, []], shippingCompany)
+      .with([BuildingEnum.Shipyard, []], shipyard)
+      .with([BuildingEnum.Slaughterhouse, []], slaughterhouse)
+      .with([BuildingEnum.StoneMerchant, [P._]], ([_, params]) => stoneMerchant(params[0]))
+      .with([BuildingEnum.TownEstate, []], townEstate)
+      .with([BuildingEnum.Windmill, [P._]], ([_, params]) => windmill(params[0]))
+      .with([BuildingEnum.Winery, []], winery)
       .otherwise(() => () => {
         throw new Error(`Invalid params [${params}] for building ${building}`)
       })


### PR DESCRIPTION
In writing each building one at a time, as soon as I add it to the "use" command, it starts running basically every test. I think if I stub them out first, that won't be the case.