### PR TITLE
feature: withPlayer retains original object if no changes

### DIFF
--- a/game/src/board/frame/__tests__/allPriorsComeBack.test.ts
+++ b/game/src/board/frame/__tests__/allPriorsComeBack.test.ts
@@ -1,0 +1,184 @@
+import { initialState } from '../../../state'
+import {
+  Clergy,
+  GameStatePlaying,
+  GameStatusEnum,
+  NextUseClergy,
+  PlayerColor,
+  SettlementRound,
+  Tableau,
+  Tile,
+} from '../../../types'
+import { allPriorsComeBack } from '../allPriorsComeBack'
+
+describe('board/frame/allPriorsComeBack', () => {
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: ['LB1B', 'LB2B', 'PRIB'] as Clergy[],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 100,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    hops: 0,
+    coal: 0,
+    book: 0,
+    pottery: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+    frame: {
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      workContractCost: 1,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+  }
+
+  it('retains undefined state', () => {
+    const s1 = allPriorsComeBack(undefined)!
+    expect(s1).toBeUndefined()
+  })
+
+  it('returns all priors for all players', () => {
+    const s1 = {
+      ...s0,
+      players: [
+        {
+          ...s0.players[0],
+          color: PlayerColor.Red,
+          clergy: ['LB1R', 'LB2R'],
+          landscape: [
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P', 'G06', 'PRIR'], ['H', 'LR1'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P'], ['P', 'LR3'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 0,
+        },
+
+        {
+          ...s0.players[0],
+          color: PlayerColor.Green,
+          clergy: ['LB2G'],
+          landscape: [
+            [['W'], ['C'], [], [], [], [], [], [], []],
+            [['W'], ['C'], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['H', 'LR1'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P', 'G01', 'PRIG'], ['P', 'LR3', 'LB1G'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 1,
+        },
+
+        {
+          ...s0.players[0],
+          color: PlayerColor.Blue,
+          clergy: ['LB2B'],
+          landscape: [
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['H', 'LR1', 'LB1B'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P', 'G13', 'PRIB'], ['P', 'LR3'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 0,
+        },
+      ],
+    } as GameStatePlaying
+    const s2 = allPriorsComeBack(s1)!
+    expect(s2.players[0].clergy).toContain('PRIR')
+    expect(s2.players[1].clergy).toContain('PRIG')
+    expect(s2.players[2].clergy).toContain('PRIB')
+  })
+
+  it('returns all priors if some players dont have them out', () => {
+    const s1 = {
+      ...s0,
+      players: [
+        {
+          ...s0.players[0],
+          color: PlayerColor.Red,
+          clergy: ['LB1R', 'LB2R', 'PRIR'],
+          landscape: [
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P', 'G06'], ['H', 'LR1'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P'], ['P', 'LR3'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 0,
+        },
+
+        {
+          ...s0.players[0],
+          color: PlayerColor.Green,
+          clergy: ['LB2G'],
+          landscape: [
+            [['W'], ['C'], [], [], [], [], [], [], []],
+            [['W'], ['C'], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['H', 'LR1'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P', 'G01', 'PRIG'], ['P', 'LR3', 'LB1G'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 1,
+        },
+
+        {
+          ...s0.players[0],
+          color: PlayerColor.Blue,
+          clergy: ['LB2B'],
+          landscape: [
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['H', 'LR1', 'LB1B'], [], []],
+            [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LR2'], ['P', 'G13', 'PRIB'], ['P', 'LR3'], [], []],
+          ] as Tile[][],
+          landscapeOffset: 0,
+        },
+      ],
+    } as GameStatePlaying
+    const s2 = allPriorsComeBack(s1)!
+    expect(s2.players[0]).toBe(s1.players[0]) // keep the same object because nothing changed
+    expect(s2.players[0].clergy).toContain('PRIR')
+    expect(s2.players[1]).not.toBe(s1.players[1])
+    expect(s2.players[1].clergy).toContain('PRIG')
+    expect(s2.players[2]).not.toBe(s1.players[2])
+    expect(s2.players[2].clergy).toContain('PRIB')
+  })
+
+  it('keeps previous state if nothing changed', () => {
+    const s1 = allPriorsComeBack(s0)!
+    expect(s1.players).toBe(s0.players)
+  })
+})

--- a/game/src/board/frame/__tests__/gameEnd.test.ts
+++ b/game/src/board/frame/__tests__/gameEnd.test.ts
@@ -1,0 +1,94 @@
+import { initialState } from '../../../state'
+import {
+  Clergy,
+  GameStatePlaying,
+  GameStatusEnum,
+  NextUseClergy,
+  PlayerColor,
+  SettlementRound,
+  Tableau,
+  Tile,
+} from '../../../types'
+import { gameEnd } from '../gameEnd'
+
+describe('board/frame/gameEnd', () => {
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: ['LB1B', 'LB2B', 'PRIB'] as Clergy[],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 100,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    hops: 0,
+    coal: 0,
+    book: 0,
+    pottery: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+    frame: {
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      workContractCost: 1,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+  }
+
+  it('retains undefined state', () => {
+    const s1 = gameEnd(undefined)!
+    expect(s1).toBeUndefined()
+  })
+
+  it('retain everything about previous state but set status to finished', () => {
+    const s1 = gameEnd(s0)!
+    expect(s1).toMatchObject({
+      ...s0,
+      status: GameStatusEnum.FINISHED,
+    })
+  })
+})

--- a/game/src/board/frame/__tests__/introduceBuildings.test.ts
+++ b/game/src/board/frame/__tests__/introduceBuildings.test.ts
@@ -1,0 +1,92 @@
+import { initialState } from '../../../state'
+import {
+  Clergy,
+  GameStatePlaying,
+  GameStatusEnum,
+  NextUseClergy,
+  PlayerColor,
+  SettlementRound,
+  Tableau,
+  Tile,
+} from '../../../types'
+import { introduceBuildings } from '../introduceBuildings'
+
+describe('board/frame/introduceBuildings', () => {
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: ['LB1B', 'LB2B', 'PRIB'] as Clergy[],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 100,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    hops: 0,
+    coal: 0,
+    book: 0,
+    pottery: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+    frame: {
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      workContractCost: 1,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+  }
+
+  it('retains undefined state', () => {
+    const s1 = introduceBuildings(undefined)!
+    expect(s1).toBeUndefined()
+  })
+
+  it('adds some buildings', () => {
+    const s1 = introduceBuildings(s0)!
+    expect(s0.buildings).toHaveLength(0)
+    expect(s1.buildings).not.toHaveLength(0)
+  })
+})

--- a/game/src/board/frame/introduceBuildings.ts
+++ b/game/src/board/frame/introduceBuildings.ts
@@ -1,12 +1,10 @@
 import { GameStatePlaying, SettlementRound } from '../../types'
 import { roundBuildings } from '../buildings'
 
-export const introduceBuildings =
-  (settlementRound: SettlementRound) =>
-  (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
-    if (state === undefined) return undefined
-    return {
-      ...state,
-      buildings: roundBuildings(state.config, settlementRound),
-    }
+export const introduceBuildings = (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
+  if (state === undefined) return undefined
+  return {
+    ...state,
+    buildings: roundBuildings(state.config, state.frame.settlementRound),
   }
+}

--- a/game/src/board/frame/nextFrame3Long.ts
+++ b/game/src/board/frame/nextFrame3Long.ts
@@ -18,9 +18,10 @@ export const nextFrame3Long: Record<
   1: {
     startingPlayer: 0,
     currentPlayerIndex: 0,
+    settlementRound: SettlementRound.S,
     upkeep: [
       rotateRondel,
-      introduceBuildings(SettlementRound.S),
+      introduceBuildings,
       withEachPlayer(getCost({ clay: 1, wood: 1, peat: 1, penny: 1, grain: 1, sheep: 1 })),
       returnClergyIfPlaced,
     ],
@@ -138,7 +139,7 @@ export const nextFrame3Long: Record<
   // Round 6
   24: {
     currentPlayerIndex: 2,
-    upkeep: [introduceBuildings(SettlementRound.A), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 25,
   },
   25: {
@@ -253,7 +254,7 @@ export const nextFrame3Long: Record<
   // Round 11
   47: {
     currentPlayerIndex: 1,
-    upkeep: [introduceBuildings(SettlementRound.B), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 48,
   },
   48: {
@@ -349,7 +350,7 @@ export const nextFrame3Long: Record<
   // Round 15
   66: {
     currentPlayerIndex: 2,
-    upkeep: [introduceBuildings(SettlementRound.C), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 67,
   },
   67: {
@@ -464,7 +465,7 @@ export const nextFrame3Long: Record<
   // Round 20
   89: {
     currentPlayerIndex: 1,
-    upkeep: [introduceBuildings(SettlementRound.D), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 90,
   },
   90: {

--- a/game/src/board/frame/nextFrame3Short.ts
+++ b/game/src/board/frame/nextFrame3Short.ts
@@ -14,7 +14,8 @@ export const nextFrame3Short: FrameFlow = {
   1: {
     startingPlayer: 0,
     currentPlayerIndex: 0,
-    upkeep: [rotateRondel, withEachPlayer(getCost({ grain: 1, sheep: 1 })), introduceBuildings(SettlementRound.S)],
+    settlementRound: SettlementRound.S,
+    upkeep: [rotateRondel, withEachPlayer(getCost({ grain: 1, sheep: 1 })), introduceBuildings],
     next: 2,
   },
   2: {
@@ -76,12 +77,7 @@ export const nextFrame3Short: FrameFlow = {
   13: {
     startingPlayer: 2,
     currentPlayerIndex: 2,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ grain: 1, wood: 1 })),
-      introduceBuildings(SettlementRound.A),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ grain: 1, wood: 1 })), introduceBuildings],
     next: 14,
   },
   14: {
@@ -143,12 +139,7 @@ export const nextFrame3Short: FrameFlow = {
   24: {
     startingPlayer: 1,
     currentPlayerIndex: 1,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ peat: 1, stone: 1 })),
-      introduceBuildings(SettlementRound.B),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ peat: 1, stone: 1 })), introduceBuildings],
     next: 25,
   },
   25: {
@@ -209,12 +200,7 @@ export const nextFrame3Short: FrameFlow = {
   // Round 7
   35: {
     currentPlayerIndex: 0,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ wood: 1, stone: 1 })),
-      introduceBuildings(SettlementRound.C),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ wood: 1, stone: 1 })), introduceBuildings],
     next: 36,
   },
   36: {
@@ -275,12 +261,7 @@ export const nextFrame3Short: FrameFlow = {
   // Round 9
   46: {
     currentPlayerIndex: 2,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ stone: 1, meat: 1 })),
-      introduceBuildings(SettlementRound.D),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ stone: 1, meat: 1 })), introduceBuildings],
     next: 47,
   },
   47: {

--- a/game/src/board/frame/nextFrame4Long.ts
+++ b/game/src/board/frame/nextFrame4Long.ts
@@ -12,9 +12,10 @@ export const nextFrame4Long: FrameFlow = {
   1: {
     startingPlayer: 0,
     currentPlayerIndex: 0,
+    settlementRound: SettlementRound.S,
     upkeep: [
       rotateRondel,
-      introduceBuildings(SettlementRound.S),
+      introduceBuildings,
       withActivePlayer(getCost({ clay: 1, wood: 1, peat: 1, penny: 1, grain: 1, sheep: 1 })),
     ],
     next: 2,
@@ -187,7 +188,7 @@ export const nextFrame4Long: FrameFlow = {
   // Round 7
   37: {
     currentPlayerIndex: 2,
-    upkeep: [introduceBuildings(SettlementRound.A), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 38,
   },
   38: {
@@ -286,7 +287,7 @@ export const nextFrame4Long: FrameFlow = {
   // Round 10
   56: {
     currentPlayerIndex: 2,
-    upkeep: [introduceBuildings(SettlementRound.B), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 57,
   },
   57: {
@@ -456,7 +457,7 @@ export const nextFrame4Long: FrameFlow = {
   // Round 16
   90: {
     currentPlayerIndex: 3,
-    upkeep: [introduceBuildings(SettlementRound.C), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 91,
   },
   91: {
@@ -555,7 +556,7 @@ export const nextFrame4Long: FrameFlow = {
   // Round 19
   109: {
     currentPlayerIndex: 2,
-    upkeep: [introduceBuildings(SettlementRound.D), rotateRondel, returnClergyIfPlaced],
+    upkeep: [introduceBuildings, rotateRondel, returnClergyIfPlaced],
     next: 110,
   },
   110: {

--- a/game/src/board/frame/nextFrame4Short.ts
+++ b/game/src/board/frame/nextFrame4Short.ts
@@ -14,7 +14,8 @@ export const nextFrame4Short: FrameFlow = {
   1: {
     startingPlayer: 0,
     currentPlayerIndex: 0,
-    upkeep: [rotateRondel, withEachPlayer(getCost({ grain: 1, sheep: 1 })), introduceBuildings(SettlementRound.S)],
+    settlementRound: SettlementRound.S,
+    upkeep: [rotateRondel, withEachPlayer(getCost({ grain: 1, sheep: 1 })), introduceBuildings],
     next: 2,
   },
   2: {
@@ -90,12 +91,7 @@ export const nextFrame4Short: FrameFlow = {
   15: {
     startingPlayer: 2,
     currentPlayerIndex: 2,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ grain: 1, wood: 1 })),
-      introduceBuildings(SettlementRound.A),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ grain: 1, wood: 1 })), introduceBuildings],
     next: 16,
   },
   16: {
@@ -170,12 +166,7 @@ export const nextFrame4Short: FrameFlow = {
   // Round 5
   29: {
     currentPlayerIndex: 0,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ peat: 1, stone: 1 })),
-      introduceBuildings(SettlementRound.B),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ peat: 1, stone: 1 })), introduceBuildings],
     next: 30,
   },
   30: {
@@ -250,12 +241,7 @@ export const nextFrame4Short: FrameFlow = {
   // Round 7
   43: {
     currentPlayerIndex: 2,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ wood: 1, stone: 1 })),
-      introduceBuildings(SettlementRound.C),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ wood: 1, stone: 1 })), introduceBuildings],
     next: 44,
   },
   44: {
@@ -330,12 +316,7 @@ export const nextFrame4Short: FrameFlow = {
   // Round 9
   57: {
     currentPlayerIndex: 0,
-    upkeep: [
-      rotateRondel,
-      returnClergyIfPlaced,
-      withEachPlayer(getCost({ stone: 1, meat: 1 })),
-      introduceBuildings(SettlementRound.D),
-    ],
+    upkeep: [rotateRondel, returnClergyIfPlaced, withEachPlayer(getCost({ stone: 1, meat: 1 })), introduceBuildings],
     next: 58,
   },
   58: {

--- a/game/src/board/frame/nextFrameSolo.ts
+++ b/game/src/board/frame/nextFrameSolo.ts
@@ -26,7 +26,8 @@ export const nextFrameSolo: FrameFlow = {
   1: {
     startingPlayer: 0,
     currentPlayerIndex: 0,
-    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings(SettlementRound.S)],
+    settlementRound: SettlementRound.S,
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings],
     next: 2,
   },
   2: { next: 3 },
@@ -131,7 +132,7 @@ export const nextFrameSolo: FrameFlow = {
 
   // Round 12
   24: {
-    upkeep: [introduceBuildings(SettlementRound.A), rotateRondelWithExpire, returnClergyIfPlaced],
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings],
     next: 25,
   },
   25: {
@@ -175,7 +176,7 @@ export const nextFrameSolo: FrameFlow = {
 
   // Round 16
   33: {
-    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced],
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings],
     next: 34,
   },
   34: {
@@ -237,7 +238,7 @@ export const nextFrameSolo: FrameFlow = {
 
   // Round 22
   46: {
-    upkeep: [introduceBuildings(SettlementRound.C), rotateRondelWithExpire, returnClergyIfPlaced],
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings],
     next: 47,
   },
   47: {
@@ -281,7 +282,7 @@ export const nextFrameSolo: FrameFlow = {
 
   // Round 25
   55: {
-    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced],
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings],
     next: 56,
   },
   56: {

--- a/game/src/board/player.ts
+++ b/game/src/board/player.ts
@@ -6,7 +6,9 @@ export const withActivePlayer =
   (func: (player: Tableau) => Tableau | undefined) =>
   (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
     if (state === undefined) return state
-    const player = func(state.players[state.frame.activePlayerIndex])
+    const oldPlayer = state.players[state.frame.activePlayerIndex]
+    const player = func(oldPlayer)
+    if (player === oldPlayer) return state // dont create another state if nothing changes
     if (player === undefined) return undefined
     return {
       ...state,
@@ -22,7 +24,13 @@ export const withEachPlayer =
   (func: (player: Tableau) => Tableau | undefined) =>
   (state: GameStatePlaying | undefined): GameStatePlaying | undefined => {
     if (state === undefined) return state
-    const players = map(func, state.players)
+    let dirty = false
+    const players = map((p) => {
+      const q = func(p)
+      if (p !== q) dirty = true
+      return q
+    }, state.players)
+    if (!dirty) return state
     if (any((p) => p === undefined, players)) return undefined
     return {
       ...state,


### PR DESCRIPTION
In writing tests for these new Frame state reducers, i realized withPlayer was actually creating a new identical object a lot of the time in spite of situations where nothing changed, so while this adds a little bit of code, it will speed things up by not iterating through objects to create identical clones of them.