### PR TITLE
refactor: remove reducer import from tests

### DIFF
--- a/game/src/buildings/__tests__/carpentry.test.ts
+++ b/game/src/buildings/__tests__/carpentry.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   GameStatePlaying,

--- a/game/src/buildings/__tests__/castle.test.ts
+++ b/game/src/buildings/__tests__/castle.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   GameStatePlaying,

--- a/game/src/buildings/__tests__/chamberOfWonders.test.ts
+++ b/game/src/buildings/__tests__/chamberOfWonders.test.ts
@@ -1,7 +1,5 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
-  BuildingEnum,
   GameStatePlaying,
   GameStatusEnum,
   NextUseClergy,

--- a/game/src/buildings/__tests__/cloisterCourtyard.test.ts
+++ b/game/src/buildings/__tests__/cloisterCourtyard.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   GameStatePlaying,

--- a/game/src/buildings/__tests__/cloisterGarden.test.ts
+++ b/game/src/buildings/__tests__/cloisterGarden.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   GameStatusEnum,

--- a/game/src/buildings/__tests__/priory.test.ts
+++ b/game/src/buildings/__tests__/priory.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   BuildingEnum,

--- a/game/src/buildings/__tests__/windmill.test.ts
+++ b/game/src/buildings/__tests__/windmill.test.ts
@@ -1,4 +1,3 @@
-import { reducer } from '../../reducer'
 import { initialState } from '../../state'
 import {
   GameStatePlaying,


### PR DESCRIPTION
It looks like Jest's `--watch` figures out what to run by looking at any files that import anything in the changeset, regardless of if the test actually used the import, so for these tests that imported this, even though they no longer used the function, they were always being run.

By cleaning up these unused imports, it actually makes iterative development faster. Neat!