### PR TITLE
build: make game logic package public

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -1,7 +1,6 @@
 {
   "name": "hathora-et-labora-game",
   "version": "0.0.8",
-  "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "jest",


### PR DESCRIPTION
okay so here's what i'm thinking...

this game logic, it's basically the rules to the game. i'm thinking it should actually be public, because then anyone can play it with standardized rules and potentially even make a better client for it, which would be dope. sort of like how chess is chess, and anyone can play chess... but when you're playing on chess.com (and you refuse to put up with the ads) you have to pay them.