### PR TITLE
feature: include current frame in frameFlow to init round

### DIFF
--- a/game/src/__tests__/control.test.ts
+++ b/game/src/__tests__/control.test.ts
@@ -20,7 +20,7 @@ describe('control', () => {
     const f0 = {
       activePlayerIndex: 0,
       bonusActions: [],
-      next: 1,
+      next: 2,
       round: 0,
       startingPlayer: 0,
       settlementRound: 'S',

--- a/game/src/board/frame/__tests__/nextFrame2Long.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame2Long.test.ts
@@ -11,7 +11,9 @@ describe('board/frame/nextFrame2Long', () => {
       config: c1,
       players: [{ color: PlayerColor.Red }, { color: PlayerColor.Blue }],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrame2Short.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame2Short.test.ts
@@ -11,7 +11,9 @@ describe('board/frame/nextFrame2Short', () => {
       config: c1,
       players: [{ color: PlayerColor.Red }, { color: PlayerColor.Blue }],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrame3Long.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame3Long.test.ts
@@ -11,7 +11,9 @@ describe('board/frame/nextFrame3Long', () => {
       config: c1,
       players: [{ color: PlayerColor.Red }, { color: PlayerColor.Blue }, { color: PlayerColor.Green }],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrame3Short.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame3Short.test.ts
@@ -11,7 +11,9 @@ describe('board/frame/nextFrame3Short', () => {
       config: c1,
       players: [{ color: PlayerColor.Red }, { color: PlayerColor.Blue }, { color: PlayerColor.Green }],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrame4Long.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame4Long.test.ts
@@ -16,7 +16,9 @@ describe('board/frame/nextFrame4Long', () => {
         { color: PlayerColor.White },
       ],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrame4Short.test.ts
+++ b/game/src/board/frame/__tests__/nextFrame4Short.test.ts
@@ -16,7 +16,9 @@ describe('board/frame/nextFrame4Short', () => {
         { color: PlayerColor.White },
       ],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/board/frame/__tests__/nextFrameSolo.test.ts
+++ b/game/src/board/frame/__tests__/nextFrameSolo.test.ts
@@ -10,7 +10,9 @@ describe('board/frame/nextFrameSolo', () => {
       config: c1,
       players: [{ color: PlayerColor.Red }],
       frame: {
-        next: 1,
+        round: 1,
+        next: 2,
+        activePlayerIndex: 0,
       },
     } as GameStatePlaying
     const s2 = control(s1, ['CONVERT'], 0)

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -1,17 +1,17 @@
 import { P, match } from 'ts-pattern'
 import { always, reduce, toPairs } from 'ramda'
 import { pickFrameFlow } from './board/frame'
-import { Flower, GameCommandEnum, GameStatePlaying, OrdinalFrame, Controls } from './types'
+import { Flower, GameCommandEnum, GameStatePlaying, OrdinalFrame, Controls, Frame } from './types'
 import { complete } from './commands'
 
 const computeFlow = (state: GameStatePlaying) => {
-  let limit = 200
   const frameFlow = pickFrameFlow(state.config)
-  let frameIndex = state.frame.next
-  let playerIndex = state.frame.activePlayerIndex
-  let frame: OrdinalFrame = frameFlow[frameIndex]
-  let { round } = frame
   const flow: Flower[] = []
+  let limit = 200
+  let frameIndex
+  let playerIndex = state.frame.activePlayerIndex
+  let { frame }: { frame: OrdinalFrame } = state
+  let { round } = frame
   do {
     round = frame.round ?? round
     playerIndex = frame.currentPlayerIndex ?? playerIndex


### PR DESCRIPTION
Rather than jump into what the next frame is, start the frame flow with the current frame.