### PR TITLE
feature: add completions for WORK_CONTRACT

### DIFF
--- a/game/src/__tests__/control.test.ts
+++ b/game/src/__tests__/control.test.ts
@@ -71,9 +71,11 @@ describe('control', () => {
         } as Tableau,
         {
           color: PlayerColor.Green,
+          clergy: [],
         },
         {
           color: PlayerColor.Blue,
+          clergy: [],
         },
       ],
       frame: f0,

--- a/game/src/board/landscape.ts
+++ b/game/src/board/landscape.ts
@@ -13,7 +13,7 @@ import {
   Tableau,
 } from '../types'
 import { terrainForErection } from './erections'
-import { isLayBrother, isPrior, withActivePlayer, withPlayer } from './player'
+import { isLayBrother, isPrior, withActivePlayer, withPlayerIndex } from './player'
 
 export const districtPrices = (config: GameCommandConfigParams): number[] =>
   match(config)
@@ -159,7 +159,7 @@ const removeClergyFromActivePlayer = (clergy: Clergy): StateReducer =>
 const addClergyToTile =
   (clergy: Clergy) =>
   (playerIndex: number, row: number, col: number): StateReducer =>
-    withPlayer(playerIndex)((player) => {
+    withPlayerIndex(playerIndex)((player) => {
       if (player === undefined) return undefined
       const [land, building, _] = player.landscape[row][col]
       return {

--- a/game/src/commands/__tests__/workContract.test.ts
+++ b/game/src/commands/__tests__/workContract.test.ts
@@ -2,6 +2,7 @@ import { initialState } from '../../state'
 import {
   BuildingEnum,
   Clergy,
+  Frame,
   GameStatePlaying,
   GameStatusEnum,
   NextUseClergy,
@@ -17,7 +18,7 @@ describe('commands/workContract', () => {
     color: PlayerColor.Blue,
     clergy: [],
     settlements: [],
-    landscape: [[]] as Tile[][],
+    landscape: [] as Tile[][],
     wonders: 0,
     landscapeOffset: 1,
     peat: 0,
@@ -127,8 +128,8 @@ describe('commands/workContract', () => {
       },
     ],
     buildings: ['F09', 'F10', 'G12', 'G13', 'G06'] as BuildingEnum[],
-    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
-    districtPurchasePrices: [],
+    plotPurchasePrices: [1, 2, 3, 4, 5],
+    districtPurchasePrices: [3, 4, 5, 6],
   }
 
   describe('use', () => {
@@ -282,9 +283,197 @@ describe('commands/workContract', () => {
   })
 
   describe('complete', () => {
-    it('stub', () => {
-      const c0 = complete(s0, [])
+    it('can work contract if they have 1 penny in early game', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+            wine: 0,
+            whiskey: 0,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, [])
+      expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+    it('can work contract if they have 1 wine', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            wine: 1,
+            whiskey: 0,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, [])
+      expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+    it('can work contract if they have 1 whiskey', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            wine: 0,
+            whiskey: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, [])
+      expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+    it('can not work contract if no money', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            wine: 0,
+            whiskey: 0,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, [])
       expect(c0).toStrictEqual([])
+    })
+    it('can work contract if they have 2 penny in late game', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 2,
+            wine: 0,
+            whiskey: 0,
+            landscape: [
+              [['P', 'F21'], ...s0.players[0].landscape[0].slice(1)],
+              ...s0.players[0].landscape.slice(1),
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+        frame: {
+          ...s0.frame,
+          settlementRound: SettlementRound.C,
+        },
+      }
+      const c0 = complete(s1, [])
+      expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+    it('can not work contract if insufficient money', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+            wine: 0,
+            whiskey: 0,
+            landscape: [
+              [['P', 'F21'], ...s0.players[0].landscape[0].slice(1)],
+              ...s0.players[0].landscape.slice(1),
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+        frame: {
+          ...s0.frame,
+          settlementRound: SettlementRound.C,
+        },
+      }
+      const c0 = complete(s1, [])
+      expect(c0).toStrictEqual([])
+    })
+
+    it('work contract lists available buildings', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+            wine: 0,
+            whiskey: 0,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, ['WORK_CONTRACT'])
+      expect(c0).toStrictEqual(['LB1', 'LB2', 'G02', 'LB3', 'F05', 'LG1', 'LG2', 'F08', 'LG3'])
+    })
+
+    it('work contract lists available buildings if we are second player', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          s0.players[0],
+          {
+            ...s0.players[1],
+            penny: 1,
+            wine: 0,
+            whiskey: 0,
+          },
+          ...s0.players.slice(2),
+        ],
+        frame: {
+          ...s0.frame,
+          activePlayerIndex: 1,
+        },
+      }
+      const c0 = complete(s1, ['WORK_CONTRACT'])
+      expect(c0).toStrictEqual(['G01', 'LR3', 'F05', 'LG1', 'LG2', 'F08', 'LG3'])
+    })
+
+    it('gives early game options for paying', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+            wine: 1,
+            whiskey: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(s1, ['WORK_CONTRACT', 'G02'])
+      expect(c0).toStrictEqual(['Wn', 'Wh', 'Pn'])
+    })
+    it('gives late game options for paying', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 2,
+            wine: 2,
+            whiskey: 2,
+            landscape: [
+              [['P', 'F21'], ...s0.players[0].landscape[0].slice(1)],
+              ...s0.players[0].landscape.slice(1),
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+        frame: {
+          ...s0.frame,
+          settlementRound: SettlementRound.C,
+        },
+      }
+      const c0 = complete(s1, ['WORK_CONTRACT', 'G02'])
+      expect(c0).toStrictEqual(['Wn', 'Wh', 'PnPn'])
     })
   })
 })

--- a/game/src/commands/__tests__/workContract.test.ts
+++ b/game/src/commands/__tests__/workContract.test.ts
@@ -475,5 +475,15 @@ describe('commands/workContract', () => {
       const c0 = complete(s1, ['WORK_CONTRACT', 'G02'])
       expect(c0).toStrictEqual(['Wn', 'Wh', 'PnPn'])
     })
+
+    it('terminates when enough options', () => {
+      const c0 = complete(s0, ['WORK_CONTRACT', 'G02', 'Pn'])
+      expect(c0).toStrictEqual([''])
+    })
+
+    it('empty completions when weird params', () => {
+      const c0 = complete(s0, ['WORK_CONTRACT', 'G02', 'Pn', 'Pn'])
+      expect(c0).toStrictEqual([])
+    })
   })
 })

--- a/game/src/commands/workContract.ts
+++ b/game/src/commands/workContract.ts
@@ -1,9 +1,18 @@
-import { all, curry, find, pipe, range, without } from 'ramda'
-import { payCost, getCost, withActivePlayer, isLayBrother, isPrior } from '../board/player'
+import { all, curry, find, forEach, lensPath, pipe, range, reduce, view, without } from 'ramda'
+import { P, match } from 'ts-pattern'
+import { payCost, getCost, withActivePlayer, isLayBrother, isPrior, activeLens } from '../board/player'
 import { findBuildingWithoutOffset, moveClergyToOwnBuilding } from '../board/landscape'
 import { costMoney, parseResourceParam } from '../board/resource'
 import { oncePerFrame, revertActivePlayerToCurrent, setFrameToAllowFreeUsage, withFrame } from '../board/frame'
 import { BuildingEnum, Cost, Frame, GameCommandEnum, GameStatePlaying, SettlementRound, StateReducer } from '../types'
+
+const workContractCost = (state: GameStatePlaying | undefined): number =>
+  state?.frame?.settlementRound === SettlementRound.S ||
+  state?.frame?.settlementRound === SettlementRound.A ||
+  state?.buildings.includes(BuildingEnum.WhiskeyDistillery) ||
+  state?.buildings.includes(BuildingEnum.Winery)
+    ? 1
+    : 2
 
 const checkWorkContractPayment =
   (payment: Cost): StateReducer =>
@@ -11,14 +20,7 @@ const checkWorkContractPayment =
     if (state === undefined) return undefined
     if (payment.whiskey ?? 0 > 1) return state
     if (payment.wine ?? 0 > 1) return state
-    const cost =
-      state.frame.settlementRound === SettlementRound.S ||
-      state.frame.settlementRound === SettlementRound.A ||
-      state.buildings.includes(BuildingEnum.WhiskeyDistillery) ||
-      state.buildings.includes(BuildingEnum.Winery)
-        ? 1
-        : 2
-    if (costMoney(payment) < cost) return undefined
+    if (costMoney(payment) < workContractCost(state)) return undefined
     return state
   }
 
@@ -27,9 +29,7 @@ const transferActiveToOwnerOf =
   (state) => {
     if (state === undefined) return undefined
     // this makes it so we dont look at the current player's landscape... prevent work contract on yourself
-    const playerIndexes: number[] = without([state.frame.activePlayerIndex], range(0, state.config.players))
-
-    // this makes it so we dont look at the current player's landscape... prevent work contract on yourself
+    const playerIndexes = without<number>([state.frame.activePlayerIndex], range(0, state.config.players))
     const foundWithPlayer = find(
       (i) => !!findBuildingWithoutOffset(building)(state.players[i].landscape),
       playerIndexes
@@ -100,6 +100,61 @@ export const workContract = (building: BuildingEnum, paymentGift: string): State
   )
 }
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  return []
-})
+export const complete = curry((state: GameStatePlaying, partial: string[]): string[] =>
+  match<string[], string[]>(partial)
+    .with([], () => {
+      if (!state.frame.bonusActions.includes(GameCommandEnum.WORK_CONTRACT) && state.frame.mainActionUsed) return []
+      const activePlayer = view(activeLens(state), state)
+      // if this player can't possibly pay the work contract fee
+      if (checkWorkContractPayment(activePlayer)(state) === undefined) return []
+      // if all other players have no clergy available
+      if (
+        all(
+          (player) =>
+            player === activePlayer ||
+            //
+            player.clergy.length === 0,
+          state.players
+        )
+      )
+        return []
+      // no need to check if there are buildings to be used, each player has 3 heartland buildings
+      return [GameCommandEnum.WORK_CONTRACT]
+    })
+    .with([GameCommandEnum.WORK_CONTRACT], () =>
+      reduce(
+        (accum, i) => {
+          if (state.frame.activePlayerIndex === i) return accum
+          const player = state.players[i]
+          if (player.clergy.length === 0) return accum
+          forEach(
+            forEach((landStack) => {
+              if (landStack.length === 0) return
+              const [, erection, clergy] = landStack
+              if (
+                erection !== undefined &&
+                clergy === undefined &&
+                ![BuildingEnum.Forest, BuildingEnum.Peat].includes(erection)
+              )
+                accum.push(erection)
+            }),
+            player.landscape
+          )
+          return accum
+        },
+        [] as BuildingEnum[],
+        range(0, state.config.players)
+      )
+    )
+    .with([GameCommandEnum.WORK_CONTRACT, P._], () => {
+      const options = []
+      const { whiskey = 0, wine = 0, penny = 0, nickel = 0 } = view(activeLens(state), state)
+      if (wine) options.push('Wn')
+      if (whiskey) options.push('Wh')
+      if (workContractCost(state) === 1 && (penny >= 1 || nickel)) options.push('Pn')
+      if (workContractCost(state) === 2 && (penny >= 2 || nickel)) options.push('PnPn')
+      return options
+    })
+    .with([GameCommandEnum.WORK_CONTRACT, P._, P._], () => [''])
+    .otherwise(() => [])
+)

--- a/game/src/types.ts
+++ b/game/src/types.ts
@@ -318,36 +318,13 @@ export enum Clergy {
 
 export type Tile = [LandEnum?, BuildingEnum?, Clergy?]
 
-// TODO: try to Required<Cost> &
-export type Tableau = {
+export type Tableau = Required<Cost> & {
   color: PlayerColor
   clergy: Clergy[]
   settlements: SettlementEnum[]
   landscape: Tile[][]
   landscapeOffset: number
   wonders: number
-  peat: number
-  penny: number
-  clay: number
-  wood: number
-  grain: number
-  sheep: number
-  stone: number
-  flour: number
-  grape: number
-  nickel: number
-  malt: number
-  coal: number
-  book: number
-  ceramic: number
-  whiskey: number
-  straw: number
-  meat: number
-  ornament: number
-  bread: number
-  wine: number
-  beer: number
-  reliquary: number
 }
 
 export type Rondel = {


### PR DESCRIPTION
* changed some stuff with withActivePlayer, so that it uses a lens, which feels better. I could probably refactor a lot with this.
* changed the definition of Tableau to be a superset of Cost where everything is required. This makes it so `checkWorkContractPayment`, which accepts a Cost normally, can accept the entire Tableau and say if there's something in there that can be used as enough payment.
* completions for WORK_CONTRACT. I'm gonna have the last step that returns an empty string just do it when there are enough params... seems like a lot of extra work to validate the move could happen, and that could be error prone with the way things are setup... the action itself and the completion should do this validation from the same place, and it's not actually necessary.