### PR TITLE
feature: add completions for buildings in round S

### DIFF
--- a/game/src/board/landscape.ts
+++ b/game/src/board/landscape.ts
@@ -1,4 +1,4 @@
-import { filter, pipe, range, reduce, reduced } from 'ramda'
+import { addIndex, filter, map, pipe, range, reduce, reduced } from 'ramda'
 import { match } from 'ts-pattern'
 import {
   LandEnum,
@@ -236,4 +236,32 @@ export const occupiedBuildingsForPlayers = (players: Tableau[]) =>
     (pAccum, { landscape }) => [...pAccum, ...occupiedBuildingsForLandscape(landscape)],
     [] as BuildingEnum[],
     players
+  )
+
+export const forestLocationsForCol = (rawCol: string, player: Tableau): string[] => {
+  const col = Number.parseInt(rawCol, 10) + 2
+  const colsAtRow = map((row: Tile[]) => row[col], player.landscape)
+  return addIndex<Tile, string[]>(reduce<Tile, string[]>)(
+    (accum: string[], tile: Tile, rowIndex: number) => {
+      if (tile[1] === BuildingEnum.Forest) accum.push(`${rowIndex - player.landscapeOffset}`)
+      return accum
+    },
+    [] as string[],
+    colsAtRow
+  )
+}
+
+export const forestLocations = (player: Tableau): string[] =>
+  addIndex(reduce<Tile[], string[]>)(
+    (accum: string[], row: Tile[], rowIndex: number) =>
+      addIndex(reduce<Tile, string[]>)(
+        (innerAccum: string[], tile: Tile, colIndex: number) => {
+          if (tile[1] === BuildingEnum.Forest) innerAccum.push(`${colIndex - 2} ${rowIndex - player.landscapeOffset}`)
+          return innerAccum
+        },
+        accum,
+        row
+      ),
+    [] as string[],
+    player.landscape
   )

--- a/game/src/buildings/__tests__/buildersMarket.test.ts
+++ b/game/src/buildings/__tests__/buildersMarket.test.ts
@@ -8,77 +8,77 @@ import {
   Tableau,
   Tile,
 } from '../../types'
-import { buildersMarket } from '..'
+import { buildersMarket, complete } from '../buildersMarket'
 
 describe('buildings/buildersMarket', () => {
-  describe('buildersMarket', () => {
-    const p0: Tableau = {
-      color: PlayerColor.Blue,
-      clergy: [],
-      settlements: [],
-      landscape: [
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-      ] as Tile[][],
-      wonders: 0,
-      landscapeOffset: 0,
-      peat: 0,
-      penny: 10,
-      clay: 0,
-      wood: 0,
-      grain: 0,
-      sheep: 0,
-      stone: 0,
-      flour: 0,
-      grape: 0,
-      nickel: 0,
-      malt: 0,
-      coal: 0,
-      book: 0,
-      ceramic: 0,
-      whiskey: 0,
-      straw: 0,
-      meat: 0,
-      ornament: 0,
-      bread: 0,
-      wine: 0,
-      beer: 0,
-      reliquary: 0,
-    }
-    const s0: GameStatePlaying = {
-      ...initialState,
-      status: GameStatusEnum.PLAYING,
-      frame: {
-        round: 1,
-        next: 1,
-        startingPlayer: 1,
-        settlementRound: SettlementRound.S,
-        currentPlayerIndex: 0,
-        activePlayerIndex: 0,
-        neutralBuildingPhase: false,
-        bonusRoundPlacement: false,
-        mainActionUsed: false,
-        bonusActions: [],
-        canBuyLandscape: true,
-        unusableBuildings: [],
-        usableBuildings: [],
-        nextUse: NextUseClergy.Any,
-      },
-      config: {
-        country: 'france',
-        players: 3,
-        length: 'long',
-      },
-      rondel: {
-        pointingBefore: 0,
-      },
-      wonders: 0,
-      players: [{ ...p0 }, { ...p0 }, { ...p0 }],
-      buildings: [],
-      plotPurchasePrices: [1, 1, 1, 1, 1, 1],
-      districtPurchasePrices: [],
-    }
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: [],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 10,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    malt: 0,
+    coal: 0,
+    book: 0,
+    ceramic: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    frame: {
+      round: 1,
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+  }
 
+  describe('buildersMarket', () => {
     it('goes through a happy path', () => {
       const s1 = buildersMarket('PnPn')(s0)! as GameStatePlaying
       expect(s1.players[0]).toMatchObject({
@@ -90,9 +90,85 @@ describe('buildings/buildersMarket', () => {
       })
     })
 
+    it('exchanges a nickel for pennies', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            nickel: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const s2 = buildersMarket('PnPn')(s1)! as GameStatePlaying
+      expect(s2.players[0]).toMatchObject({
+        penny: 3,
+        wood: 2,
+        clay: 2,
+        stone: 1,
+        straw: 1,
+      })
+    })
+
     it('does nothing if you dont give it two coins', () => {
       const s1 = buildersMarket()(s0)! as GameStatePlaying
       expect(s1).toBeUndefined()
+    })
+  })
+
+  describe('complete', () => {
+    it('gives the option of PnPn if player has pennies', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 2,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual(['PnPn', ''])
+    })
+    it('only allows nothing if not enough money', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual([''])
+    })
+    it('will offer to exchange a nickel for pennies', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            nickel: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual(['PnPn', ''])
+    })
+    it('once it knows, that is it', () => {
+      const c0 = complete(['PnPn'])(s0)
+      expect(c0).toStrictEqual([''])
+    })
+    it('does not complete anything with a param', () => {
+      const c0 = complete(['Pn', 'Pn'])(s0)
+      expect(c0).toStrictEqual([])
     })
   })
 })

--- a/game/src/buildings/__tests__/carpentry.test.ts
+++ b/game/src/buildings/__tests__/carpentry.test.ts
@@ -1,5 +1,6 @@
 import { initialState } from '../../state'
 import {
+  GameCommandEnum,
   GameStatePlaying,
   GameStatusEnum,
   NextUseClergy,
@@ -8,77 +9,76 @@ import {
   Tableau,
   Tile,
 } from '../../types'
-import { carpentry } from '..'
+import { carpentry, complete } from '../carpentry'
 
 describe('buildings/carpentry', () => {
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: [],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 0,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    malt: 0,
+    coal: 0,
+    book: 0,
+    ceramic: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    frame: {
+      round: 1,
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+  }
   describe('carpentry', () => {
-    const p0: Tableau = {
-      color: PlayerColor.Blue,
-      clergy: [],
-      settlements: [],
-      landscape: [
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-      ] as Tile[][],
-      wonders: 0,
-      landscapeOffset: 0,
-      peat: 0,
-      penny: 0,
-      clay: 0,
-      wood: 0,
-      grain: 0,
-      sheep: 0,
-      stone: 0,
-      flour: 0,
-      grape: 0,
-      nickel: 0,
-      malt: 0,
-      coal: 0,
-      book: 0,
-      ceramic: 0,
-      whiskey: 0,
-      straw: 0,
-      meat: 0,
-      ornament: 0,
-      bread: 0,
-      wine: 0,
-      beer: 0,
-      reliquary: 0,
-    }
-    const s0: GameStatePlaying = {
-      ...initialState,
-      status: GameStatusEnum.PLAYING,
-      frame: {
-        round: 1,
-        next: 1,
-        startingPlayer: 1,
-        settlementRound: SettlementRound.S,
-        currentPlayerIndex: 0,
-        activePlayerIndex: 0,
-        neutralBuildingPhase: false,
-        bonusRoundPlacement: false,
-        mainActionUsed: false,
-        bonusActions: [],
-        canBuyLandscape: true,
-        unusableBuildings: [],
-        usableBuildings: [],
-        nextUse: NextUseClergy.Any,
-      },
-      config: {
-        country: 'france',
-        players: 3,
-        length: 'long',
-      },
-      rondel: {
-        pointingBefore: 0,
-      },
-      wonders: 0,
-      players: [{ ...p0 }, { ...p0 }, { ...p0 }],
-      buildings: [],
-      plotPurchasePrices: [1, 1, 1, 1, 1, 1],
-      districtPurchasePrices: [],
-    }
-
     it('goes through a happy path', () => {
       const s1 = carpentry(0, 2)(s0)! as GameStatePlaying
       expect(s1.players[0]).toMatchObject({
@@ -87,6 +87,78 @@ describe('buildings/carpentry', () => {
           [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
         ],
       })
+      expect(s1.frame?.bonusActions).toContain(GameCommandEnum.BUILD)
+    })
+  })
+
+  describe('complete', () => {
+    it('completes with all of the forest locations', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P'], ['P'], ['P'], [], []],
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([], s1)
+      expect(c0).toStrictEqual(['1 0', '1 1', '2 1', ''])
+    })
+    it('still lets you use it if there are no forests to take down', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P'], ['P', 'LPE'], ['P'], ['P'], ['P', 'LG1'], [], []],
+              [[], [], ['P'], ['P', 'LPE'], ['P', 'LG2'], ['P'], ['P', 'LG3'], [], []],
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual([''])
+    })
+    it('gives rows if given a column', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P'], ['P'], ['P'], [], []],
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(['1'], s1)
+      expect(c0).toStrictEqual(['0', '1'])
+    })
+    it('gives no rows if column is whack', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P'], ['P'], ['P'], [], []],
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+            ] as Tile[][],
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete(['0'], s1)
+      expect(c0).toStrictEqual([])
     })
   })
 })

--- a/game/src/buildings/__tests__/falseLighthouse.test.ts
+++ b/game/src/buildings/__tests__/falseLighthouse.test.ts
@@ -118,12 +118,16 @@ describe('buildings/falseLighthouse', () => {
   })
 
   describe('complete', () => {
-    it('takes no parameters', () => {
+    it('just wants to know whiskey or beer', () => {
       const c0 = complete([])(s0)
+      expect(c0).toStrictEqual(['Be', 'Wh'])
+    })
+    it('once it knows, that is it', () => {
+      const c0 = complete(['Be'])(s0)
       expect(c0).toStrictEqual([''])
     })
     it('does not complete anything with a param', () => {
-      const c0 = complete([''])(s0)
+      const c0 = complete(['Be', 'Wh'])(s0)
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/buildings/__tests__/market.test.ts
+++ b/game/src/buildings/__tests__/market.test.ts
@@ -8,77 +8,77 @@ import {
   Tableau,
   Tile,
 } from '../../types'
-import { market } from '..'
+import { complete, market } from '../market'
 
 describe('buildings/market', () => {
-  describe('market', () => {
-    const p0: Tableau = {
-      color: PlayerColor.Blue,
-      clergy: [],
-      settlements: [],
-      landscape: [
-        [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
-        [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
-      ] as Tile[][],
-      wonders: 0,
-      landscapeOffset: 0,
-      peat: 0,
-      penny: 0,
-      clay: 0,
-      wood: 0,
-      grain: 0,
-      sheep: 0,
-      stone: 0,
-      flour: 0,
-      grape: 0,
-      nickel: 0,
-      malt: 0,
-      coal: 0,
-      book: 0,
-      ceramic: 0,
-      whiskey: 0,
-      straw: 0,
-      meat: 0,
-      ornament: 0,
-      bread: 0,
-      wine: 0,
-      beer: 0,
-      reliquary: 0,
-    }
-    const s0: GameStatePlaying = {
-      ...initialState,
-      status: GameStatusEnum.PLAYING,
-      frame: {
-        round: 1,
-        next: 1,
-        startingPlayer: 1,
-        settlementRound: SettlementRound.S,
-        currentPlayerIndex: 0,
-        activePlayerIndex: 0,
-        neutralBuildingPhase: false,
-        bonusRoundPlacement: false,
-        mainActionUsed: false,
-        bonusActions: [],
-        canBuyLandscape: true,
-        unusableBuildings: [],
-        usableBuildings: [],
-        nextUse: NextUseClergy.Any,
-      },
-      config: {
-        country: 'france',
-        players: 3,
-        length: 'long',
-      },
-      rondel: {
-        pointingBefore: 0,
-      },
-      wonders: 0,
-      players: [{ ...p0 }, { ...p0 }, { ...p0 }],
-      buildings: [],
-      plotPurchasePrices: [1, 1, 1, 1, 1, 1],
-      districtPurchasePrices: [],
-    }
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: [],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P'], ['P'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 0,
+    penny: 0,
+    clay: 0,
+    wood: 0,
+    grain: 0,
+    sheep: 0,
+    stone: 0,
+    flour: 0,
+    grape: 0,
+    nickel: 0,
+    malt: 0,
+    coal: 0,
+    book: 0,
+    ceramic: 0,
+    whiskey: 0,
+    straw: 0,
+    meat: 0,
+    ornament: 0,
+    bread: 0,
+    wine: 0,
+    beer: 0,
+    reliquary: 0,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    frame: {
+      round: 1,
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+  }
 
+  describe('market', () => {
     it('goes through a happy path', () => {
       const s1 = {
         ...s0,
@@ -119,6 +119,60 @@ describe('buildings/market', () => {
       }
       const s2 = market('SwClPnPn')(s1)!
       expect(s2).toBeUndefined()
+    })
+  })
+
+  describe('complete', () => {
+    it('gives 5 options for 4 things, with 5 different things,', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            peat: 1,
+            penny: 2,
+            sheep: 1,
+            clay: 1,
+            wood: 5,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual(['PtPnClWo', 'PtPnClSh', 'PtPnWoSh', 'PtClWoSh', 'PnClWoSh', ''])
+    })
+    it('gives 1 option for 4 things, with 4 different things,', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            peat: 1,
+            penny: 2,
+            sheep: 1,
+            wood: 5,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual(['PtPnWoSh', ''])
+    })
+    it('gives 0 option for 4 things, with 3 different things,', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            peat: 1,
+            penny: 2,
+            sheep: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual([''])
     })
   })
 })

--- a/game/src/buildings/__tests__/stoneMerchant.test.ts
+++ b/game/src/buildings/__tests__/stoneMerchant.test.ts
@@ -8,77 +8,76 @@ import {
   Tableau,
   Tile,
 } from '../../types'
-import { stoneMerchant } from '..'
+import { complete, stoneMerchant } from '../stoneMerchant'
 
 describe('buildings/stoneMerchant', () => {
+  const p0: Tableau = {
+    color: PlayerColor.Blue,
+    clergy: [],
+    settlements: [],
+    landscape: [
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+      [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+    ] as Tile[][],
+    wonders: 0,
+    landscapeOffset: 0,
+    peat: 10,
+    penny: 10,
+    clay: 10,
+    wood: 10,
+    grain: 10,
+    sheep: 10,
+    stone: 10,
+    flour: 10,
+    grape: 10,
+    nickel: 10,
+    malt: 10,
+    coal: 10,
+    book: 10,
+    ceramic: 10,
+    whiskey: 10,
+    straw: 10,
+    meat: 10,
+    ornament: 10,
+    bread: 10,
+    wine: 10,
+    beer: 10,
+    reliquary: 10,
+  }
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    frame: {
+      round: 1,
+      next: 1,
+      startingPlayer: 1,
+      settlementRound: SettlementRound.S,
+      currentPlayerIndex: 0,
+      activePlayerIndex: 0,
+      neutralBuildingPhase: false,
+      bonusRoundPlacement: false,
+      mainActionUsed: false,
+      bonusActions: [],
+      canBuyLandscape: true,
+      unusableBuildings: [],
+      usableBuildings: [],
+      nextUse: NextUseClergy.Any,
+    },
+    config: {
+      country: 'france',
+      players: 3,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{ ...p0 }, { ...p0 }, { ...p0 }],
+    buildings: [],
+    plotPurchasePrices: [1, 1, 1, 1, 1, 1],
+    districtPurchasePrices: [],
+  }
   describe('stoneMerchant', () => {
-    const p0: Tableau = {
-      color: PlayerColor.Blue,
-      clergy: [],
-      settlements: [],
-      landscape: [
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-        [[], [], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
-      ] as Tile[][],
-      wonders: 0,
-      landscapeOffset: 0,
-      peat: 10,
-      penny: 10,
-      clay: 10,
-      wood: 10,
-      grain: 10,
-      sheep: 10,
-      stone: 10,
-      flour: 10,
-      grape: 10,
-      nickel: 10,
-      malt: 10,
-      coal: 10,
-      book: 10,
-      ceramic: 10,
-      whiskey: 10,
-      straw: 10,
-      meat: 10,
-      ornament: 10,
-      bread: 10,
-      wine: 10,
-      beer: 10,
-      reliquary: 10,
-    }
-    const s0: GameStatePlaying = {
-      ...initialState,
-      status: GameStatusEnum.PLAYING,
-      frame: {
-        round: 1,
-        next: 1,
-        startingPlayer: 1,
-        settlementRound: SettlementRound.S,
-        currentPlayerIndex: 0,
-        activePlayerIndex: 0,
-        neutralBuildingPhase: false,
-        bonusRoundPlacement: false,
-        mainActionUsed: false,
-        bonusActions: [],
-        canBuyLandscape: true,
-        unusableBuildings: [],
-        usableBuildings: [],
-        nextUse: NextUseClergy.Any,
-      },
-      config: {
-        country: 'france',
-        players: 3,
-        length: 'long',
-      },
-      rondel: {
-        pointingBefore: 0,
-      },
-      wonders: 0,
-      players: [{ ...p0 }, { ...p0 }, { ...p0 }],
-      buildings: [],
-      plotPurchasePrices: [1, 1, 1, 1, 1, 1],
-      districtPurchasePrices: [],
-    }
-
     it('goes through a happy path', () => {
       const s1 = stoneMerchant('ShShCo')(s0)! as GameStatePlaying
       expect(s1.players[0]).toMatchObject({
@@ -132,6 +131,129 @@ describe('buildings/stoneMerchant', () => {
       }
       const s2 = stoneMerchant('ShWo')(s1)! as GameStatePlaying
       expect(s2).toBeUndefined()
+    })
+  })
+
+  describe('complete', () => {
+    const s1 = {
+      ...s0,
+      players: [
+        {
+          ...s0.players[0],
+          peat: 0,
+          penny: 0,
+          clay: 0,
+          wood: 0,
+          grain: 0,
+          sheep: 0,
+          stone: 0,
+          flour: 0,
+          grape: 0,
+          nickel: 0,
+          malt: 0,
+          coal: 0,
+          book: 0,
+          ceramic: 0,
+          whiskey: 0,
+          straw: 0,
+          meat: 0,
+          ornament: 0,
+          bread: 0,
+          wine: 0,
+          beer: 0,
+          reliquary: 0,
+        },
+        ...s0.players.slice(1),
+      ],
+    }
+    it("returns [''] still if nothing to do", () => {
+      const c0 = complete([])(s1)
+      expect(c0).toStrictEqual([''])
+    })
+    it('if only one way, returns that way', () => {
+      const s2 = {
+        ...s1,
+        players: [
+          {
+            ...s1.players[0],
+            sheep: 1,
+            wood: 1,
+          },
+          ...s1.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s2)
+      expect(c0).toStrictEqual(['ShWo', ''])
+    })
+    it('if two ways if possible', () => {
+      const s2 = {
+        ...s1,
+        players: [
+          {
+            ...s1.players[0],
+            sheep: 2,
+            wood: 2,
+          },
+          ...s1.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s2)
+      expect(c0).toStrictEqual(['ShShWoWo', 'ShWo', ''])
+    })
+    it('tries other goods', () => {
+      const s2 = {
+        ...s1,
+        players: [
+          {
+            ...s1.players[0],
+            sheep: 1,
+            wood: 1,
+            grain: 2,
+          },
+          ...s1.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s2)
+      expect(c0).toStrictEqual(['ShWo', 'GnGnWo', ''])
+    })
+    it('supports complexity', () => {
+      const s2 = {
+        ...s1,
+        players: [
+          {
+            ...s1.players[0],
+            sheep: 1,
+            meat: 1,
+            grain: 1,
+            wood: 2,
+            coal: 1,
+          },
+          ...s1.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s2)
+      expect(c0).toStrictEqual(['MtShGnCoWo', 'MtShCo', 'MtGnCo', 'MtCo', 'MtWoWo', 'MtCo', 'MtWo', 'ShCo', 'ShWo', ''])
+    })
+    it('does not go insane over a reasonably complex situation', () => {
+      const s2 = {
+        ...s1,
+        players: [
+          {
+            ...s1.players[0],
+            meat: 5,
+            grain: 6,
+            beer: 5,
+            wood: 5,
+            peat: 5,
+            coal: 2,
+            penny: 10,
+          },
+          ...s1.players.slice(1),
+        ],
+      }
+      const c0 = complete([])(s2)
+      // this is kind of a lot... but also, it should not crash us. If this takes too long, then we have problems.
+      expect(c0).toHaveLength(6806)
     })
   })
 })

--- a/game/src/buildings/buildersMarket.ts
+++ b/game/src/buildings/buildersMarket.ts
@@ -1,7 +1,8 @@
-import { pipe } from 'ramda'
-import { getCost, payCost, withActivePlayer } from '../board/player'
+import { always, curry, pipe, view } from 'ramda'
+import { P, match } from 'ts-pattern'
+import { activeLens, getCost, payCost, withActivePlayer } from '../board/player'
 import { costMoney, parseResourceParam } from '../board/resource'
-import { Cost, Tableau } from '../types'
+import { Cost, GameStatePlaying, Tableau } from '../types'
 
 const checkWorthTwoCoins =
   (input: Cost) =>
@@ -19,3 +20,13 @@ export const buildersMarket = (param = '') => {
     )
   )
 }
+
+export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
+  match(partial)
+    .with([], () => {
+      if (costMoney(view(activeLens(state), state)) < 2) return ['']
+      return ['PnPn', '']
+    })
+    .with([P._], always(['']))
+    .otherwise(always([]))
+)

--- a/game/src/buildings/carpentry.ts
+++ b/game/src/buildings/carpentry.ts
@@ -1,7 +1,9 @@
-import { pipe } from 'ramda'
+import { always, curry, pipe, view } from 'ramda'
+import { P, match } from 'ts-pattern'
 import { addBonusAction } from '../board/frame'
-import { withActivePlayer } from '../board/player'
+import { activeLens, withActivePlayer } from '../board/player'
 import { BuildingEnum, GameCommandEnum, GameStatePlaying } from '../types'
+import { forestLocations, forestLocationsForCol } from '../board/landscape'
 
 const checkSpotIsForest = (row: number, col: number) =>
   withActivePlayer((player) => {
@@ -33,3 +35,14 @@ export const carpentry = (row: number, col: number) =>
     removeForestAt(row, col),
     addBonusAction(GameCommandEnum.BUILD)
   )
+
+export const complete = curry((partial: string[], state: GameStatePlaying): string[] => {
+  const player = view(activeLens(state), state)
+  return match(partial)
+    .with([], () => [...forestLocations(player), ''])
+    .with([P._], ([c]) => {
+      return [...forestLocationsForCol(c, player)]
+    })
+    .with([P._, P._], always(['']))
+    .otherwise(always([]))
+})

--- a/game/src/buildings/falseLighthouse.ts
+++ b/game/src/buildings/falseLighthouse.ts
@@ -1,5 +1,5 @@
 import { always, curry, xor } from 'ramda'
-import { match } from 'ts-pattern'
+import { P, match } from 'ts-pattern'
 import { getCost, withActivePlayer } from '../board/player'
 import { parseResourceParam } from '../board/resource'
 import { GameStatePlaying, StateReducer } from '../types'
@@ -18,6 +18,7 @@ export const falseLighthouse = (param = ''): StateReducer => {
 
 export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
   match(partial)
-    .with([], always(['']))
+    .with([], always(['Be', 'Wh']))
+    .with([P._], always(['']))
     .otherwise(always([]))
 )

--- a/game/src/buildings/market.ts
+++ b/game/src/buildings/market.ts
@@ -1,7 +1,8 @@
-import { pipe } from 'ramda'
-import { getCost, withActivePlayer, payCost } from '../board/player'
-import { parseResourceParam, totalGoods, differentGoods } from '../board/resource'
-import { StateReducer } from '../types'
+import { always, curry, pipe, reduce, view } from 'ramda'
+import { P, match } from 'ts-pattern'
+import { getCost, withActivePlayer, payCost, activeLens } from '../board/player'
+import { parseResourceParam, totalGoods, differentGoods, allResource, combinations } from '../board/resource'
+import { GameStatePlaying, StateReducer } from '../types'
 
 export const market = (input = ''): StateReducer => {
   const inputs = parseResourceParam(input)
@@ -20,3 +21,26 @@ export const market = (input = ''): StateReducer => {
       )
     )(state)
 }
+
+export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
+  match<string[], string[]>(partial)
+    .with([], () => {
+      const player = view(activeLens(state), state)
+      return [
+        ...combinations(
+          4,
+          reduce(
+            (accum, [key, token]) => {
+              if (player[key]) accum.push(token)
+              return accum
+            },
+            [] as string[],
+            allResource
+          )
+        ),
+        '',
+      ]
+    })
+    .with([P._], always(['']))
+    .otherwise(always([]))
+)

--- a/game/src/buildings/stoneMerchant.ts
+++ b/game/src/buildings/stoneMerchant.ts
@@ -1,7 +1,8 @@
-import { pipe } from 'ramda'
-import { getCost, withActivePlayer, payCost } from '../board/player'
-import { costEnergy, costFood, parseResourceParam } from '../board/resource'
-import { StateReducer } from '../types'
+import { always, curry, map, min, pipe, range, reverse, unnest, view } from 'ramda'
+import { P, match } from 'ts-pattern'
+import { getCost, withActivePlayer, payCost, activeLens } from '../board/player'
+import { costEnergy, costFood, parseResourceParam, settlementCostOptions } from '../board/resource'
+import { GameStatePlaying, StateReducer } from '../types'
 
 export const stoneMerchant = (param = ''): StateReducer => {
   const inputs = parseResourceParam(param)
@@ -14,3 +15,17 @@ export const stoneMerchant = (param = ''): StateReducer => {
     )
   )
 }
+
+export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
+  match<string[], string[]>(partial)
+    .with([], () => {
+      const player = view(activeLens(state), state)
+      const food = Math.floor(costFood(player) / 2)
+      const energy = costEnergy(player)
+      const maxIterations = min(food, energy)
+      const iterations = reverse(range(0, 1 + maxIterations)) // [ 0, 1, 2, 3, 4, 5 ]
+      return unnest(map((i) => settlementCostOptions({ food: i * 2, energy: i }, player), iterations))
+    })
+    .with([P._], always(['']))
+    .otherwise(always([]))
+)

--- a/game/src/commands/fellTrees.ts
+++ b/game/src/commands/fellTrees.ts
@@ -12,6 +12,7 @@ import {
 } from '../types'
 import { take } from '../board/rondel'
 import { oncePerFrame } from '../board/frame'
+import { forestLocations, forestLocationsForCol } from '../board/landscape'
 
 const removeForestAt = (row: number, col: number) =>
   withActivePlayer((player) => {
@@ -41,34 +42,6 @@ const hasAForest = (landscape: Tile[][]): boolean =>
       return tile?.[1] === BuildingEnum.Forest
     }, landRow)
   }, landscape)
-
-const forestLocationsForCol = (rawCol: string, player: Tableau): string[] => {
-  const col = Number.parseInt(rawCol, 10) + 2
-  const colsAtRow = map((row: Tile[]) => row[col], player.landscape)
-  return addIndex<Tile, string[]>(reduce<Tile, string[]>)(
-    (accum: string[], tile: Tile, rowIndex: number) => {
-      if (tile[1] === BuildingEnum.Forest) accum.push(`${rowIndex - player.landscapeOffset}`)
-      return accum
-    },
-    [] as string[],
-    colsAtRow
-  )
-}
-
-const forestLocations = (player: Tableau): string[] =>
-  addIndex(reduce<Tile[], string[]>)(
-    (accum: string[], row: Tile[], rowIndex: number) =>
-      addIndex(reduce<Tile, string[]>)(
-        (innerAccum: string[], tile: Tile, colIndex: number) => {
-          if (tile[1] === BuildingEnum.Forest) innerAccum.push(`${colIndex - 2} ${rowIndex - player.landscapeOffset}`)
-          return innerAccum
-        },
-        accum,
-        row
-      ),
-    [] as string[],
-    player.landscape
-  )
 
 export const givePlayerWood =
   (useJoker: boolean): StateReducer =>


### PR DESCRIPTION
finishes all of the buildings in S.

i wanna finish the buildings in A also before going back to frontend and letting completions in B, C, and D become a side thing.