### PR TITLE
BREAKING: change parameters of winery to support completion

### DIFF
--- a/game/src/__tests__/game21872.test.ts
+++ b/game/src/__tests__/game21872.test.ts
@@ -501,7 +501,7 @@ describe('game 21872', () => {
 
     const s136 = reducer(s135, ['CONVERT', 'Gn'])! as GameStatePlaying
     const s137 = reducer(s136, ['BUILD', 'F21', '2', '0'])! as GameStatePlaying
-    const s138 = reducer(s137, ['USE', 'F21', 'GpGp', 'Wn'])! as GameStatePlaying
+    const s138 = reducer(s137, ['USE', 'F21', 'GpGpWn'])! as GameStatePlaying
     const s139 = reducer(s138, ['BUY_PLOT', '-2', 'MOUNTAIN'])! as GameStatePlaying
     const s140 = reducer(s139, ['COMMIT'])! as GameStatePlaying
     expect(s140.frame).toMatchObject({
@@ -510,7 +510,7 @@ describe('game 21872', () => {
     })
 
     const s141 = reducer(s140, ['USE', 'G01'])! as GameStatePlaying
-    const s142 = reducer(s141, ['USE', 'F21', 'GpGpGp', 'Wn'])! as GameStatePlaying
+    const s142 = reducer(s141, ['USE', 'F21', 'GpGpGpWn'])! as GameStatePlaying
     const s143 = reducer(s142, ['COMMIT'])! as GameStatePlaying
     expect(s143.players[1].clergy).toStrictEqual([])
     expect(s143.frame).toMatchObject({
@@ -807,7 +807,7 @@ describe('game 21872', () => {
       next: 95,
     })
 
-    const s238 = reducer(s237, ['USE', 'F21', 'GpGpGpGpGpGpGpGpGp', 'Wn'])! as GameStatePlaying
+    const s238 = reducer(s237, ['USE', 'F21', 'GpGpGpGpGpGpGpGpGpWn'])! as GameStatePlaying
     const s239 = reducer(s238, ['COMMIT'])! as GameStatePlaying
     expect(s239.frame).toMatchObject({
       activePlayerIndex: 0,

--- a/game/src/board/frame/__tests__/rotateRondel.test.ts
+++ b/game/src/board/frame/__tests__/rotateRondel.test.ts
@@ -1,0 +1,116 @@
+import { GameStatePlaying } from '../../../types'
+import { rotateRondel, rotateRondelWithExpire } from '../rotateRondel'
+
+describe('board/frame', () => {
+  const s0 = {
+    rondel: {
+      pointingBefore: 4,
+      wood: 3,
+      clay: 4,
+      coin: 1,
+      joker: 4,
+      grain: 0,
+    },
+  } as GameStatePlaying
+
+  describe('rotateRondel', () => {
+    it('rotates things forward, normally', () => {
+      const s1 = {
+        ...s0,
+      }
+      const s2 = rotateRondel(s1)
+      expect(s2).toMatchObject({
+        rondel: {
+          pointingBefore: 5,
+          wood: 3,
+          clay: 4,
+          coin: 1,
+          joker: 4,
+          grain: 0,
+          stone: undefined,
+        },
+      })
+    })
+
+    it('pushes things at max to their next level', () => {
+      const s1 = {
+        ...s0,
+        rondel: {
+          ...s0.rondel,
+          pointingBefore: 5,
+          wood: 3,
+          clay: 6,
+          coin: 1,
+          joker: 6,
+          grain: 0,
+        },
+      }
+      const s2 = rotateRondel(s1)
+      expect(s2).toMatchObject({
+        rondel: {
+          pointingBefore: 6,
+          wood: 3,
+          clay: 7,
+          coin: 1,
+          joker: 7,
+          grain: 0,
+          stone: undefined,
+        },
+      })
+    })
+
+    it('wraps around at 13', () => {
+      const s1 = {
+        ...s0,
+        rondel: {
+          ...s0.rondel,
+          pointingBefore: 12,
+          wood: 12,
+          clay: 11,
+          grain: 0,
+          coin: 1,
+          joker: 2,
+        },
+      }
+      const s2 = rotateRondel(s1)
+      expect(s2).toMatchObject({
+        rondel: {
+          pointingBefore: 0,
+          wood: 12,
+          clay: 11,
+          grain: 1,
+          coin: 1,
+          joker: 2,
+        },
+      })
+    })
+  })
+  describe('rotateRondelWithExpire', () => {
+    it('lets things drop off in solo mode', () => {
+      const s1 = {
+        ...s0,
+        rondel: {
+          ...s0.rondel,
+          pointingBefore: 5,
+          wood: 3,
+          clay: 6,
+          coin: 1,
+          joker: 6,
+          grain: 0,
+        },
+      }
+      const s2 = rotateRondelWithExpire(s1)
+      expect(s2).toMatchObject({
+        rondel: {
+          pointingBefore: 6,
+          wood: 3,
+          clay: undefined,
+          coin: 1,
+          joker: undefined,
+          grain: 0,
+          stone: undefined,
+        },
+      })
+    })
+  })
+})

--- a/game/src/board/frame/rotateRondel.ts
+++ b/game/src/board/frame/rotateRondel.ts
@@ -2,7 +2,6 @@ import { withRondel } from '../rondel'
 
 const pushArm = (expireAfterTen = false) =>
   withRondel((rondel) => {
-    if (rondel === undefined) return undefined
     const next = (rondel.pointingBefore + 1) % 13
     const bumper = (from?: number) => {
       if (from === next) {

--- a/game/src/board/frame/rotateRondel.ts
+++ b/game/src/board/frame/rotateRondel.ts
@@ -1,9 +1,9 @@
 import { withRondel } from '../rondel'
 
-export const pushArm = (expireAfterTen = false) =>
+const pushArm = (expireAfterTen = false) =>
   withRondel((rondel) => {
     if (rondel === undefined) return undefined
-    const next = rondel.pointingBefore + (1 % 13)
+    const next = (rondel.pointingBefore + 1) % 13
     const bumper = (from?: number) => {
       if (from === next) {
         if (expireAfterTen) return undefined

--- a/game/src/board/rondel.ts
+++ b/game/src/board/rondel.ts
@@ -5,7 +5,7 @@ import { multiplyGoods } from './resource'
 type TokenName = 'grain' | 'sheep' | 'clay' | 'coin' | 'wood' | 'joker' | 'peat' | 'grape' | 'stone'
 
 export const withRondel =
-  (func: (rondel: Rondel | undefined) => Rondel | undefined): StateReducer =>
+  (func: (rondel: Rondel) => Rondel | undefined): StateReducer =>
   (state) => {
     if (state === undefined) return state
     const rondel = func(state.rondel)

--- a/game/src/buildings/__tests__/winery.test.ts
+++ b/game/src/buildings/__tests__/winery.test.ts
@@ -8,7 +8,7 @@ import {
   Tableau,
   Tile,
 } from '../../types'
-import { winery } from '..'
+import { winery } from '../winery'
 
 describe('buildings/winery', () => {
   describe('winery', () => {
@@ -114,6 +114,19 @@ describe('buildings/winery', () => {
         wine: 0,
         penny: 2,
         nickel: 1,
+      })
+    })
+
+    it('can have a noop', () => {
+      const s1 = {
+        ...s0,
+        players: [{ ...s0.players[0], grape: 0, wine: 0, penny: 0, nickel: 0 }, ...s0.players.slice(1)],
+      }
+      const s2 = winery()(s1)! as GameStatePlaying
+      expect(s2.players[0]).toMatchObject({
+        wine: 0,
+        penny: 0,
+        nickel: 0,
       })
     })
   })

--- a/game/src/buildings/__tests__/winery.test.ts
+++ b/game/src/buildings/__tests__/winery.test.ts
@@ -80,7 +80,7 @@ describe('buildings/winery', () => {
     }
 
     it('goes through a happy path', () => {
-      const s1 = winery('GpGpGp', 'Wn')(s0)! as GameStatePlaying
+      const s1 = winery('GpGpGpWn')(s0)! as GameStatePlaying
       expect(s1.players[0]).toMatchObject({
         grape: 7,
         wine: 12,
@@ -95,7 +95,7 @@ describe('buildings/winery', () => {
         players: [{ ...s0.players[0], grape: 1, wine: 0, penny: 0, nickel: 0 }, ...s0.players.slice(1)],
       }
 
-      const s2 = winery('Gp', 'Wn')(s1)! as GameStatePlaying
+      const s2 = winery('GpWn')(s1)! as GameStatePlaying
       expect(s2.players[0]).toMatchObject({
         grape: 0,
         wine: 0,
@@ -109,7 +109,7 @@ describe('buildings/winery', () => {
         ...s0,
         players: [{ ...s0.players[0], grape: 0, wine: 1, penny: 0, nickel: 0 }, ...s0.players.slice(1)],
       }
-      const s2 = winery('', 'Wn')(s1)! as GameStatePlaying
+      const s2 = winery('Wn')(s1)! as GameStatePlaying
       expect(s2.players[0]).toMatchObject({
         wine: 0,
         penny: 2,

--- a/game/src/buildings/winery.ts
+++ b/game/src/buildings/winery.ts
@@ -2,20 +2,17 @@ import { pipe } from 'ramda'
 import { getCost, payCost, withActivePlayer } from '../board/player'
 import { parseResourceParam } from '../board/resource'
 
-export const winery = (param1 = '', param2 = '') => {
-  const input1 = parseResourceParam(param1)
-  const input2 = parseResourceParam(param2)
+export const winery = (input = '') => {
+  const { wine = 0, grape = 0 } = parseResourceParam(input)
   return withActivePlayer(
     pipe(
       //
-      payCost(input1),
+      payCost({ grape }),
+      getCost({ wine: grape }),
+      payCost({ wine }),
       getCost({
-        wine: input1.grape ?? 0,
-      }),
-      payCost(input2),
-      getCost({
-        nickel: (input2.wine ?? 0) > 0 ? 1 : 0,
-        penny: (input2.wine ?? 0) > 0 ? 2 : 0,
+        nickel: (wine ?? 0) > 0 ? 1 : 0,
+        penny: (wine ?? 0) > 0 ? 2 : 0,
       })
     )
   )

--- a/game/src/commands/use.ts
+++ b/game/src/commands/use.ts
@@ -201,7 +201,7 @@ export const use = (building: BuildingEnum, params: string[]): StateReducer =>
       .with(BuildingEnum.TownEstate, () => townEstate(params[0]))
       .with(BuildingEnum.WhiskeyDistillery, () => whiskeyDistillery(params[0]))
       .with(BuildingEnum.Windmill, () => windmill(params[0]))
-      .with(BuildingEnum.Winery, () => winery(params[0], params[1]))
+      .with(BuildingEnum.Winery, () => winery(params[0]))
       .otherwise(() => () => {
         throw new Error(`Invalid params [${params}] for building ${building}`)
       })


### PR DESCRIPTION
The problem with Winery in its previous form is that it could be called with `'', 'Wn'`, meaning don't make any wine but sell it for money. That's totally valid, however with completions thinking an empty string parameter is like a noop that ends the command and sends it to reduce the game state, since each param is selected one at a time, it wouldn't let the user select anything to follow the first `''`.

This changes the building so it only accepts one param, and you just put in all of your Grapes and Wine at the same time.