### PR TITLE
fix: workaround until ts-pattern has variadic array length matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 !/data/saves
 /client/prototype-ui/*
 !/client/prototype-ui/plugins
+.DS_Store

--- a/game/src/__tests__/control.test.ts
+++ b/game/src/__tests__/control.test.ts
@@ -4,6 +4,7 @@ import {
   Clergy,
   Frame,
   GameCommandConfigParams,
+  GameCommandEnum,
   GameStatePlaying,
   GameStatusEnum,
   NextUseClergy,
@@ -12,6 +13,40 @@ import {
   Tableau,
   Tile,
 } from '../types'
+
+import {
+  completeBuild,
+  completeCommit,
+  completeConvert,
+  completeCutPeat,
+  completeFellTrees,
+  completeSettle,
+  completeUse,
+  completeWorkContract,
+  completeWithLaybrother,
+  completeWithPrior,
+  completeBuyPlot,
+  completeBuyDistrict,
+} from '../commands'
+
+jest.mock('../commands', () => {
+  const innerUse = jest.fn().mockReturnValue(['USE'])
+  return {
+    ...jest.requireActual('../commands'),
+    completeBuild: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['BUILD'])),
+    completeCommit: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['COMMIT'])),
+    completeConvert: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['CONVERT'])),
+    completeCutPeat: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['CUT_PEAT'])),
+    completeFellTrees: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['FELL_TREES'])),
+    completeSettle: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['SETTLE'])),
+    completeUse: jest.fn().mockReturnValue(innerUse),
+    completeWorkContract: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['WORK_CONTRACT'])),
+    completeWithLaybrother: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['WITH_LAYBROTHER'])),
+    completeWithPrior: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['WITH_PRIOR'])),
+    completeBuyPlot: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['BUY_PLOT'])),
+    completeBuyDistrict: jest.fn().mockReturnValue(jest.fn().mockReturnValue(['BUY_DISTRICT'])),
+  }
+})
 
 describe('control', () => {
   describe('control/view', () => {
@@ -106,25 +141,142 @@ describe('control', () => {
       ])
     })
 
-    it('gives a list of commands if no partial', () => {
+    it('asks the command completeBuild with no partial to see if it can be used', () => {
       const c0 = control(s0, [], 0)
-      expect(c0.partial).toStrictEqual([])
-      expect(c0.completion).toContain('USE')
-      expect(c0.completion).toContain('BUY_DISTRICT')
-      expect(c0.completion).toContain('FELL_TREES')
-      expect(c0.completion).toContain('CUT_PEAT')
+      expect(completeBuild(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuild).toHaveBeenCalledWith(s0)
     })
-
-    it('gives a list of usable buidings if partial use', () => {
-      const c0 = control(s0, ['USE'], 0)
-      expect(c0.partial).toStrictEqual(['USE'])
-      expect(c0.completion).toStrictEqual(['LR1', 'LR2', 'G01'])
+    it('delegates completion with other params to completeBuild', () => {
+      const c0 = control(s0, [GameCommandEnum.BUILD], 0)
+      expect(completeBuild(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuild).toHaveBeenCalledWith(s0)
     })
-
-    it('using LR1 can be nothing, or Jo', () => {
-      const c0 = control(s0, ['USE', 'LR1'], 0)
-      expect(c0.partial).toStrictEqual(['USE', 'LR1'])
-      expect(c0.completion).toStrictEqual(['', 'Jo'])
+    it('asks the command completeCommit with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeCommit(undefined!)).toHaveBeenCalledWith([])
+      expect(completeCommit).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeCommit', () => {
+      const c0 = control(s0, [GameCommandEnum.COMMIT], 0)
+      expect(completeCommit(undefined!)).toHaveBeenCalledWith([])
+      expect(completeCommit).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeConvert with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeConvert(undefined!)).toHaveBeenCalledWith([])
+      expect(completeConvert).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeConvert', () => {
+      const c0 = control(s0, [GameCommandEnum.CONVERT], 0)
+      expect(completeConvert(undefined!)).toHaveBeenCalledWith([])
+      expect(completeConvert).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeCutPeat with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeCutPeat(undefined!)).toHaveBeenCalledWith([])
+      expect(completeCutPeat).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeCutPeat', () => {
+      const c0 = control(s0, [GameCommandEnum.CUT_PEAT], 0)
+      expect(completeCutPeat(undefined!)).toHaveBeenCalledWith([])
+      expect(completeCutPeat).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeFellTrees with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeFellTrees(undefined!)).toHaveBeenCalledWith([])
+      expect(completeFellTrees).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeFellTrees', () => {
+      const c0 = control(s0, [GameCommandEnum.FELL_TREES], 0)
+      expect(completeFellTrees(undefined!)).toHaveBeenCalledWith([])
+      expect(completeFellTrees).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeSettle with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeSettle(undefined!)).toHaveBeenCalledWith([])
+      expect(completeSettle).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeSettle', () => {
+      const c0 = control(s0, [GameCommandEnum.SETTLE], 0)
+      expect(completeSettle(undefined!)).toHaveBeenCalledWith([])
+      expect(completeSettle).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeUse with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeUse(undefined!)).toHaveBeenCalledWith([])
+      expect(completeUse).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeUse', () => {
+      const c0 = control(s0, [GameCommandEnum.USE], 0)
+      expect(completeUse(undefined!)).toHaveBeenCalledWith([])
+      expect(completeUse).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeWorkContract with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeWorkContract(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWorkContract).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeWorkContract', () => {
+      const c0 = control(s0, [GameCommandEnum.WORK_CONTRACT], 0)
+      expect(completeWorkContract(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWorkContract).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeWithLaybrother with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeWithLaybrother(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWithLaybrother).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeWithLaybrother', () => {
+      const c0 = control(s0, [GameCommandEnum.WITH_LAYBROTHER], 0)
+      expect(completeWithLaybrother(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWithLaybrother).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeWithPrior with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeWithPrior(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWithPrior).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeWithPrior', () => {
+      const c0 = control(s0, [GameCommandEnum.WITH_PRIOR], 0)
+      expect(completeWithPrior(undefined!)).toHaveBeenCalledWith([])
+      expect(completeWithPrior).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeBuyPlot with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeBuyPlot(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuyPlot).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeBuyPlot', () => {
+      const c0 = control(s0, [GameCommandEnum.BUY_PLOT], 0)
+      expect(completeBuyPlot(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuyPlot).toHaveBeenCalledWith(s0)
+    })
+    it('asks the command completeBuyDistrict with no partial to see if it can be used', () => {
+      const c0 = control(s0, [], 0)
+      expect(completeBuyDistrict(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuyDistrict).toHaveBeenCalledWith(s0)
+    })
+    it('delegates completion with other params to completeBuyDistrict', () => {
+      const c0 = control(s0, [GameCommandEnum.BUY_DISTRICT], 0)
+      expect(completeBuyDistrict(undefined!)).toHaveBeenCalledWith([])
+      expect(completeBuyDistrict).toHaveBeenCalledWith(s0)
+    })
+    it('concats root commands together into a list', () => {
+      const c0 = control(s0, [], 0)
+      expect(c0.completion).toStrictEqual([
+        'USE',
+        'BUILD',
+        'CUT_PEAT',
+        'FELL_TREES',
+        'WORK_CONTRACT',
+        'BUY_PLOT',
+        'BUY_DISTRICT',
+        'CONVERT',
+        'SETTLE',
+        'WITH_LAYBROTHER',
+        'WITH_PRIOR',
+        'COMMIT',
+      ])
     })
 
     it('handles a mistake in the flow without an error or overflow', () => {

--- a/game/src/commands/__tests__/build.test.ts
+++ b/game/src/commands/__tests__/build.test.ts
@@ -340,6 +340,29 @@ describe('commands/build', () => {
           {
             ...s0.players[0],
             landscape: [
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['H', 'LB1'], [], []],
+              [[], [], ['P', 'LPE'], ['P', 'LFO'], ['P', 'LB2'], ['P'], ['H', 'LB3'], [], []],
+            ] as Tile[][],
+            landscapeOffset: 0,
+          },
+          ...s0.players.slice(1),
+        ],
+        frame: {
+          ...s0.frame,
+          bonusActions: [],
+        },
+        buildings: [BuildingEnum.StoneMerchant],
+      }
+      const c0 = complete(s1, ['BUILD', BuildingEnum.StoneMerchant])
+      expect(c0).toStrictEqual(['3 0', '3 1'])
+    })
+    it('considers terrain type', () => {
+      const s1: GameStatePlaying = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            landscape: [
               [['W'], ['C'], [], [], [], [], [], [], []],
               [['W'], ['C'], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
               [['W'], ['C', 'F04'], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
@@ -352,7 +375,6 @@ describe('commands/build', () => {
         ],
         frame: {
           ...s0.frame,
-          mainActionUsed: true,
           bonusActions: [],
         },
       }

--- a/game/src/commands/__tests__/build.test.ts
+++ b/game/src/commands/__tests__/build.test.ts
@@ -258,7 +258,7 @@ describe('commands/build', () => {
           bonusActions: [GameCommandEnum.BUILD],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['BUILD'])
     })
     it('allows running if main action not used yet', () => {
@@ -270,7 +270,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['BUILD'])
     })
     it('does not allow running if not not permitted by frame', () => {
@@ -282,7 +282,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('gives all the buildings which may be built', () => {
@@ -321,7 +321,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, ['BUILD'])
+      const c0 = complete(s1)(['BUILD'])
       expect(c0).toStrictEqual([
         BuildingEnum.Priory,
         BuildingEnum.GrainStorage,
@@ -353,7 +353,7 @@ describe('commands/build', () => {
         },
         buildings: [BuildingEnum.StoneMerchant],
       }
-      const c0 = complete(s1, ['BUILD', BuildingEnum.StoneMerchant])
+      const c0 = complete(s1)(['BUILD', BuildingEnum.StoneMerchant])
       expect(c0).toStrictEqual(['3 0', '3 1'])
     })
     it('considers terrain type', () => {
@@ -378,7 +378,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, ['BUILD', BuildingEnum.HarborPromenade])
+      const c0 = complete(s1)(['BUILD', BuildingEnum.HarborPromenade])
       expect(c0).toStrictEqual(['-1 -1', '-1 0', '-1 2', '-1 3'])
     })
     it('gives all the places the given building can be built if given a col', () => {
@@ -402,7 +402,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, ['BUILD', BuildingEnum.GrapevineA, '4'])
+      const c0 = complete(s1)(['BUILD', BuildingEnum.GrapevineA, '4'])
       expect(c0).toStrictEqual(['-1', '1'])
     })
     it('complete if given all necessary params', () => {
@@ -420,7 +420,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, ['BUILD', BuildingEnum.GrapevineA, '4', '1'])
+      const c0 = complete(s1)(['BUILD', BuildingEnum.GrapevineA, '4', '1'])
       expect(c0).toStrictEqual([''])
     })
     it('cant complete if too many params', () => {
@@ -438,7 +438,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, ['BUILD', BuildingEnum.GrapevineA, '4', '1', 'Wo'])
+      const c0 = complete(s1)(['BUILD', BuildingEnum.GrapevineA, '4', '1', 'Wo'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/buyDistrict.test.ts
+++ b/game/src/commands/__tests__/buyDistrict.test.ts
@@ -266,7 +266,7 @@ describe('commands/buyDistrict', () => {
 
   describe('complete', () => {
     it('stub', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual(['BUY_DISTRICT'])
     })
   })

--- a/game/src/commands/__tests__/buyPlot.test.ts
+++ b/game/src/commands/__tests__/buyPlot.test.ts
@@ -376,7 +376,7 @@ describe('commands/buyPlot', () => {
 
   describe('complete', () => {
     it('stub', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/commit.test.ts
+++ b/game/src/commands/__tests__/commit.test.ts
@@ -26,15 +26,15 @@ describe('commands/commit', () => {
           mainActionUsed: false,
         } as Frame,
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('allows commit if main action used', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual(['COMMIT'])
     })
     it('allows submit, because COMMIT has no parameters', () => {
-      const c0 = complete(s0, [GameCommandEnum.COMMIT])
+      const c0 = complete(s0)([GameCommandEnum.COMMIT])
       expect(c0).toStrictEqual([''])
     })
   })

--- a/game/src/commands/__tests__/convert.test.ts
+++ b/game/src/commands/__tests__/convert.test.ts
@@ -227,7 +227,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('allows convert if they have nickels', () => {
@@ -245,7 +245,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CONVERT'])
     })
     it('does not allow convert if they have four pennies', () => {
@@ -263,7 +263,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('allows convert if they have five pennies', () => {
@@ -281,7 +281,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CONVERT'])
     })
     it('does not allow convert if they have grain', () => {
@@ -299,7 +299,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CONVERT'])
     })
     it('does not allow convert if they have wine', () => {
@@ -317,7 +317,7 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CONVERT'])
     })
     it('does not allow convert if they have whiskey', () => {
@@ -335,11 +335,11 @@ describe('commands/convert', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CONVERT'])
     })
     it('returns [] if weird partial', () => {
-      const c0 = complete(s0, ['CONVERT', 'TWO', 'APPLES'])
+      const c0 = complete(s0)(['CONVERT', 'TWO', 'APPLES'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/cutPeat.test.ts
+++ b/game/src/commands/__tests__/cutPeat.test.ts
@@ -137,7 +137,7 @@ describe('commands/cutPeat', () => {
 
   describe('complete', () => {
     it('returns CUT_PEAT if no partial and active player has forest', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual(['CUT_PEAT'])
     })
     it('returns [] if active player has no moor', () => {
@@ -153,7 +153,7 @@ describe('commands/cutPeat', () => {
         ...s0,
         players: [p1],
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('returns [] if frame has already consumed action', () => {
@@ -164,7 +164,7 @@ describe('commands/cutPeat', () => {
           mainActionUsed: true,
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('returns CUT_PEAT if frame has already consumed action, but allowed via bonus actions', () => {
@@ -176,23 +176,23 @@ describe('commands/cutPeat', () => {
           bonusActions: [GameCommandEnum.CUT_PEAT],
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['CUT_PEAT'])
     })
     it('if partial in CUT_PEAT, returns a list of locations', () => {
-      const c0 = complete(s0, [GameCommandEnum.CUT_PEAT])
+      const c0 = complete(s0)([GameCommandEnum.CUT_PEAT])
       expect(c0).toStrictEqual(['0 0', '0 1', '2 1'])
     })
     it('if partial in CUT_PEAT has row, give cols for that row', () => {
-      const c0 = complete(s0, [GameCommandEnum.CUT_PEAT, '0'])
+      const c0 = complete(s0)([GameCommandEnum.CUT_PEAT, '0'])
       expect(c0).toStrictEqual(['0', '1'])
     })
     it('if CUT_PEAT at a location, give empty string response', () => {
-      const c0 = complete(s0, [GameCommandEnum.CUT_PEAT, '0', '1'])
+      const c0 = complete(s0)([GameCommandEnum.CUT_PEAT, '0', '1'])
       expect(c0).toStrictEqual([''])
     })
     it('if CUT_PEAT not at a location, dont indicate this can be submitted', () => {
-      const c0 = complete(s0, [GameCommandEnum.CUT_PEAT, '0', '5'])
+      const c0 = complete(s0)([GameCommandEnum.CUT_PEAT, '0', '5'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/fellTrees.test.ts
+++ b/game/src/commands/__tests__/fellTrees.test.ts
@@ -140,7 +140,7 @@ describe('commands/fellTrees', () => {
 
   describe('complete', () => {
     it('returns FELL_TREES if no partial and active player has forest', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual(['FELL_TREES'])
     })
     it('returns [] if active player has no forest', () => {
@@ -156,7 +156,7 @@ describe('commands/fellTrees', () => {
         ...s0,
         players: [p1],
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('returns [] if frame has already consumed action', () => {
@@ -167,7 +167,7 @@ describe('commands/fellTrees', () => {
           mainActionUsed: true,
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('returns FELL_TREES if frame has already consumed action, but allowed via bonus actions', () => {
@@ -179,23 +179,23 @@ describe('commands/fellTrees', () => {
           bonusActions: [GameCommandEnum.FELL_TREES],
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['FELL_TREES'])
     })
     it('if partial in FELL_TREES, returns a list of locations', () => {
-      const c0 = complete(s0, [GameCommandEnum.FELL_TREES])
+      const c0 = complete(s0)([GameCommandEnum.FELL_TREES])
       expect(c0).toStrictEqual(['1 0', '2 0', '1 1', '4 1'])
     })
     it('if partial in FELL_TREES has row, give cols for that row', () => {
-      const c0 = complete(s0, [GameCommandEnum.FELL_TREES, '2'])
+      const c0 = complete(s0)([GameCommandEnum.FELL_TREES, '2'])
       expect(c0).toStrictEqual(['0'])
     })
     it('if FELL_TREES at a location, give empty string response', () => {
-      const c0 = complete(s0, [GameCommandEnum.FELL_TREES, '2', '0'])
+      const c0 = complete(s0)([GameCommandEnum.FELL_TREES, '2', '0'])
       expect(c0).toStrictEqual([''])
     })
     it('if FELL_TREES not at a location, dont indicate this can be submitted', () => {
-      const c0 = complete(s0, [GameCommandEnum.FELL_TREES, '0', '5'])
+      const c0 = complete(s0)([GameCommandEnum.FELL_TREES, '0', '5'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/settle.test.ts
+++ b/game/src/commands/__tests__/settle.test.ts
@@ -150,7 +150,7 @@ describe('commands/build', () => {
           bonusActions: [GameCommandEnum.SETTLE],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['SETTLE'])
     })
     it('does not allow running if not in a settlement frame', () => {
@@ -161,7 +161,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('does not allow if none of their settlements can be built', () => {
@@ -172,7 +172,7 @@ describe('commands/build', () => {
           bonusActions: [],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('gives all of the active player settlements, if there are any', () => {
@@ -186,7 +186,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE'])
+      const c0 = complete(s1)(['SETTLE'])
       expect(c0).toStrictEqual(['SR1', 'SR3', 'SR5', 'SR6'])
     })
     it('only gives settlements that the player can afford', () => {
@@ -204,7 +204,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE'])
+      const c0 = complete(s1)(['SETTLE'])
       expect(c0).toStrictEqual(['SR1', 'SR3'])
     })
     it('only gives spots that match the building', () => {
@@ -223,7 +223,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE', 'SR4']) // Fishing Village can only be on coast
+      const c0 = complete(s1)(['SETTLE', 'SR4']) // Fishing Village can only be on coast
       expect(c0).toStrictEqual(['-1 -1', '-1 0'])
     })
     it('gives no settlements if there are none', () => {
@@ -242,7 +242,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE', 'SR6'])
+      const c0 = complete(s1)(['SETTLE', 'SR6'])
       expect(c0).toStrictEqual(['-1 -1', '3 -1', '4 -1', '-1 0', '3 0', '3 1'])
     })
     it('gives rows that the first col is free', () => {
@@ -261,7 +261,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE', 'SR8', '3'])
+      const c0 = complete(s1)(['SETTLE', 'SR8', '3'])
       expect(c0).toStrictEqual(['-1', '0'])
     })
     it('gives ways of paying for the given thing', () => {
@@ -302,7 +302,7 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE', 'SR6', '-1', '0'])
+      const c0 = complete(s1)(['SETTLE', 'SR6', '-1', '0'])
       // 5 food 6 energy
       expect(c0).toStrictEqual([
         // this sort is intentional, because people probably want to eat meat first
@@ -355,12 +355,12 @@ describe('commands/build', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['SETTLE', 'SR6', '-1', '0', 'MtCoCo'])
+      const c0 = complete(s1)(['SETTLE', 'SR6', '-1', '0', 'MtCoCo'])
       expect(c0).toStrictEqual([''])
     })
 
     it('doesnt continue anything else', () => {
-      const c0 = complete(s0, ['HELLO'])
+      const c0 = complete(s0)(['HELLO'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/use.test.ts
+++ b/game/src/commands/__tests__/use.test.ts
@@ -633,7 +633,7 @@ describe('commands/use', () => {
 
   describe('complete', () => {
     it('allows USE when main action available', () => {
-      const c0 = complete(s0, [])
+      const c0 = complete(s0)([])
       expect(c0).toStrictEqual(['USE'])
     })
     it('does not allow use main action already used', () => {
@@ -644,7 +644,7 @@ describe('commands/use', () => {
           mainActionUsed: true,
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
 
@@ -664,7 +664,7 @@ describe('commands/use', () => {
           nextUse: NextUseClergy.Any,
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
 
@@ -678,7 +678,7 @@ describe('commands/use', () => {
           usableBuildings: [BuildingEnum.Priory],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['USE'])
     })
 
@@ -699,7 +699,7 @@ describe('commands/use', () => {
           usableBuildings: [BuildingEnum.Priory],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
 
@@ -717,27 +717,27 @@ describe('commands/use', () => {
           usableBuildings: [BuildingEnum.GrainStorage, BuildingEnum.BuildersMarket],
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['USE'])
     })
 
     it('gives a list of buildings that are free', () => {
-      const c0 = complete(s0, ['USE'])
+      const c0 = complete(s0)(['USE'])
       expect(c0).toStrictEqual(['LR1', 'LR2', 'LR3'])
     })
 
     it('calls the buildingComplete with all the params', () => {
-      const c0 = complete(s0, ['USE', 'LR1', 'Jo'])
+      const c0 = complete(s0)(['USE', 'LR1', 'Jo'])
       expect(clayMoundComplete).toHaveBeenCalledWith(['Jo'])
     })
 
     it('gives back [] if weird building being used', () => {
-      const c0 = complete(s0, ['USE', 'PRIR'])
+      const c0 = complete(s0)(['USE', 'PRIR'])
       expect(c0).toStrictEqual([])
     })
 
     it('gives back [] if weird command, how did we get here?', () => {
-      const c0 = complete(s0, ['YUZU'])
+      const c0 = complete(s0)(['YUZU'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/withLayBrother.test.ts
+++ b/game/src/commands/__tests__/withLayBrother.test.ts
@@ -212,7 +212,7 @@ describe('commands/withLaybrother', () => {
           currentPlayerIndex: 2,
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WITH_LAYBROTHER'])
     })
     it('is not possible if active player is current player', () => {
@@ -224,16 +224,16 @@ describe('commands/withLaybrother', () => {
           currentPlayerIndex: 2,
         },
       } as GameStatePlaying
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('has no other parameters', () => {
-      const c0 = complete(s0, [GameCommandEnum.WITH_LAYBROTHER])
+      const c0 = complete(s0)([GameCommandEnum.WITH_LAYBROTHER])
       expect(c0).toStrictEqual([''])
     })
 
     it('returns [] on anything else', () => {
-      const c0 = complete(s0, ['HELLO'])
+      const c0 = complete(s0)(['HELLO'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/withPrior.test.ts
+++ b/game/src/commands/__tests__/withPrior.test.ts
@@ -283,7 +283,7 @@ describe('commands/withPrior', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WITH_PRIOR'])
     })
     it('if the player does not have a prior', () => {
@@ -297,15 +297,15 @@ describe('commands/withPrior', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('completes the command', () => {
-      const c0 = complete(s0, ['WITH_PRIOR'])
+      const c0 = complete(s0)(['WITH_PRIOR'])
       expect(c0).toStrictEqual([''])
     })
     it('doesnt know what this is', () => {
-      const c0 = complete(s0, ['WITH_PRIOR', 'Pn'])
+      const c0 = complete(s0)(['WITH_PRIOR', 'Pn'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/__tests__/workContract.test.ts
+++ b/game/src/commands/__tests__/workContract.test.ts
@@ -296,8 +296,27 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+    it('will not allow if nobody else has any clergy to use', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 1,
+            wine: 0,
+            whiskey: 0,
+          },
+          ...s0.players.map((p) => ({
+            ...p,
+            clergy: [],
+          })),
+        ],
+      }
+      const c0 = complete(s1)([])
+      expect(c0).toStrictEqual([])
     })
     it('can work contract if they have 1 wine', () => {
       const s1 = {
@@ -312,7 +331,7 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WORK_CONTRACT'])
     })
     it('can work contract if they have 1 whiskey', () => {
@@ -328,7 +347,7 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WORK_CONTRACT'])
     })
     it('can not work contract if no money', () => {
@@ -344,7 +363,7 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
     it('can work contract if they have 2 penny in late game', () => {
@@ -368,7 +387,7 @@ describe('commands/workContract', () => {
           settlementRound: SettlementRound.C,
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WORK_CONTRACT'])
     })
     it('can not work contract if insufficient money', () => {
@@ -392,7 +411,7 @@ describe('commands/workContract', () => {
           settlementRound: SettlementRound.C,
         },
       }
-      const c0 = complete(s1, [])
+      const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
     })
 
@@ -409,7 +428,7 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['WORK_CONTRACT'])
+      const c0 = complete(s1)(['WORK_CONTRACT'])
       expect(c0).toStrictEqual(['LB1', 'LB2', 'G02', 'LB3', 'F05', 'LG1', 'LG2', 'F08', 'LG3'])
     })
 
@@ -431,7 +450,7 @@ describe('commands/workContract', () => {
           activePlayerIndex: 1,
         },
       }
-      const c0 = complete(s1, ['WORK_CONTRACT'])
+      const c0 = complete(s1)(['WORK_CONTRACT'])
       expect(c0).toStrictEqual(['G01', 'LR3', 'F05', 'LG1', 'LG2', 'F08', 'LG3'])
     })
 
@@ -448,7 +467,7 @@ describe('commands/workContract', () => {
           ...s0.players.slice(1),
         ],
       }
-      const c0 = complete(s1, ['WORK_CONTRACT', 'G02'])
+      const c0 = complete(s1)(['WORK_CONTRACT', 'G02'])
       expect(c0).toStrictEqual(['Wn', 'Wh', 'Pn'])
     })
     it('gives late game options for paying', () => {
@@ -472,17 +491,17 @@ describe('commands/workContract', () => {
           settlementRound: SettlementRound.C,
         },
       }
-      const c0 = complete(s1, ['WORK_CONTRACT', 'G02'])
+      const c0 = complete(s1)(['WORK_CONTRACT', 'G02'])
       expect(c0).toStrictEqual(['Wn', 'Wh', 'PnPn'])
     })
 
     it('terminates when enough options', () => {
-      const c0 = complete(s0, ['WORK_CONTRACT', 'G02', 'Pn'])
+      const c0 = complete(s0)(['WORK_CONTRACT', 'G02', 'Pn'])
       expect(c0).toStrictEqual([''])
     })
 
     it('empty completions when weird params', () => {
-      const c0 = complete(s0, ['WORK_CONTRACT', 'G02', 'Pn', 'Pn'])
+      const c0 = complete(s0)(['WORK_CONTRACT', 'G02', 'Pn', 'Pn'])
       expect(c0).toStrictEqual([])
     })
   })

--- a/game/src/commands/build.ts
+++ b/game/src/commands/build.ts
@@ -67,32 +67,34 @@ export const build = ({ row, col, building }: GameCommandBuildParams): StateRedu
     allowPriorToUse(building)
   )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  const player = view(activeLens(state), state)
-  return (
-    match<string[], string[]>(partial)
-      .with([], () => {
-        if (oncePerFrame(GameCommandEnum.BUILD)(state)) return [GameCommandEnum.BUILD]
-        return []
-      })
-      .with(
-        [GameCommandEnum.BUILD],
-        // return all buildings we have the resources for
-        always(
-          filter((building: BuildingEnum): boolean => !!payCost(costForBuilding(building))(player), state.buildings)
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    const player = view(activeLens(state), state)
+    return (
+      match<string[], string[]>(partial)
+        .with([], () => {
+          if (oncePerFrame(GameCommandEnum.BUILD)(state)) return [GameCommandEnum.BUILD]
+          return []
+        })
+        .with(
+          [GameCommandEnum.BUILD],
+          // return all buildings we have the resources for
+          always(
+            filter((building: BuildingEnum): boolean => !!payCost(costForBuilding(building))(player), state.buildings)
+          )
         )
-      )
-      .with([GameCommandEnum.BUILD, P._], ([, building]) =>
-        // Return all the coords which match the terrain for this building...
-        erectableLocations(building as BuildingEnum, player)
-      )
-      .with([GameCommandEnum.BUILD, P._, P._], ([, building, col]) =>
-        // Return all the coords which match the terrain from the previous step, and have
-        // the same prefix as the column
-        erectableLocationsCol(building as BuildingEnum, col, player)
-      )
-      // TODO: only show '' if the command is ultimately valid
-      .with([GameCommandEnum.BUILD, P._, P._, P._], always(['']))
-      .otherwise(always([]))
-  )
-})
+        .with([GameCommandEnum.BUILD, P._], ([, building]) =>
+          // Return all the coords which match the terrain for this building...
+          erectableLocations(building as BuildingEnum, player)
+        )
+        .with([GameCommandEnum.BUILD, P._, P._], ([, building, col]) =>
+          // Return all the coords which match the terrain from the previous step, and have
+          // the same prefix as the column
+          erectableLocationsCol(building as BuildingEnum, col, player)
+        )
+        // TODO: only show '' if the command is ultimately valid
+        .with([GameCommandEnum.BUILD, P._, P._, P._], always(['']))
+        .otherwise(always([]))
+    )
+  }

--- a/game/src/commands/buyDistrict.ts
+++ b/game/src/commands/buyDistrict.ts
@@ -146,12 +146,14 @@ export const buyDistrict = ({ side, y }: GameCommandBuyDistrictParams) =>
     addNewDistrict(y, side)
   )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  if (!state.frame.bonusActions.includes(GameCommandEnum.BUY_DISTRICT) && !state.frame.canBuyLandscape) return []
-  const player = state.players[state.frame.activePlayerIndex]
-  const playerWealth = costMoney(player)
-  const nextDistrictCost = head(state.districtPurchasePrices)
-  if (nextDistrictCost === undefined) return []
-  if (playerWealth < nextDistrictCost) return []
-  return [GameCommandEnum.BUY_DISTRICT]
-})
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    if (!state.frame.bonusActions.includes(GameCommandEnum.BUY_DISTRICT) && !state.frame.canBuyLandscape) return []
+    const player = state.players[state.frame.activePlayerIndex]
+    const playerWealth = costMoney(player)
+    const nextDistrictCost = head(state.districtPurchasePrices)
+    if (nextDistrictCost === undefined) return []
+    if (playerWealth < nextDistrictCost) return []
+    return [GameCommandEnum.BUY_DISTRICT]
+  }

--- a/game/src/commands/buyPlot.ts
+++ b/game/src/commands/buyPlot.ts
@@ -182,6 +182,8 @@ export const buyPlot = ({ side, y }: GameCommandBuyPlotParams) =>
     addNewPlot(y, side)
   )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  return []
-})
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    return []
+  }

--- a/game/src/commands/commit.ts
+++ b/game/src/commands/commit.ts
@@ -8,12 +8,14 @@ export const commit: StateReducer = pipe(
   nextFrame
 )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  return match<string[], string[]>(partial)
-    .with([], () => {
-      if (state.frame.mainActionUsed) return [GameCommandEnum.COMMIT]
-      return []
-    })
-    .with([GameCommandEnum.COMMIT], () => [''])
-    .otherwise(always([]))
-})
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    return match<string[], string[]>(partial)
+      .with([], () => {
+        if (state.frame.mainActionUsed) return [GameCommandEnum.COMMIT]
+        return []
+      })
+      .with([GameCommandEnum.COMMIT], () => [''])
+      .otherwise(always([]))
+  }

--- a/game/src/commands/convert.ts
+++ b/game/src/commands/convert.ts
@@ -65,23 +65,24 @@ export const convert = ({ grain, wine, nickel, whiskey, penny }: GameCommandConv
   )
 }
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] =>
-  match<string[], string[]>(partial)
-    .with([], () => {
-      if (
-        withActivePlayer((player) => {
-          if (!player) return player
-          const { penny, grain, wine, nickel, whiskey } = player
-          if (penny >= 5 || grain || wine || nickel || whiskey) return player
-          return undefined
-        })(state)
-      ) {
-        return [GameCommandEnum.CONVERT]
-      }
-      return []
-    })
-    .with([GameCommandEnum.CONVERT], () => {
-      return []
-    })
-    .otherwise(() => [])
-)
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] =>
+    match<string[], string[]>(partial)
+      .with([], () => {
+        if (
+          withActivePlayer((player) => {
+            if (!player) return player
+            const { penny, grain, wine, nickel, whiskey } = player
+            if (penny >= 5 || grain || wine || nickel || whiskey) return player
+            return undefined
+          })(state)
+        ) {
+          return [GameCommandEnum.CONVERT]
+        }
+        return []
+      })
+      .with([GameCommandEnum.CONVERT], () => {
+        return []
+      })
+      .otherwise(() => [])

--- a/game/src/commands/cutPeat.ts
+++ b/game/src/commands/cutPeat.ts
@@ -52,25 +52,27 @@ export const cutPeat = ({ row, col, useJoker }: GameCommandCutPeatParams): State
     withRondel(updateRondel(useJoker ? 'joker' : 'peat'))
   )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  const player = state.players[state.frame.activePlayerIndex]
-  return (
-    match<string[], string[]>(partial)
-      .with([], () => {
-        if (!hasAMoor(player.landscape)) return []
-        if (oncePerFrame(GameCommandEnum.CUT_PEAT)(state) === undefined) return []
-        return [GameCommandEnum.CUT_PEAT]
-      })
-      .with([GameCommandEnum.CUT_PEAT], () => moorLocations(player))
-      // shouldnt actually ever see this, but i think its important for completeness
-      .with([GameCommandEnum.CUT_PEAT, P._], (_, [, c]) => moorLocationsForCol(c, player))
-      .with([GameCommandEnum.CUT_PEAT, P._, P._], (_, [, c, r]) => {
-        const row = Number.parseInt(r, 10) + player.landscapeOffset
-        const col = Number.parseInt(c, 10) + 2
-        const tile = player.landscape?.[row]?.[col]
-        if (tile?.[1] === BuildingEnum.Peat) return ['']
-        return []
-      })
-      .otherwise(always([]))
-  )
-})
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    const player = state.players[state.frame.activePlayerIndex]
+    return (
+      match<string[], string[]>(partial)
+        .with([], () => {
+          if (!hasAMoor(player.landscape)) return []
+          if (oncePerFrame(GameCommandEnum.CUT_PEAT)(state) === undefined) return []
+          return [GameCommandEnum.CUT_PEAT]
+        })
+        .with([GameCommandEnum.CUT_PEAT], () => moorLocations(player))
+        // shouldnt actually ever see this, but i think its important for completeness
+        .with([GameCommandEnum.CUT_PEAT, P._], (_, [, c]) => moorLocationsForCol(c, player))
+        .with([GameCommandEnum.CUT_PEAT, P._, P._], (_, [, c, r]) => {
+          const row = Number.parseInt(r, 10) + player.landscapeOffset
+          const col = Number.parseInt(c, 10) + 2
+          const tile = player.landscape?.[row]?.[col]
+          if (tile?.[1] === BuildingEnum.Peat) return ['']
+          return []
+        })
+        .otherwise(always([]))
+    )
+  }

--- a/game/src/commands/fellTrees.ts
+++ b/game/src/commands/fellTrees.ts
@@ -79,25 +79,27 @@ export const fellTrees = ({ row, col, useJoker }: GameCommandFellTreesParams): S
     useJoker ? updateJokerRondel : updateWoodRondel
   )
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] => {
-  const player = state.players[state.frame.activePlayerIndex]
-  return (
-    match<string[], string[]>(partial)
-      .with([], () => {
-        if (!hasAForest(player.landscape)) return []
-        if (oncePerFrame(GameCommandEnum.FELL_TREES)(state) === undefined) return []
-        return [GameCommandEnum.FELL_TREES]
-      })
-      .with([GameCommandEnum.FELL_TREES], () => forestLocations(player))
-      // shouldnt actually ever see this, but i think its important for completeness
-      .with([GameCommandEnum.FELL_TREES, P._], (_, [, c]) => forestLocationsForCol(c, player))
-      .with([GameCommandEnum.FELL_TREES, P._, P._], (_, [, c, r]) => {
-        const row = Number.parseInt(r, 10) + player.landscapeOffset
-        const col = Number.parseInt(c, 10) + 2
-        const tile = player.landscape?.[row]?.[col]
-        if (tile?.[1] === BuildingEnum.Forest) return ['']
-        return []
-      })
-      .otherwise(always([]))
-  )
-})
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] => {
+    const player = state.players[state.frame.activePlayerIndex]
+    return (
+      match<string[], string[]>(partial)
+        .with([], () => {
+          if (!hasAForest(player.landscape)) return []
+          if (oncePerFrame(GameCommandEnum.FELL_TREES)(state) === undefined) return []
+          return [GameCommandEnum.FELL_TREES]
+        })
+        .with([GameCommandEnum.FELL_TREES], () => forestLocations(player))
+        // shouldnt actually ever see this, but i think its important for completeness
+        .with([GameCommandEnum.FELL_TREES, P._], (_, [, c]) => forestLocationsForCol(c, player))
+        .with([GameCommandEnum.FELL_TREES, P._, P._], (_, [, c, r]) => {
+          const row = Number.parseInt(r, 10) + player.landscapeOffset
+          const col = Number.parseInt(c, 10) + 2
+          const tile = player.landscape?.[row]?.[col]
+          if (tile?.[1] === BuildingEnum.Forest) return ['']
+          return []
+        })
+        .otherwise(always([]))
+    )
+  }

--- a/game/src/commands/index.ts
+++ b/game/src/commands/index.ts
@@ -1,17 +1,15 @@
-import { always, curry, toPairs } from 'ramda'
-import { complete as completeBuild } from './build'
-import { complete as completeCommit } from './commit'
-import { complete as completeConvert } from './convert'
-import { complete as completeCutPeat } from './cutPeat'
-import { complete as completeFellTrees } from './fellTrees'
-import { complete as completeSettle } from './settle'
-import { complete as completeUse } from './use'
-import { complete as completeWorkContract } from './workContract'
-import { complete as completeWithLaybrother } from './withLaybrother'
-import { complete as completeWithPrior } from './withPrior'
-import { complete as completeBuyPlot } from './buyPlot'
-import { complete as completeBuyDistrict } from './buyDistrict'
-import { GameCommandEnum, GameStatePlaying } from '../types'
+export { complete as completeBuild } from './build'
+export { complete as completeCommit } from './commit'
+export { complete as completeConvert } from './convert'
+export { complete as completeCutPeat } from './cutPeat'
+export { complete as completeFellTrees } from './fellTrees'
+export { complete as completeSettle } from './settle'
+export { complete as completeUse } from './use'
+export { complete as completeWorkContract } from './workContract'
+export { complete as completeWithLaybrother } from './withLaybrother'
+export { complete as completeWithPrior } from './withPrior'
+export { complete as completeBuyPlot } from './buyPlot'
+export { complete as completeBuyDistrict } from './buyDistrict'
 
 export { build } from './build'
 export { commit } from './commit'
@@ -27,28 +25,3 @@ export { withLaybrother } from './withLaybrother'
 export { withPrior } from './withPrior'
 export { buyPlot } from './buyPlot'
 export { buyDistrict } from './buyDistrict'
-
-/**
- * These completion functions will return a list of command strings you could append to the partial list of command strings (which
- * is basically just a command tokenized by spaces). So it follows that if you give it a partial=[], then something like completeWorkContract
- * would return ["WORK_CONTRACT"] if it thought that the active player has a legal command they can do with that (that is, they can pay the
- * fee, and at least one other player has a clergy free).
- *
- * If an empty string is included, then the command thinks the partial command can be submitted as it is.
- */
-export const complete: Record<GameCommandEnum, (state: GameStatePlaying) => (partial: string[]) => string[]> = {
-  [GameCommandEnum.START]: always(always([])),
-  [GameCommandEnum.CONFIG]: always(always([])),
-  [GameCommandEnum.BUILD]: completeBuild,
-  [GameCommandEnum.COMMIT]: completeCommit,
-  [GameCommandEnum.CONVERT]: completeConvert,
-  [GameCommandEnum.CUT_PEAT]: completeCutPeat,
-  [GameCommandEnum.FELL_TREES]: completeFellTrees,
-  [GameCommandEnum.SETTLE]: completeSettle,
-  [GameCommandEnum.USE]: completeUse,
-  [GameCommandEnum.WORK_CONTRACT]: completeWorkContract,
-  [GameCommandEnum.WITH_LAYBROTHER]: completeWithLaybrother,
-  [GameCommandEnum.WITH_PRIOR]: completeWithPrior,
-  [GameCommandEnum.BUY_PLOT]: completeBuyPlot,
-  [GameCommandEnum.BUY_DISTRICT]: completeBuyDistrict,
-}

--- a/game/src/commands/settle.ts
+++ b/game/src/commands/settle.ts
@@ -81,7 +81,10 @@ export const complete = curry((state: GameStatePlaying, partial: string[]): stri
           return playerFood >= requiredFood && playerEnergy >= requiredEnergy
         }, view(activeLens(state), state).settlements)
       })
-      .with([GameCommandEnum.SETTLE, P._], ([, settlement]) => erectableLocations(settlement as SettlementEnum, player))
+      .with([GameCommandEnum.SETTLE, P._], ([, settlement]) =>
+        // Return all the coords which match the terrain for this building...
+        erectableLocations(settlement as SettlementEnum, player)
+      )
       .with([GameCommandEnum.SETTLE, P._, P._], ([, settlement, col]) =>
         erectableLocationsCol(settlement as SettlementEnum, col, player)
       )

--- a/game/src/commands/withLaybrother.ts
+++ b/game/src/commands/withLaybrother.ts
@@ -32,9 +32,10 @@ export const withLaybrother: StateReducer = (state) => {
   )(state)
 }
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] =>
-  match<string[], string[]>(partial)
-    .with([], () => (checkActivePlayerIsNotCurrent(state) ? [GameCommandEnum.WITH_LAYBROTHER] : []))
-    .with([GameCommandEnum.WITH_LAYBROTHER], () => [''])
-    .otherwise(() => [])
-)
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] =>
+    match<string[], string[]>(partial)
+      .with([], () => (checkActivePlayerIsNotCurrent(state) ? [GameCommandEnum.WITH_LAYBROTHER] : []))
+      .with([GameCommandEnum.WITH_LAYBROTHER], () => [''])
+      .otherwise(() => [])

--- a/game/src/commands/withPrior.ts
+++ b/game/src/commands/withPrior.ts
@@ -43,16 +43,17 @@ export const withPrior: StateReducer = (state) => {
   return withPriorForWorkContract(state)
 }
 
-export const complete = curry((state: GameStatePlaying, partial: string[]): string[] =>
-  match<string[], string[]>(partial)
-    .with([], () => {
-      const player = view(activeLens(state), state)
-      // TODO don't show if we already have nextUse = prior only
-      if (any(isPrior, player.clergy)) return [GameCommandEnum.WITH_PRIOR]
-      return []
-    })
-    .with([GameCommandEnum.WITH_PRIOR], () => {
-      return ['']
-    })
-    .otherwise(() => [])
-)
+export const complete =
+  (state: GameStatePlaying) =>
+  (partial: string[]): string[] =>
+    match<string[], string[]>(partial)
+      .with([], () => {
+        const player = view(activeLens(state), state)
+        // TODO don't show if we already have nextUse = prior only
+        if (any(isPrior, player.clergy)) return [GameCommandEnum.WITH_PRIOR]
+        return []
+      })
+      .with([GameCommandEnum.WITH_PRIOR], () => {
+        return ['']
+      })
+      .otherwise(() => [])

--- a/game/src/commands/withPrior.ts
+++ b/game/src/commands/withPrior.ts
@@ -47,6 +47,7 @@ export const complete = curry((state: GameStatePlaying, partial: string[]): stri
   match<string[], string[]>(partial)
     .with([], () => {
       const player = view(activeLens(state), state)
+      // TODO don't show if we already have nextUse = prior only
       if (any(isPrior, player.clergy)) return [GameCommandEnum.WITH_PRIOR]
       return []
     })

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -1,5 +1,5 @@
 import { P, match } from 'ts-pattern'
-import { always, reduce, toPairs } from 'ramda'
+import { always, head, reduce, toPairs } from 'ramda'
 import { pickFrameFlow } from './board/frame'
 import { Flower, GameCommandEnum, GameStatePlaying, OrdinalFrame, Controls, Frame } from './types'
 import { complete } from './commands'
@@ -28,8 +28,8 @@ const computeFlow = (state: GameStatePlaying) => {
 }
 
 export const control = (state: GameStatePlaying, partial: string[], player?: number): Controls => {
-  const completion = match(partial)
-    .with([], () =>
+  const completion = match(head(partial))
+    .with(undefined, () =>
       reduce(
         (accum, pair) => {
           const [_command, complete] = pair
@@ -40,15 +40,18 @@ export const control = (state: GameStatePlaying, partial: string[], player?: num
         toPairs(complete) as [GameCommandEnum, (state: GameStatePlaying) => (partial: string[]) => string[]][]
       )
     )
-    .with([GameCommandEnum.USE], [GameCommandEnum.USE, P._], [GameCommandEnum.USE, P._, P._], complete.USE(state))
-    .with([GameCommandEnum.BUILD], complete.BUILD(state))
-    .with([GameCommandEnum.CUT_PEAT], complete.CUT_PEAT(state))
-    .with([GameCommandEnum.FELL_TREES], complete.FELL_TREES(state))
-    .with([GameCommandEnum.WORK_CONTRACT], complete.WORK_CONTRACT(state))
-    .with([GameCommandEnum.BUY_PLOT], complete.BUY_PLOT(state))
-    .with([GameCommandEnum.BUY_DISTRICT], complete.BUY_DISTRICT(state))
-    .with([GameCommandEnum.CONVERT], complete.CONVERT(state))
-    .with([GameCommandEnum.SETTLE], complete.SETTLE(state))
+    // this can be prettier with https://github.com/gvergnaud/ts-pattern/pull/139
+    // git blame this line and see how it used to be, but i really want something like
+    // .with([GameCommandEnum.Use, P.rest], complete.USE(state))
+    .with(GameCommandEnum.USE, () => complete.USE(state)(partial))
+    .with(GameCommandEnum.BUILD, () => complete.BUILD(state)(partial))
+    .with(GameCommandEnum.CUT_PEAT, () => complete.CUT_PEAT(state)(partial))
+    .with(GameCommandEnum.FELL_TREES, () => complete.FELL_TREES(state)(partial))
+    .with(GameCommandEnum.WORK_CONTRACT, () => complete.WORK_CONTRACT(state)(partial))
+    .with(GameCommandEnum.BUY_PLOT, () => complete.BUY_PLOT(state)(partial))
+    .with(GameCommandEnum.BUY_DISTRICT, () => complete.BUY_DISTRICT(state)(partial))
+    .with(GameCommandEnum.CONVERT, () => complete.CONVERT(state)(partial))
+    .with(GameCommandEnum.SETTLE, () => complete.SETTLE(state)(partial))
     .otherwise(always([]))
 
   return {


### PR DESCRIPTION
i'm not really a fan of this
```typescript
.with(
  [GameCommandEnum.USE],
  [GameCommandEnum.USE, P._],
  [GameCommandEnum.USE, P._, P._],
  complete.USE(state))
```
and it also craps out after a certain number of params. Ideally there'd be some sort of match with a rest operator to say "i want arrays which begin like this and have any number of params". I guess I could use `P.when`, but i would rather wait for https://github.com/gvergnaud/ts-pattern/pull/139