### PR TITLE
feature: add a selector for other completions

### DIFF
--- a/client/web/src/components/MoveList.tsx
+++ b/client/web/src/components/MoveList.tsx
@@ -1,4 +1,5 @@
 import { useHathoraContext } from '../context/GameContext'
+import { Picker } from './Picker'
 
 const resetStyle = {
   fontFamily: 'monospace',
@@ -10,11 +11,14 @@ const resetStyle = {
 }
 
 export const MoveList = () => {
-  const { state, control } = useHathoraContext()
+  const { state, control, undo, redo } = useHathoraContext()
   return (
-    <div>
-      <button type="button" onClick={() => control('')}>
-        Reset Control
+    <div style={{ paddingTop: 20 }}>
+      <button type="button" onClick={undo}>
+        &lt;
+      </button>
+      <button type="button" onClick={redo}>
+        &gt;
       </button>
       <ul style={resetStyle}>
         {state?.moves.map((m, i) => (
@@ -23,6 +27,13 @@ export const MoveList = () => {
             {m}
           </li>
         ))}
+        <li style={{ fontWeight: 'bold' }}>
+          {state?.control?.partial}
+          <Picker />
+          <button type="button" onClick={() => control('')}>
+            Clear Command
+          </button>
+        </li>
       </ul>
     </div>
   )

--- a/client/web/src/components/Picker.tsx
+++ b/client/web/src/components/Picker.tsx
@@ -1,0 +1,30 @@
+import { equals, reject } from 'ramda'
+import { ChangeEvent, useState } from 'react'
+import { useHathoraContext } from '../context/GameContext'
+
+export const Picker = () => {
+  const [resource, setResource] = useState<string>('')
+  const { state, control } = useHathoraContext()
+  const completions = state?.control?.completion ?? []
+  const noSelectableOptions = reject(equals(''), completions).length < 1
+  if (noSelectableOptions) return null
+
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const tokens = state?.control?.partial?.split(/\s+/) ?? []
+    if (tokens.length === 1 && tokens[0] === '') tokens.pop()
+    tokens.push(e.target.value)
+    control(`${state?.control?.partial} ${e.target.value}`)
+    setResource('')
+  }
+
+  return (
+    <div>
+      <select value={resource} onChange={handleChange}>
+        <option> </option>
+        {state?.control?.completion?.map((completion) => (
+          <option key={completion}>{completion}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/client/web/src/components/Player.tsx
+++ b/client/web/src/components/Player.tsx
@@ -17,7 +17,7 @@ export const Player = ({ player, active }: Props) => {
       <PlayerClergy clergy={clergy} color={color} />
       <PlayerLandscape landscape={landscape} offset={landscapeOffset} active={active} />
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <PlayerResources {...resources} />
+      <PlayerResources active={active} {...resources} />
       <PlayerWonders wonders={wonders} />
       <PlayerSettlements settlements={settlements} />
     </div>

--- a/client/web/src/components/PlayerResources.tsx
+++ b/client/web/src/components/PlayerResources.tsx
@@ -1,23 +1,8 @@
 import { range } from 'ramda'
-import { ReactNode } from 'react'
-
-interface TimesProps {
-  n: number
-  children: ReactNode | ReactNode[]
-}
-interface ResourceProps {
-  id: string
-}
-
-const Times = ({ n, children }: TimesProps) => (
-  <>
-    {range(0, n).map((i) => (
-      <span key={`${i}:${children}`}>{children}</span>
-    ))}
-  </>
-)
+import { ResourcePicker } from './Picker'
 
 interface Props {
+  active: boolean
   peat: number
   penny: number
   clay: number
@@ -44,6 +29,9 @@ interface Props {
 
 const multiplier = 1.1
 
+interface ResourceProps {
+  id: string
+}
 export const Resource = ({ id }: ResourceProps) => (
   <img
     alt={id}
@@ -62,7 +50,20 @@ export const Resource = ({ id }: ResourceProps) => (
   />
 )
 
+interface TimesProps {
+  n: number
+  id: string
+}
+const Times = ({ n, id }: TimesProps) => (
+  <>
+    {range(0, n).map((i) => (
+      <Resource key={`${i}:${id}`} id={id} />
+    ))}
+  </>
+)
+
 export const PlayerResources = ({
+  active,
   peat,
   penny,
   clay,
@@ -87,71 +88,27 @@ export const PlayerResources = ({
   reliquary,
 }: Props) => (
   <div style={{ margin: 10 }}>
-    <Times n={peat}>
-      <Resource id="Pt" />
-    </Times>
-    <Times n={penny}>
-      <Resource id="Pn" />
-    </Times>
-    <Times n={clay}>
-      <Resource id="Cl" />
-    </Times>
-    <Times n={wood}>
-      <Resource id="Wo" />
-    </Times>
-    <Times n={grain}>
-      <Resource id="Gn" />
-    </Times>
-    <Times n={sheep}>
-      <Resource id="Sh" />
-    </Times>
-    <Times n={stone}>
-      <Resource id="Sn" />
-    </Times>
-    <Times n={flour}>
-      <Resource id="Fl" />
-    </Times>
-    <Times n={grape}>
-      <Resource id="Gp" />
-    </Times>
-    <Times n={nickel}>
-      <Resource id="Ni" />
-    </Times>
-    <Times n={malt}>
-      <Resource id="Ho" />
-    </Times>
-    <Times n={coal}>
-      <Resource id="Co" />
-    </Times>
-    <Times n={book}>
-      <Resource id="Bo" />
-    </Times>
-    <Times n={ceramic}>
-      <Resource id="Ce" />
-    </Times>
-    <Times n={whiskey}>
-      <Resource id="Wh" />
-    </Times>
-    <Times n={straw}>
-      <Resource id="Sw" />
-    </Times>
-    <Times n={meat}>
-      <Resource id="Mt" />
-    </Times>
-    <Times n={ornament}>
-      <Resource id="Or" />
-    </Times>
-    <Times n={bread}>
-      <Resource id="Br" />
-    </Times>
-    <Times n={wine}>
-      <Resource id="Wn" />
-    </Times>
-    <Times n={beer}>
-      <Resource id="Be" />
-    </Times>
-    <Times n={reliquary}>
-      <Resource id="Rq" />
-    </Times>
+    <Times n={peat} id="Pt" />
+    <Times n={penny} id="Pn" />
+    <Times n={clay} id="Cl" />
+    <Times n={wood} id="Wo" />
+    <Times n={grain} id="Gn" />
+    <Times n={sheep} id="Sh" />
+    <Times n={stone} id="Sn" />
+    <Times n={flour} id="Fl" />
+    <Times n={grape} id="Gp" />
+    <Times n={nickel} id="Ni" />
+    <Times n={malt} id="Ho" />
+    <Times n={coal} id="Co" />
+    <Times n={book} id="Bo" />
+    <Times n={ceramic} id="Ce" />
+    <Times n={whiskey} id="Wh" />
+    <Times n={straw} id="Sw" />
+    <Times n={meat} id="Mt" />
+    <Times n={ornament} id="Or" />
+    <Times n={bread} id="Br" />
+    <Times n={wine} id="Wn" />
+    <Times n={beer} id="Be" />
+    <Times n={reliquary} id="Rq" />
   </div>
 )

--- a/client/web/src/components/StatePlaying.tsx
+++ b/client/web/src/components/StatePlaying.tsx
@@ -9,7 +9,6 @@ import { UnbuiltWonders } from './UnbuiltWonders'
 import { MoveList } from './MoveList'
 import { Actions } from './sliders/Actions'
 import { Submit } from './sliders/Submit'
-import { Debug } from './sliders/Debug'
 
 export const StatePlaying = () => {
   const { state } = useHathoraContext()
@@ -20,8 +19,7 @@ export const StatePlaying = () => {
     <>
       <Actions />
       <Submit />
-      <Debug />
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 470px 200px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 470px 200px', paddingTop: 40 }}>
         <div>
           {buildings && <UnbuiltBuildings buildings={buildings} />}
           {plotPurchasePrices && <UnbuiltPlots plots={plotPurchasePrices} />}

--- a/client/web/src/components/sliders/Actions.tsx
+++ b/client/web/src/components/sliders/Actions.tsx
@@ -24,8 +24,8 @@ export const Actions = () => {
       <ActionWorkContract />
       <ActionBuyPlot />
       <ActionBuyDistrict />
-      <ActionConvert />
       <ActionSettle />
+      <ActionConvert />
       <ActionCommit />
     </div>
   )


### PR DESCRIPTION
Development is kinda slowing and I think it's because I really don't know how to proceed with the resource picker for something like "CONVERT". Hard to think of something that will be both intuitive to use and also work on mobile. Like clicking and dragging would be a little weird seeing as tokens don't have physical coordinates and the game state doesn't keep track of that kind of stuff that's not meaningful to the game's logic. I think if I also have in addition, this dropdown at the end of the movelist, and have the movelist show the current partial move at the end, it actually feels like it works pretty well.

With this in, I can get excited about working on other stuff. It just felt like this had painted itself into a corner where the only thing I could work on was game UI to command logic. Now I'm feeling like after playing this a little bit, I really want an ability to save and load games... almost like a nintendo cartridge. Just like how Horizon Zero Dawn doesn't need to save things that come from the generative world, like where wildlife and herbs are, really just what ammo and guns the player has and which missions they've finished, and stuff that would be on a character sheet. That would make it so people don't even have to save state on a server, they just keep the files with them, and the website is more just like a program they run. That would be kinda cool and different.