### PR TITLE
feature: start solo settlements with only allowing builds for free

### DIFF
--- a/game/src/board/frame.ts
+++ b/game/src/board/frame.ts
@@ -56,6 +56,7 @@ const runProgression =
           unusableBuildings: [],
           usableBuildings: [],
           nextUse: NextUseClergy.Any,
+          neutralBuildingPhase: false,
           ...frameUpdates,
         } as Frame
         return newFrame

--- a/game/src/board/frame/__tests__/checkSoloSettlementReady.test.ts
+++ b/game/src/board/frame/__tests__/checkSoloSettlementReady.test.ts
@@ -1,0 +1,75 @@
+import { initialState } from '../../../state'
+import {
+  BuildingEnum,
+  Frame,
+  GameCommandConfigParams,
+  GameCommandEnum,
+  GameStatePlaying,
+  GameStatusEnum,
+  NextUseClergy,
+  SettlementRound,
+  Tableau,
+} from '../../../types'
+import { checkSoloSettlementReady } from '../checkSoloSettlementReady'
+
+describe('board/frame/checkSoloSettlementReady', () => {
+  const f0: Frame = {
+    round: 0,
+    startingPlayer: 0,
+    currentPlayerIndex: 0,
+    activePlayerIndex: 0,
+    next: 42,
+    mainActionUsed: true,
+    neutralBuildingPhase: true,
+    bonusActions: [],
+    settlementRound: SettlementRound.A,
+    usableBuildings: [],
+    unusableBuildings: [],
+    nextUse: NextUseClergy.OnlyPrior,
+    bonusRoundPlacement: false,
+    canBuyLandscape: true,
+  } as Frame
+  const s0: GameStatePlaying = {
+    ...initialState,
+    status: GameStatusEnum.PLAYING,
+    config: {
+      country: 'france',
+      players: 1,
+      length: 'long',
+    },
+    rondel: {
+      pointingBefore: 0,
+    },
+    wonders: 0,
+    players: [{}, {}, {}] as Tableau[],
+    buildings: ['G01'],
+    plotPurchasePrices: [],
+    districtPurchasePrices: [],
+    frame: f0,
+  } as GameStatePlaying
+
+  it('retains undefined state', () => {
+    const s1 = checkSoloSettlementReady(undefined)!
+    expect(s1).toBeUndefined()
+  })
+  it('all buildings placed, allow SETTLE only', () => {
+    const s1 = {
+      ...s0,
+      buildings: [],
+    }
+    const s2 = checkSoloSettlementReady(s1)!
+    expect(s2.frame).toMatchObject({
+      bonusActions: [GameCommandEnum.SETTLE],
+    })
+  })
+  it('unplaced buildings, only allow BUILD', () => {
+    const s1 = {
+      ...s0,
+      buildings: [BuildingEnum.ChamberOfWonders],
+    }
+    const s2 = checkSoloSettlementReady(s1)!
+    expect(s2.frame).toMatchObject({
+      bonusActions: [GameCommandEnum.BUILD],
+    })
+  })
+})

--- a/game/src/board/frame/checkSoloSettlementReady.ts
+++ b/game/src/board/frame/checkSoloSettlementReady.ts
@@ -1,0 +1,9 @@
+import { lensPath, set } from 'ramda'
+import { GameCommandEnum, StateReducer } from '../../types'
+
+const frameBonusActions = lensPath(['frame', 'bonusActions'])
+
+export const checkSoloSettlementReady: StateReducer = (state) =>
+  state &&
+  // if we start the frame with buildings, only allow building them, otherwise only allow settle (or commit)
+  set(frameBonusActions, state.buildings.length !== 0 ? [GameCommandEnum.BUILD] : [GameCommandEnum.SETTLE], state)

--- a/game/src/board/frame/nextFrameSolo.ts
+++ b/game/src/board/frame/nextFrameSolo.ts
@@ -4,6 +4,8 @@ import { addNeutralPlayer } from './addNeutralPlayer'
 import { gameEnd } from '../state'
 import { returnClergyIfPlaced } from './returnClergyIfPlaced'
 import { rotateRondelWithExpire } from './rotateRondel'
+import { introduceJokerToken } from '../rondel'
+import { checkSoloSettlementReady } from './checkSoloSettlementReady'
 
 // TODO: joker comes out in A space
 
@@ -126,8 +128,12 @@ export const nextFrameSolo: FrameFlow = {
   // Settlement A
   23: {
     mainActionUsed: true,
-    bonusActions: [GameCommandEnum.SETTLE],
+    neutralBuildingPhase: true,
+    bonusActions: [
+      /* determined by checkSoloSettlementReady */
+    ],
     settlementRound: SettlementRound.A,
+    upkeep: [returnClergyIfPlaced, introduceJokerToken, checkSoloSettlementReady],
     next: 24,
   },
 
@@ -170,8 +176,12 @@ export const nextFrameSolo: FrameFlow = {
   // Settlement B
   32: {
     mainActionUsed: true,
-    bonusActions: [GameCommandEnum.SETTLE],
+    neutralBuildingPhase: true,
+    bonusActions: [
+      /* determined by checkSoloSettlementReady */
+    ],
     settlementRound: SettlementRound.B,
+    upkeep: [checkSoloSettlementReady],
     next: 33,
   },
 
@@ -232,8 +242,12 @@ export const nextFrameSolo: FrameFlow = {
   // Settlement C
   45: {
     mainActionUsed: true,
-    bonusActions: [GameCommandEnum.SETTLE],
+    neutralBuildingPhase: true,
+    bonusActions: [
+      /* determined by checkSoloSettlementReady */
+    ],
     settlementRound: SettlementRound.C,
+    upkeep: [checkSoloSettlementReady],
     next: 46,
   },
 
@@ -276,8 +290,12 @@ export const nextFrameSolo: FrameFlow = {
   // Settlement D
   54: {
     mainActionUsed: true,
-    bonusActions: [GameCommandEnum.SETTLE],
+    neutralBuildingPhase: true,
+    bonusActions: [
+      /* determined by checkSoloSettlementReady */
+    ],
     settlementRound: SettlementRound.D,
+    upkeep: [checkSoloSettlementReady],
     next: 55,
   },
 

--- a/game/src/board/rondel.ts
+++ b/game/src/board/rondel.ts
@@ -27,7 +27,7 @@ export const updateRondel =
     }
   }
 
-const introduceToken = (token: 'grape' | 'stone') =>
+const introduceToken = (token: 'grape' | 'stone' | 'joker') =>
   withRondel((rondel) => {
     if (rondel === undefined) return undefined
     if (rondel[token] !== undefined) return rondel
@@ -41,6 +41,7 @@ export const introduceGrapeToken: StateReducer = (state) => {
   return introduceToken('grape')(state)
 }
 export const introduceStoneToken: StateReducer = introduceToken('stone')
+export const introduceJokerToken: StateReducer = introduceToken('joker')
 
 export const armValues = ({ length, players }: GameCommandConfigParams) => {
   if (players === 2 && length === 'short') {

--- a/game/src/commands/__tests__/build.test.ts
+++ b/game/src/commands/__tests__/build.test.ts
@@ -246,6 +246,115 @@ describe('commands/build', () => {
         ],
       })
     })
+
+    describe('neutralBuildingPhase', () => {
+      it('allows building without any resources in neutral building phase', () => {
+        const s1 = {
+          ...s0,
+          players: [
+            {
+              ...s0.players[0],
+              landscape: [
+                [['W'], ['C'], ['P', 'G01'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+                [['W'], ['C'], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+              ] as Tile[][],
+              wood: 0,
+              clay: 0,
+              stone: 0,
+              straw: 0,
+              penny: 0,
+              nickel: 0,
+            },
+            ...s0.players.slice(1),
+          ],
+          buildings: [BuildingEnum.Windmill, BuildingEnum.Bakery],
+          frame: {
+            ...s0.frame,
+            activePlayerIndex: 0,
+            neutralBuildingPhase: true,
+            mainActionUsed: true,
+            bonusActions: [GameCommandEnum.BUILD],
+            usableBuildings: [BuildingEnum.Priory],
+          },
+        }
+        const s2 = build({ row: 1, col: -1, building: BuildingEnum.Windmill })(s1)!
+        expect(s2).toBeDefined()
+        expect(s2.buildings).not.toContain(BuildingEnum.Windmill)
+        expect(s2.buildings).toContain(BuildingEnum.Bakery)
+        expect(s2.players[0]).toMatchObject({
+          wood: 0,
+          clay: 0,
+          stone: 0,
+          straw: 0,
+          penny: 0,
+          nickel: 0,
+          landscape: [
+            [['W'], ['C'], ['P', 'G01'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+            [['W'], ['C', 'F04'], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+          ],
+        })
+        expect(s2.frame).toMatchObject({
+          activePlayerIndex: 0,
+          neutralBuildingPhase: true,
+          mainActionUsed: true,
+          bonusActions: [GameCommandEnum.BUILD],
+          usableBuildings: ['G01', 'F04'],
+        })
+      })
+      it('sets bonusActions after building to allow WORK_CONTRACT or BUILD after building the last building', () => {
+        const s1 = {
+          ...s0,
+          players: [
+            {
+              ...s0.players[0],
+              landscape: [
+                [['W'], ['C'], ['P', 'G01'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+                [['W'], ['C', 'F04'], ['P'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+              ] as Tile[][],
+              wood: 0,
+              clay: 0,
+              stone: 0,
+              straw: 0,
+              penny: 0,
+              nickel: 0,
+            },
+            ...s0.players.slice(1),
+          ],
+          buildings: [BuildingEnum.Bakery],
+          frame: {
+            ...s0.frame,
+            activePlayerIndex: 0,
+            neutralBuildingPhase: true,
+            mainActionUsed: true,
+            bonusActions: [GameCommandEnum.BUILD],
+            usableBuildings: [BuildingEnum.Priory, BuildingEnum.Windmill],
+          },
+        }
+        const s2 = build({ row: 1, col: 0, building: BuildingEnum.Bakery })(s1)!
+        expect(s2).toBeDefined()
+        expect(s2.buildings).not.toContain(BuildingEnum.Windmill)
+        expect(s2.buildings).not.toContain(BuildingEnum.Bakery)
+        expect(s2.players[0]).toMatchObject({
+          wood: 0,
+          clay: 0,
+          stone: 0,
+          straw: 0,
+          penny: 0,
+          nickel: 0,
+          landscape: [
+            [['W'], ['C'], ['P', 'G01'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+            [['W'], ['C', 'F04'], ['P', 'F05'], ['P', 'LFO'], ['P', 'LFO'], ['P'], ['P'], [], []],
+          ],
+        })
+        expect(s2.frame).toMatchObject({
+          activePlayerIndex: 0,
+          neutralBuildingPhase: true,
+          mainActionUsed: true,
+          bonusActions: [GameCommandEnum.WORK_CONTRACT, GameCommandEnum.SETTLE],
+          usableBuildings: [BuildingEnum.Priory, BuildingEnum.Windmill, BuildingEnum.Bakery],
+        })
+      })
+    })
   })
 
   describe('complete', () => {

--- a/game/src/commands/__tests__/commit.test.ts
+++ b/game/src/commands/__tests__/commit.test.ts
@@ -1,4 +1,4 @@
-import { Frame, GameCommandEnum, GameStatePlaying } from '../../types'
+import { BuildingEnum, Frame, GameCommandEnum, GameStatePlaying } from '../../types'
 import { complete } from '../commit'
 
 describe('commands/commit', () => {
@@ -28,6 +28,37 @@ describe('commands/commit', () => {
       } as GameStatePlaying
       const c0 = complete(s1)([])
       expect(c0).toStrictEqual([])
+    })
+    describe('neutral building phase', () => {
+      it('does not allow commit if still buildings', () => {
+        const s1 = {
+          ...s0,
+          buildings: [BuildingEnum.Bakery],
+          frame: {
+            ...s0.frame,
+            // this is set in nextFrameSolo
+            neutralBuildingPhase: true,
+            mainActionUsed: true,
+          } as Frame,
+        } as GameStatePlaying
+        const c0 = complete(s1)([])
+        expect(c0).toStrictEqual([])
+      })
+      it('allows commit if all buildings placed, has not settled', () => {
+        const s1 = {
+          ...s0,
+          buildings: [],
+          frame: {
+            ...s0.frame,
+            // this is set in nextFrameSolo
+            neutralBuildingPhase: true,
+            mainActionUsed: true,
+            bonusActions: [GameCommandEnum.SETTLE],
+          } as Frame,
+        } as GameStatePlaying
+        const c0 = complete(s1)([])
+        expect(c0).toStrictEqual(['COMMIT'])
+      })
     })
     it('allows commit if main action used', () => {
       const c0 = complete(s0)([])

--- a/game/src/commands/__tests__/settle.test.ts
+++ b/game/src/commands/__tests__/settle.test.ts
@@ -153,6 +153,20 @@ describe('commands/build', () => {
       const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['SETTLE'])
     })
+    it('allows running if in a settlement frame of neutral building phase', () => {
+      const s1: GameStatePlaying = {
+        ...s0,
+        buildings: [],
+        frame: {
+          ...s0.frame,
+          neutralBuildingPhase: true,
+          mainActionUsed: true,
+          bonusActions: [GameCommandEnum.SETTLE],
+        },
+      }
+      const c0 = complete(s1)([])
+      expect(c0).toStrictEqual(['SETTLE'])
+    })
     it('does not allow running if not in a settlement frame', () => {
       const s1: GameStatePlaying = {
         ...s0,

--- a/game/src/commands/__tests__/workContract.test.ts
+++ b/game/src/commands/__tests__/workContract.test.ts
@@ -2,7 +2,7 @@ import { initialState } from '../../state'
 import {
   BuildingEnum,
   Clergy,
-  Frame,
+  GameCommandEnum,
   GameStatePlaying,
   GameStatusEnum,
   NextUseClergy,
@@ -350,6 +350,30 @@ describe('commands/workContract', () => {
       const c0 = complete(s1)([])
       expect(c0).toStrictEqual(['WORK_CONTRACT'])
     })
+    it('can work contract in neutral building phase after buildings placed', () => {
+      const s1 = {
+        ...s0,
+        players: [
+          {
+            ...s0.players[0],
+            penny: 0,
+            wine: 0,
+            whiskey: 1,
+          },
+          ...s0.players.slice(1),
+        ],
+        buildings: [],
+        frame: {
+          ...s0.frame,
+          bonusActions: [GameCommandEnum.WORK_CONTRACT, GameCommandEnum.SETTLE],
+          neutralBuildingPhase: true,
+          mainActionUsed: true,
+        },
+      }
+      const c0 = complete(s1)([])
+      expect(c0).toStrictEqual(['WORK_CONTRACT'])
+    })
+
     it('can not work contract if no money', () => {
       const s1 = {
         ...s0,

--- a/game/src/commands/commit.ts
+++ b/game/src/commands/commit.ts
@@ -13,6 +13,10 @@ export const complete =
   (partial: string[]): string[] => {
     return match<string[], string[]>(partial)
       .with([], () => {
+        if (state.frame.neutralBuildingPhase) {
+          if (state.buildings.length !== 0) return []
+          return [GameCommandEnum.COMMIT]
+        }
         if (state.frame.mainActionUsed) return [GameCommandEnum.COMMIT]
         return []
       })

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -31,7 +31,7 @@ const computeFlow = (state: GameStatePlaying) => {
     flow.push({
       round,
       player: state?.players?.[playerIndex]?.color,
-      settle: !!frame.bonusActions?.includes(GameCommandEnum.SETTLE),
+      settle: !!frame.bonusActions?.includes(GameCommandEnum.SETTLE) || !!frame.neutralBuildingPhase,
       bonus: !!frame.bonusRoundPlacement,
     })
     frameIndex = frame.next


### PR DESCRIPTION
Resolves #339

This adds additional constraints for how to handle settlement rounds in solitaire games.

* Settlements are still mostly centered around bonusActions being the things the player can do.
* Doing a BUILD while `frame.neutralSettlementRound===true` will be free.
* After a BUILD in this manner consumes the build in bonusActions, BUILD will actually set bonusActions to either be another BUILD, or WORK_CONTRACT (which is optional) and SETTLE. I think it might be necessary to remove WORK_CONTRACT after the SETTLE, but I don't yet think it matters too much.
* This also resolves a TODO of when to add the Joker token in solo games.