### PR TITLE
fix: neutral building phase end needs WORK_CONTRACT before USE

### DIFF
--- a/game/src/board/clergy.ts
+++ b/game/src/board/clergy.ts
@@ -1,0 +1,59 @@
+import { filter, find, lensPath, pipe, set } from 'ramda'
+import { match } from 'ts-pattern'
+import { BuildingEnum, Clergy, GameStatePlaying, NextUseClergy, StateReducer, Tableau, Tile } from '../types'
+import { findBuildingWithoutOffset } from './landscape'
+import { isPrior, withActivePlayer } from './player'
+import { setFrameToAllowFreeUsage } from './frame'
+
+export const moveClergyToOwnBuilding =
+  (building: BuildingEnum): StateReducer =>
+  (state) => {
+    if (state === undefined) return undefined
+    if (state.frame.nextUse === NextUseClergy.Free) return state
+    const player = state.players[state.frame.activePlayerIndex]
+    const matrixLocation = findBuildingWithoutOffset(building)(player.landscape)
+    if (matrixLocation === undefined) return undefined
+    const [row, col] = matrixLocation
+    const [land, ,] = player.landscape[row][col]
+
+    const priors = player.clergy.filter(isPrior)
+    if (state.frame.nextUse === NextUseClergy.OnlyPrior && priors.length === 0) return undefined
+    // ^this line unnecessary
+    const nextClergy = match(state.frame.nextUse)
+      .with(NextUseClergy.Any, () => player.clergy[0])
+      .with(NextUseClergy.OnlyPrior, () => priors[0])
+      .exhaustive()
+
+    if (nextClergy === undefined) return undefined
+
+    return withActivePlayer(
+      pipe(
+        //
+        set<Tableau, Tile>(lensPath(['landscape', row, col]), [land, building, nextClergy]),
+        set<Tableau, Clergy[]>(lensPath(['clergy']), filter((c) => c !== nextClergy)(player.clergy))
+      )
+    )(state)
+  }
+
+export const moveClergyToNeutralBuilding =
+  (building: BuildingEnum): StateReducer =>
+  (state) => {
+    if (state === undefined) return undefined
+    const neutralPlayer = state.players[1]
+    const matrixLocation = findBuildingWithoutOffset(building)(neutralPlayer.landscape)
+    if (matrixLocation === undefined) return undefined
+    const [row, col] = matrixLocation
+    const [land, ,] = neutralPlayer.landscape[row][col]
+    const nextClergy =
+      state.frame.nextUse === NextUseClergy.OnlyPrior ? find(isPrior, neutralPlayer.clergy) : neutralPlayer.clergy[0]
+    if (nextClergy === undefined) return undefined
+
+    return pipe(
+      set<GameStatePlaying, Tile>(lensPath(['players', 1, 'landscape', row, col]), [land, building, nextClergy]),
+      set<GameStatePlaying, Clergy[]>(
+        lensPath(['players', 1, 'clergy']),
+        filter((c) => c !== nextClergy)(neutralPlayer.clergy)
+      ),
+      setFrameToAllowFreeUsage([building])
+    )(state)
+  }

--- a/game/src/board/frame/addNeutralPlayer.ts
+++ b/game/src/board/frame/addNeutralPlayer.ts
@@ -1,5 +1,4 @@
-import { createPcg32, randomInt } from 'fn-pcg'
-import { PCGState } from 'fn-pcg/dist/types'
+import { randomInt } from 'fn-pcg'
 import { BuildingEnum, LandEnum, PlayerColor, StateReducer, Tile } from '../../types'
 import { makeLandscape } from '../landscape'
 import { clergyForColor } from '../player'

--- a/game/src/board/frame/nextFrameSolo.ts
+++ b/game/src/board/frame/nextFrameSolo.ts
@@ -1,4 +1,4 @@
-import { FrameFlow, GameCommandEnum, SettlementRound } from '../../types'
+import { FrameFlow, SettlementRound } from '../../types'
 import { introduceBuildings } from '../buildings'
 import { addNeutralPlayer } from './addNeutralPlayer'
 import { gameEnd } from '../state'

--- a/game/src/commands/__tests__/workContract.test.ts
+++ b/game/src/commands/__tests__/workContract.test.ts
@@ -360,7 +360,10 @@ describe('commands/workContract', () => {
             wine: 0,
             whiskey: 1,
           },
-          ...s0.players.slice(1),
+          {
+            ...s0.players[1],
+            clergy: ['LB1B', 'PRIB'] as Clergy[],
+          },
         ],
         buildings: [],
         frame: {
@@ -368,6 +371,7 @@ describe('commands/workContract', () => {
           bonusActions: [GameCommandEnum.WORK_CONTRACT, GameCommandEnum.SETTLE],
           neutralBuildingPhase: true,
           mainActionUsed: true,
+          usableBuildings: [BuildingEnum.Bakery, BuildingEnum.Windmill],
         },
       }
       const c0 = complete(s1)([])

--- a/game/src/commands/withLaybrother.ts
+++ b/game/src/commands/withLaybrother.ts
@@ -1,8 +1,8 @@
-import { curry, pipe } from 'ramda'
+import { pipe } from 'ramda'
 import { match } from 'ts-pattern'
 import { revertActivePlayerToCurrent, setFrameToAllowFreeUsage, withFrame } from '../board/frame'
-import { moveClergyToOwnBuilding } from '../board/landscape'
 import { GameCommandEnum, GameStatePlaying, NextUseClergy, StateReducer } from '../types'
+import { moveClergyToOwnBuilding } from '../board/clergy'
 
 const withAnyForCurrentPlayer: StateReducer = withFrame((frame) => ({
   ...frame,

--- a/game/src/commands/withPrior.ts
+++ b/game/src/commands/withPrior.ts
@@ -1,9 +1,9 @@
-import { all, any, curry, lens, lensProp, pipe, view } from 'ramda'
+import { all, lensProp, pipe, view } from 'ramda'
 import { match } from 'ts-pattern'
 import { addBonusAction, revertActivePlayerToCurrent, setFrameToAllowFreeUsage, withFrame } from '../board/frame'
-import { moveClergyToOwnBuilding } from '../board/landscape'
 import { activeLens, isLayBrother, isPrior } from '../board/player'
 import { GameCommandEnum, GameStatePlaying, NextUseClergy, StateReducer } from '../types'
+import { moveClergyToOwnBuilding } from '../board/clergy'
 
 // there are two modes of this, really...
 

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern'
-import { always, head, reduce, toPairs, unnest } from 'ramda'
+import { always, head } from 'ramda'
 import { pickFrameFlow } from './board/frame'
 import { Flower, GameCommandEnum, GameStatePlaying, OrdinalFrame, Controls } from './types'
 import {


### PR DESCRIPTION
I misread the instructions on the previous version and thought during a neutral building phase, the player can just use one of the neutral player's newly built buildings if there was a prior free.

At the end of that sentence, there's a sentence "_You must pay the work contract price for the neutral player's prior_" which I think this really makes the bullet more like a special instance where you can issue a WORK_CONTRACT that can be done only:
* during a neutral building phase
* when there are no more buildings to place
* frame.nextUse is `only-prior` - so USE can behave like it's placing a prior after a building, because mainActionUsed will be false
* frame.usableBuildings contains something (indicating that an unbuilt building was placed)

If this is all true, then allow a WORK_CONTRACT to happen, but put the neutral player's PRIOR on the neutral player's building