### PR TITLE
fix: prettier 3 upgrade wants explicit eslint-plugin-prettier dependency

### DIFF
--- a/.github/workflows/game.yml
+++ b/.github/workflows/game.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 18.x
       - run: npm install
+      - run: npm run lint
       - run: npm run build --if-present
       - run: npm run test -- --coverage
       - name: Coveralls

--- a/game/package.json
+++ b/game/package.json
@@ -46,6 +46,7 @@
     "eslint": "8.44.0",
     "eslint-import-resolver-typescript": "3.5.5",
     "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "5.0.0",
     "husky": "8.0.3",
     "jest": "29.6.1",
     "lint-staged": "13.2.3",

--- a/game/src/board/__tests__/erections.test.ts
+++ b/game/src/board/__tests__/erections.test.ts
@@ -11,7 +11,7 @@ describe('board/erections', () => {
         canBuildPlains: 0 | 1,
         canBuildHills: 0 | 1,
         canBuildMountain: 0 | 1,
-        erection: ErectionEnum
+        erection: ErectionEnum,
       ][] = [
         [0, 1, 1, 1, 0, BuildingEnum.Priory],
         [0, 1, 0, 1, 0, BuildingEnum.Windmill],

--- a/game/src/board/resource.ts
+++ b/game/src/board/resource.ts
@@ -17,11 +17,8 @@ import {
   zipWith,
   zip,
   uniq,
-  sortBy,
-  tap,
   comparator,
   sort,
-  all,
 } from 'ramda'
 import { Cost, ResourceEnum, SettlementCost, Tableau } from '../types'
 
@@ -149,15 +146,18 @@ const amountCostOptions =
     reduce(
       (accum, prevTrace) => {
         const [prevPrefix, prevFood] = prevTrace
-        map((numSheep) => {
-          const nextFood = prevFood - numSheep * foodValue
-          const nextPrefix = `${prevPrefix}${stringRepeater(token, numSheep)}`
-          if (nextFood <= 0) {
-            outputs.push(nextPrefix)
-          } else {
-            accum.push([nextPrefix, nextFood])
-          }
-        }, range(0, Math.min(totalCount, prevFood / foodValue) + 1))
+        map(
+          (numSheep) => {
+            const nextFood = prevFood - numSheep * foodValue
+            const nextPrefix = `${prevPrefix}${stringRepeater(token, numSheep)}`
+            if (nextFood <= 0) {
+              outputs.push(nextPrefix)
+            } else {
+              accum.push([nextPrefix, nextFood])
+            }
+          },
+          range(0, Math.min(totalCount, prevFood / foodValue) + 1)
+        )
         return accum
       },
       [] as Tracer[],
@@ -170,16 +170,19 @@ const rewardOptions =
     return reduce(
       (accum, prevTrace) => {
         const [prevPrefix, prevFood] = prevTrace
-        map((numSheep) => {
-          const nextFood = prevFood - numSheep * points
-          const nextPrefix = `${prevPrefix}${stringRepeater(token, numSheep)}`
-          if (nextFood >= 0) {
-            outputs.push(nextPrefix)
-          }
-          if (nextFood >= pointsNext) {
-            accum.push([nextPrefix, nextFood])
-          }
-        }, reverse(range(0, 1 + Math.floor(prevFood / points))))
+        map(
+          (numSheep) => {
+            const nextFood = prevFood - numSheep * points
+            const nextPrefix = `${prevPrefix}${stringRepeater(token, numSheep)}`
+            if (nextFood >= 0) {
+              outputs.push(nextPrefix)
+            }
+            if (nextFood >= pointsNext) {
+              accum.push([nextPrefix, nextFood])
+            }
+          },
+          reverse(range(0, 1 + Math.floor(prevFood / points)))
+        )
         return accum
       },
       [] as Tracer[],

--- a/game/src/commands/__tests__/cutPeat.test.ts
+++ b/game/src/commands/__tests__/cutPeat.test.ts
@@ -191,7 +191,7 @@ describe('commands/cutPeat', () => {
       const c0 = complete(s0)([GameCommandEnum.CUT_PEAT, '0', '1'])
       expect(c0).toStrictEqual(['', 'Jo'])
     })
-    it('if CUT_PEAT at a location, give empty string response', () => {
+    it('if CUT_PEAT at a location with joker, give empty string response', () => {
       const c0 = complete(s0)([GameCommandEnum.CUT_PEAT, '0', '1', 'Jo'])
       expect(c0).toStrictEqual([''])
     })

--- a/game/src/commands/settle.ts
+++ b/game/src/commands/settle.ts
@@ -1,6 +1,6 @@
-import { addIndex, curry, filter, map, pipe, reduce, view } from 'ramda'
+import { filter, pipe, view } from 'ramda'
 import { P, match } from 'ts-pattern'
-import { addErectionAtLandscape, terrainForErection } from '../board/erections'
+import { addErectionAtLandscape } from '../board/erections'
 import { onlyViaBonusActions } from '../board/frame'
 import { checkLandscapeFree, checkLandTypeMatches, erectableLocations, erectableLocationsCol } from '../board/landscape'
 import { activeLens, payCost, withActivePlayer } from '../board/player'
@@ -13,8 +13,6 @@ import {
   GameStatePlaying,
   SettlementEnum,
   StateReducer,
-  Tableau,
-  Tile,
 } from '../types'
 
 const payForSettlement = (settlement: SettlementEnum, resources: Cost) =>
@@ -76,12 +74,15 @@ export const complete =
           return []
         })
         .with([GameCommandEnum.SETTLE], () => {
-          return filter((settlement) => {
-            const playerFood = costFood(player)
-            const playerEnergy = costEnergy(player)
-            const { food: requiredFood, energy: requiredEnergy } = costForSettlement(settlement)
-            return playerFood >= requiredFood && playerEnergy >= requiredEnergy
-          }, view(activeLens(state), state).settlements)
+          return filter(
+            (settlement) => {
+              const playerFood = costFood(player)
+              const playerEnergy = costEnergy(player)
+              const { food: requiredFood, energy: requiredEnergy } = costForSettlement(settlement)
+              return playerFood >= requiredFood && playerEnergy >= requiredEnergy
+            },
+            view(activeLens(state), state).settlements
+          )
         })
         .with([GameCommandEnum.SETTLE, P._], ([, settlement]) =>
           // Return all the coords which match the terrain for this building...

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern'
-import { always, head, reduce, toPairs, unnest } from 'ramda'
+import { always, head } from 'ramda'
 import { pickFrameFlow } from './board/frame'
 import { Flower, GameCommandEnum, GameStatePlaying, OrdinalFrame, Controls } from './types'
 import {


### PR DESCRIPTION
Resolved in https://github.com/prettier/eslint-plugin-prettier/issues/562, didn't catch this until now because I wasn't running prettier (or eslint for that matter!) in CI, so this also adds that check.