### PR TITLE
feature: mountain tile adjacencies

### DIFF
--- a/game/src/board/frame.ts
+++ b/game/src/board/frame.ts
@@ -18,7 +18,7 @@ import {
   StateReducer,
   Tile,
 } from '../types'
-import { findBuildingWithoutOffset, occupiedBuildingsForPlayers } from './landscape'
+import { findBuildingWithoutOffset, getAdjacentOffsets, occupiedBuildingsForPlayers } from './landscape'
 
 export const withFrame =
   (func: (frame: Frame) => Frame | undefined): StateReducer =>
@@ -139,13 +139,6 @@ const whichIndexHasBuilding =
     return undefined
   }
 
-const ADJACENT = [
-  [-1, 0],
-  [1, 0],
-  [0, -1],
-  [0, 1],
-]
-
 export const allowFreeUsageToNeighborsOf =
   (building: BuildingEnum): StateReducer =>
   (state) => {
@@ -166,7 +159,11 @@ export const allowFreeUsageToNeighborsOf =
           return accum
         },
         [] as BuildingEnum[],
-        map(([rowMod, colMod]) => [player, row + rowMod, col + colMod], ADJACENT) as [number, number, number][]
+        map(([rowMod, colMod]) => [player, row + rowMod, col + colMod], getAdjacentOffsets(col - 2)) as [
+          number,
+          number,
+          number,
+        ][]
       )
     )(state)
   }

--- a/game/src/board/landscape.ts
+++ b/game/src/board/landscape.ts
@@ -147,7 +147,7 @@ export const checkLandscapeFree =
     })(state)
   }
 
-const getAdjacentOffsets = (col: number): [number, number][] =>
+export const getAdjacentOffsets = (col: number): [number, number][] =>
   match<number, [number, number][]>(col)
     .with(5, () => [
       [1, 0], // south

--- a/game/src/board/landscape.ts
+++ b/game/src/board/landscape.ts
@@ -147,15 +147,36 @@ export const checkLandscapeFree =
     })(state)
   }
 
+const getAdjacentOffsets = (col: number): [number, number][] =>
+  match<number, [number, number][]>(col)
+    .with(5, () => [
+      [1, 0], // south
+      [-1, 0], // north
+      [0, -1], // west
+      [-1, 1], // northeast
+      [0, 1], // southeast
+    ])
+    .with(6, () => [
+      [0, -1], // northwest
+      [1, -1], // southwest
+    ])
+    .otherwise(() => [
+      [1, 0], // south
+      [-1, 0], // north
+      [0, 1], // east
+      [0, -1], // west
+    ])
+
 export const checkCloisterAdjacencyPlayer = (row: number, col: number, building: ErectionEnum) => (player: Tableau) => {
   if (isCloisterBuilding(building) === false) return player
-  const { landscape, landscapeOffset } = player
-  return any(isCloisterBuilding, [
-    landscape[row + landscapeOffset + 1]?.[col + 2]?.[1],
-    landscape[row + landscapeOffset - 1]?.[col + 2]?.[1],
-    landscape[row + landscapeOffset]?.[col + 3]?.[1],
-    landscape[row + landscapeOffset]?.[col + 1]?.[1],
-  ])
+  return pipe<[number], [number, number][], (ErectionEnum | undefined)[], boolean>(
+    getAdjacentOffsets,
+    map(
+      ([rowOffset, colOffset]) =>
+        player?.landscape[row + rowOffset + (player.landscapeOffset ?? 0)]?.[col + 2 + colOffset]?.[1]
+    ),
+    any(isCloisterBuilding)
+  )(col)
     ? player
     : undefined
 }


### PR DESCRIPTION
resolves #406 handle mountain tiles that are sort of offset. sort of.

this was something i punted, and now i think i need to handle it. so far it's the buildings that care about adjacency, and the cloisters which are impacted by it... but it's most apparent in scoring, so if i want to handle scoring, i'll need to fix this now.