### PR TITLE
refactor: move input to prevent dead ends

### DIFF
--- a/client/web/src/components/Debug.tsx
+++ b/client/web/src/components/Debug.tsx
@@ -3,11 +3,15 @@ import { useHathoraContext } from '../context/GameContext'
 
 export const Debug = () => {
   const [expanded, setExpanded] = useState<boolean>(false)
-  const { state } = useHathoraContext()
+  const { state, control } = useHathoraContext()
   const handleClick = () => setExpanded(!expanded)
+  const handleReset = () => control('')
 
   return (
     <div>
+      <button type="button" onClick={handleReset}>
+        Reset
+      </button>
       <button type="button" onClick={handleClick}>
         Debug
       </button>

--- a/client/web/src/components/MoveList.tsx
+++ b/client/web/src/components/MoveList.tsx
@@ -1,4 +1,4 @@
-import { collectBy, find, map, range } from 'ramda'
+import { collectBy, equals, find, map, range, reject } from 'ramda'
 import { useHathoraContext } from '../context/GameContext'
 import { Picker } from './Picker'
 import { EngineColor } from '../../../../api/types'
@@ -47,7 +47,9 @@ const colorToStyle = (c?: EngineColor): ColorStyle => {
 }
 
 export const MoveList = () => {
-  const { state } = useHathoraContext()
+  const { state, undo, redo } = useHathoraContext()
+  const completions = state?.control?.completion ?? []
+  const noSelectableOptions = reject(equals(''), completions).length < 1
 
   const flow = collectBy((f) => `${f.round}`, state?.flow ?? [])
   return (
@@ -96,6 +98,23 @@ export const MoveList = () => {
         )}
       </div>
       <hr />
+
+      {state?.control === undefined && (
+        <div>Waiting on {EngineColor[state?.players?.[state?.frame?.activePlayerIndex ?? -1]?.color ?? -1]}...</div>
+      )}
+      {state?.control !== undefined && (
+        <>
+          <button type="button" onClick={undo}>
+            Undo
+          </button>
+          <button type="button" onClick={redo}>
+            Redo
+          </button>
+        </>
+      )}
+
+      <hr />
+
       <ul style={resetStyle}>
         {state?.moves.map((m, i) => (
           // eslint-disable-next-line react/no-array-index-key
@@ -105,9 +124,6 @@ export const MoveList = () => {
         ))}
 
         <li>
-          <hr />
-          <span style={{ fontFamily: 'monospace' }}>{state?.control?.partial}</span>
-          <Picker />
           <hr />
         </li>
 

--- a/client/web/src/components/Picker.tsx
+++ b/client/web/src/components/Picker.tsx
@@ -1,15 +1,12 @@
-import { equals, reject } from 'ramda'
 import { ChangeEvent, useState } from 'react'
 import { useHathoraContext } from '../context/GameContext'
-import { EngineColor } from '../../../../api/types'
 
 export const Picker = () => {
   const [resource, setResource] = useState<string>('')
-  const { state, control, undo, redo } = useHathoraContext()
-  const completions = state?.control?.completion ?? []
-  const noSelectableOptions = reject(equals(''), completions).length < 1
-  if (noSelectableOptions)
-    return <div>Waiting on {EngineColor[state?.players?.[state?.frame?.activePlayerIndex ?? -1]?.color ?? -1]}...</div>
+  const { state, control } = useHathoraContext()
+
+  const completions = state?.control?.completion?.filter?.((c) => c !== '') ?? []
+  const showPicker = completions.length > 0
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const tokens = state?.control?.partial?.split(/\s+/) ?? []
@@ -20,17 +17,15 @@ export const Picker = () => {
   }
 
   return (
-    <div>
-      <button type="button" onClick={undo}>
-        Undo
-      </button>
-      <button type="button" onClick={redo}>
-        Redo
-      </button>
-      <select value={resource} onChange={handleChange}>
-        <option> </option>
-        {state?.control?.completion?.map((completion) => <option key={completion}>{completion}</option>)}
-      </select>
+    <div style={{ minWidth: 300 }}>
+      {showPicker && (
+        <select value={resource} onChange={handleChange} style={{ width: '100%' }}>
+          <option> </option>
+          {completions.map((completion) => (
+            <option key={completion}>{completion}</option>
+          ))}
+        </select>
+      )}
     </div>
   )
 }

--- a/client/web/src/components/sliders/ActionWithLaybrother.tsx
+++ b/client/web/src/components/sliders/ActionWithLaybrother.tsx
@@ -1,18 +1,18 @@
 import { useHathoraContext } from '../../context/GameContext'
 import classes from './actions.module.css'
 
-export const ActionCommit = () => {
+export const ActionWithLaybrother = () => {
   const { state, control } = useHathoraContext()
 
   const handleClick = () => {
-    control('COMMIT')
+    control('WITH_LAYBROTHER')
   }
 
-  const disabled = !(state?.control?.completion ?? []).includes('COMMIT')
+  const disabled = !(state?.control?.completion ?? []).includes('WITH_LAYBROTHER')
 
   return (
     <button type="button" disabled={disabled} className={classes.action} onClick={handleClick}>
-      Commit
+      With Laybrother
     </button>
   )
 }

--- a/client/web/src/components/sliders/ActionWithPrior.tsx
+++ b/client/web/src/components/sliders/ActionWithPrior.tsx
@@ -1,0 +1,18 @@
+import { useHathoraContext } from '../../context/GameContext'
+import classes from './actions.module.css'
+
+export const ActionwithPrior = () => {
+  const { state, control } = useHathoraContext()
+
+  const handleClick = () => {
+    control('WITH_PRIOR')
+  }
+
+  const disabled = !(state?.control?.completion ?? []).includes('WITH_PRIOR')
+
+  return (
+    <button type="button" disabled={disabled} className={classes.action} onClick={handleClick}>
+      With Laybrother
+    </button>
+  )
+}

--- a/client/web/src/components/sliders/Actions.tsx
+++ b/client/web/src/components/sliders/Actions.tsx
@@ -9,24 +9,65 @@ import { ActionWorkContract } from './ActionWorkContract'
 import { ActionBuyPlot } from './ActionBuyPlot'
 import { ActionBuyDistrict } from './ActionBuyDistrict'
 import { ActionConvert } from './ActionConvert'
-import { ActionCommit } from './ActionCommit'
+import { Picker } from '../Picker'
+import { ActionWithLaybrother } from './ActionWithLaybrother'
+import { ActionwithPrior } from './ActionWithPrior'
 
 export const Actions = () => {
-  const { state } = useHathoraContext()
-  const position = state?.control?.partial === '' ? 80 : 0
+  const { state, move, control } = useHathoraContext()
+  const position = state?.control ? 80 : 0
+
+  const handleSend = () => {
+    if (state?.control?.partial) {
+      control('')
+      move(state?.control?.partial)
+    }
+  }
 
   return (
     <div className={classes.container} style={{ transform: `translateY(${position}px)` }}>
-      <ActionCutPeat />
-      <ActionFellTrees />
-      <ActionBuild />
-      <ActionUse />
-      <ActionWorkContract />
-      <ActionBuyPlot />
-      <ActionBuyDistrict />
-      <ActionSettle />
-      <ActionConvert />
-      <ActionCommit />
+      {state?.control?.partial === '' && (
+        <>
+          {state?.control?.completion?.includes('WITH_LAYBROTHER') === true && (
+            <>
+              <ActionWithLaybrother />
+              <ActionwithPrior />
+            </>
+          )}
+          {state?.control?.completion?.includes('WITH_LAYBROTHER') === false && (
+            <>
+              <ActionCutPeat />
+              <ActionFellTrees />
+              <ActionBuild />
+              <ActionUse />
+              <ActionWorkContract />
+              <ActionBuyPlot />
+              <ActionBuyDistrict />
+              <ActionConvert />
+              <ActionSettle />
+            </>
+          )}
+        </>
+      )}
+      {state?.control?.partial !== '' && (
+        <>
+          <button type="button" className={classes.action} onClick={() => control('')}>
+            Clear
+          </button>
+          <div>
+            <code>{state?.control?.partial}</code>
+            <Picker />
+          </div>
+          <button
+            type="button"
+            disabled={!state?.control?.completion?.includes('')}
+            className={classes.action}
+            onClick={handleSend}
+          >
+            Send Move
+          </button>
+        </>
+      )}
     </div>
   )
 }

--- a/client/web/src/components/sliders/Submit.tsx
+++ b/client/web/src/components/sliders/Submit.tsx
@@ -3,27 +3,22 @@ import { useHathoraContext } from '../../context/GameContext'
 
 export const Submit = () => {
   const { state, control, move } = useHathoraContext()
-  const position = state?.control?.completion?.includes('') ? -80 : 0
-
-  const handleReset = () => {
-    control('')
-  }
+  const position = state?.control?.completion?.includes('COMMIT') ? -80 : 0
 
   const handleSubmit = () => {
     const command = state?.control?.partial
-    if (command) {
+    if (command !== undefined) {
+      // command could be '', dont remove !== undefined
       control('')
-      move(command)
+      console.log('commit')
+      move('COMMIT')
     }
   }
 
   return (
     <div className={classes.container} style={{ transform: `translateY(${position}px)` }}>
-      <button className={classes.submit} type="submit" onClick={handleReset}>
-        Reset
-      </button>
       <button className={classes.submit} type="submit" onClick={handleSubmit}>
-        Send Move
+        End Turn
       </button>
     </div>
   )

--- a/client/web/src/components/sliders/actions.module.css
+++ b/client/web/src/components/sliders/actions.module.css
@@ -4,6 +4,7 @@
   border-radius: 4px;
   border: 1px solid #ddd;
   margin: 5px;
+  max-width: 100px;
 }
 .action:active:enabled {
   background-color: #f2f2f2;


### PR DESCRIPTION
* Refactors a lot of frontend UI around the move.
* The bottom pane is instead, now, just a "end turn" button, that comes up at appropriate times when the user might want to end turn. They can end turn if there's a "COMMIT" in the completions.
* The top pane now shows the picker when a partial move is pending.
* Undo/Redo moved to the top left, above the movelist, below player scores. When not the active player, it will say who it's waiting on