### PR TITLE
feature: allow CONFIG to not shuffle if no seed

### DIFF
--- a/game/src/__tests__/game-solo-settle.test.ts
+++ b/game/src/__tests__/game-solo-settle.test.ts
@@ -7,7 +7,8 @@ describe('game-solo-settle', () => {
   it('settling should', () => {
     const s01 = initialState
     const s02 = reducer(s01, ['CONFIG', '1', 'france', 'long'])! as GameStateSetup
-    const s03 = reducer(s02, ['START', '41303', 'G'])! as GameStatePlaying
+    const s03 = reducer(s02, ['START', 'G', 'W'])! as GameStatePlaying
+    expect(s03.players.map((p) => p.color)).toStrictEqual(['G', 'W'])
     expect(s03).toBeDefined()
     const s06 = reducer(s03, ['USE', 'LG1'])! as GameStatePlaying
     expect(s06).toBeDefined()
@@ -15,7 +16,9 @@ describe('game-solo-settle', () => {
     const s08 = reducer(s07, ['FELL_TREES', '2', '0'])! as GameStatePlaying
     expect(s08).toBeDefined()
     const s09 = reducer(s08, ['COMMIT'])! as GameStatePlaying
+    expect(s09).toBeDefined()
     const s10 = reducer(s09, ['USE', 'LG2', 'Gn'])! as GameStatePlaying
+    expect(s10).toBeDefined()
     const s11 = reducer(s10, ['CONVERT', 'Gn'])! as GameStatePlaying
     expect(s11).toBeDefined()
     const s12 = reducer(s11, ['COMMIT'])! as GameStatePlaying

--- a/game/src/__tests__/game21872.test.ts
+++ b/game/src/__tests__/game21872.test.ts
@@ -7,7 +7,7 @@ describe('game 21872', () => {
   it('runs through moves', () => {
     const s01 = initialState
     const s02 = reducer(s01, ['CONFIG', '4', 'france', 'long'])! as GameStateSetup
-    const s03 = reducer(s02, ['START', '41303', 'W', 'B', 'G', 'R'])! as GameStatePlaying
+    const s03 = reducer(s02, ['START', 'R', 'G', 'B', 'W'])! as GameStatePlaying
     expect(s03.buildings).toContain('G07')
     expect(s03.players[0].color).toBe('R')
     expect(s03.players[1].color).toBe('G')

--- a/game/src/board/frame/__tests__/addNeutralPlayer.test.ts
+++ b/game/src/board/frame/__tests__/addNeutralPlayer.test.ts
@@ -1,5 +1,4 @@
 import { createPcg32 } from 'fn-pcg'
-import { times } from 'ramda'
 import { initialState } from '../../../state'
 import {
   Clergy,
@@ -61,7 +60,13 @@ describe('board/frame/addNeutralPlayer', () => {
         pointingBefore: 0,
       },
       wonders: 0,
-      players: [p0],
+      players: [
+        p0,
+        {
+          ...p0,
+          color: PlayerColor.Red,
+        },
+      ],
       buildings: [],
       plotPurchasePrices: [1, 1, 1, 1, 1, 1],
       districtPurchasePrices: [],
@@ -99,21 +104,6 @@ describe('board/frame/addNeutralPlayer', () => {
       const s1 = addNeutralPlayer(s0)!
       expect(s1.players[0].clergy).toStrictEqual(['LB1B', 'LB2B', 'PRIB'])
       expect(s1.players[1].clergy).toStrictEqual(['LB1R', 'LB2R', 'PRIR'])
-    })
-
-    it('does not give the neutral player the same color as the starting player', () => {
-      const colors = [PlayerColor.Red, PlayerColor.Blue, PlayerColor.Green, PlayerColor.White]
-      times((seed) => {
-        colors.forEach((color) => {
-          const s1 = {
-            ...s0,
-            randGen: createPcg32({}, 42, 56),
-            players: [{ ...s0.players[0], color }],
-          }
-          const s2 = addNeutralPlayer(s1)!
-          expect(s2.players[0].color).not.toBe(s2.players[1].color)
-        })
-      }, 50)
     })
   })
 })

--- a/game/src/board/frame/addNeutralPlayer.ts
+++ b/game/src/board/frame/addNeutralPlayer.ts
@@ -1,23 +1,11 @@
-import { createPcg32, randomInt } from 'fn-pcg'
-import { PCGState } from 'fn-pcg/dist/types'
-import { BuildingEnum, LandEnum, PlayerColor, StateReducer, Tile } from '../../types'
+import { BuildingEnum, LandEnum, StateReducer, Tile } from '../../types'
 import { makeLandscape } from '../landscape'
 import { clergyForColor } from '../player'
-
-const neutralColor = (playerColor: PlayerColor, neutralColorIndex: number) =>
-  [
-    // pick a color that the player isn't using
-    PlayerColor.Red,
-    PlayerColor.Blue,
-    PlayerColor.Green,
-    PlayerColor.White,
-  ].filter((c) => c !== playerColor)[neutralColorIndex]
 
 export const addNeutralPlayer: StateReducer = (state) => {
   if (state === undefined) return state
 
-  const [neutralColorIndex, randGen] = randomInt(0, 3, state.randGen)
-  const color = neutralColor(state.players[0].color, neutralColorIndex)
+  const { color } = state.players[1]
   const clergy = clergyForColor(state.config)(color)
   const [row0, row1] = makeLandscape(color)
   const landscape: Tile[][] = [
@@ -47,13 +35,12 @@ export const addNeutralPlayer: StateReducer = (state) => {
 
   return {
     ...state,
-    randGen,
     players: [
-      ...state.players,
+      state.players[0],
       {
-        ...state.players[0],
-        clergy,
+        ...state.players[1],
         color,
+        clergy,
         landscape,
       },
     ],

--- a/game/src/reducer.ts
+++ b/game/src/reducer.ts
@@ -97,12 +97,20 @@ export const reducer = (state: GameState, [command, ...params]: string[]): GameS
         country: country as GameConfigCountry,
       })(state as GameStateSetup)
     )
-    .with([GameCommandEnum.START, P.array(P.string)], ([_, [unparsedSeed, ...colors]]) =>
-      start(state as GameStateSetup, {
-        seed: Number.parseInt(unparsedSeed, 10),
-        colors: colors as PlayerColor[],
+    .with([GameCommandEnum.START, P.array(P.string)], ([_, params]) => {
+      const seed = Number.parseInt(params[0], 10)
+      if (Number.isNaN(seed)) {
+        return start(state as GameStateSetup, {
+          seed: undefined,
+          colors: params as PlayerColor[],
+        })
+      }
+
+      return start(state as GameStateSetup, {
+        seed,
+        colors: params.slice(1) as PlayerColor[],
       })
-    )
+    })
     .otherwise((command) => {
       throw new Error(`Unable to parse [${command.join(',')}]`)
     })

--- a/game/src/types.ts
+++ b/game/src/types.ts
@@ -44,7 +44,7 @@ export enum PlayerColor {
 }
 
 export type GameCommandStartParams = {
-  seed: number
+  seed?: number
   colors: PlayerColor[]
 }
 
@@ -429,7 +429,7 @@ export type GameStateSetup = {
 }
 export type GameStatePlaying = {
   status: GameStatusEnum.PLAYING | GameStatusEnum.FINISHED
-  randGen: PCGState
+  randGen?: PCGState
   config: GameCommandConfigParams
   rondel: Rondel
   wonders: number


### PR DESCRIPTION
* New feature to CONFIG, if you just dont give it a number for a seed, then it wont shuffle the players. Also it works with solo, yay testing