### PR TITLE
feature: navigate solo building phase

### DIFF
--- a/game/src/__tests__/control-solo.test.ts
+++ b/game/src/__tests__/control-solo.test.ts
@@ -1,0 +1,100 @@
+import { GameStatePlaying, control, reducer } from '..'
+import { spiel } from '../spiel'
+
+describe('control/settlement round checks', () => {
+  const s0 = spiel`
+CONFIG 1 france long
+START R B
+CUT_PEAT 0 0
+COMMIT
+FELL_TREES 1 0
+COMMIT
+USE LR1
+COMMIT
+BUILD G07 0 0
+USE G07 PtPt
+COMMIT
+USE LR3
+COMMIT
+BUILD G01 3 1
+COMMIT
+USE LR2 Gn
+CONVERT GnGn
+COMMIT
+BUILD G06 1 0
+USE G06 CoCoCo
+COMMIT
+BUY_DISTRICT 2 PLAINS
+BUILD F09 3 2
+COMMIT
+USE LR1
+COMMIT
+FELL_TREES 0 2
+COMMIT
+CUT_PEAT 0 1
+COMMIT
+USE G07 PtPtPtPtPtPt
+COMMIT
+USE G06 CoCoCo
+BUY_PLOT 2 COAST
+COMMIT
+BUY_DISTRICT 3 PLAINS
+BUILD F03 1 3
+USE F03 Pn
+COMMIT
+BUILD F04 -1 3
+COMMIT
+USE F04 GnGnGnGnGnGnGn
+COMMIT
+BUILD F05 0 2
+USE F05 FlFlFlFlFlFlFlCoSwBrBr
+COMMIT
+BUILD G12 0 1
+COMMIT
+USE G12 BrBrBrPnCoCo
+COMMIT
+BUILD F08 2 2
+USE F08 PnGnWoSw
+BUY_PLOT 0 COAST
+COMMIT
+BUILD F11 -1 1
+COMMIT` as GameStatePlaying
+
+  it('gives options to build or buy land', () => {
+    const c0 = control(s0, [])
+    expect(c0.completion).toStrictEqual([
+      //
+      'BUILD',
+      'BUY_PLOT',
+      'BUY_DISTRICT',
+      'CONVERT',
+    ])
+  })
+  it('does not have option to buy if used', () => {
+    const s1 = reducer(s0, ['BUY_PLOT', '0', 'MOUNTAIN']) as GameStatePlaying
+    const c1 = control(s1, [])
+    expect(c1.completion).toStrictEqual([
+      //
+      'BUILD',
+      'CONVERT',
+    ])
+  })
+  it('can build on neutral player', () => {
+    expect(s0).toMatchObject({
+      buildings: ['G02'],
+    })
+    expect(control(s0, [])?.completion).toStrictEqual([
+      //
+      'BUILD',
+      'BUY_PLOT',
+      'BUY_DISTRICT',
+      'CONVERT',
+    ])
+    expect(control(s0, ['BUILD'])?.completion).toStrictEqual([
+      //
+      'G02',
+    ])
+    const s1 = reducer(s0, ['BUILD', 'G02', '3', '1']) as GameStatePlaying
+    expect(s1).toBeDefined()
+  })
+})

--- a/game/src/board/frame.ts
+++ b/game/src/board/frame.ts
@@ -1,4 +1,4 @@
-import { equals, findIndex, lensProp, map, pipe, reduce, remove, set } from 'ramda'
+import { assoc, equals, findIndex, lensProp, map, pipe, reduce, remove, set } from 'ramda'
 import { match } from 'ts-pattern'
 import { nextFrame4Long } from './frame/nextFrame4Long'
 import { nextFrame3Long } from './frame/nextFrame3Long'
@@ -113,6 +113,8 @@ export const oncePerFrame = (command: GameCommandEnum): StateReducer =>
     if (frame.mainActionUsed === false) return { ...frame, mainActionUsed: true }
     return undefined
   })
+
+export const clearNeutralBuildingPhase: StateReducer = withFrame(assoc('neutralBuildingPhase', false))
 
 export const setFrameToAllowFreeUsage = (building: BuildingEnum[]): StateReducer =>
   withFrame((frame) => ({

--- a/game/src/commands/__tests__/build.test.ts
+++ b/game/src/commands/__tests__/build.test.ts
@@ -703,6 +703,67 @@ describe('commands/build', () => {
       const c0 = complete(s1)(['BUILD', BuildingEnum.Priory])
       expect(c0).toStrictEqual(['3 0', '3 2', '4 2'])
     })
+    it('neutral building phase building a cloister only on adjacent or overbuild', () => {
+      const s1: GameStatePlaying = {
+        ...s0,
+        config: {
+          ...s0.config,
+          players: 1,
+        },
+        players: [
+          {
+            ...s0.players[0],
+          },
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P', 'G12'], ['P'], ['P'], ['P'], ['P', 'LG1'], [], []],
+              [[], [], ['P'], ['P'], ['P', 'LG2'], ['P', 'G01'], ['H', 'LG3'], [], []],
+            ] as Tile[][],
+            landscapeOffset: 0,
+          },
+        ],
+        frame: {
+          ...s0.frame,
+          mainActionUsed: true,
+          neutralBuildingPhase: true,
+          bonusActions: [GameCommandEnum.BUILD],
+        },
+      }
+      const c0 = complete(s1)(['BUILD', BuildingEnum.Priory])
+      expect(c0).toStrictEqual(['3 0', '3 1', '4 1'])
+    })
+    it('neutral building phase building a regular building', () => {
+      const s1: GameStatePlaying = {
+        ...s0,
+        config: {
+          ...s0.config,
+          players: 1,
+        },
+        buildings: [BuildingEnum.Market],
+        players: [
+          {
+            ...s0.players[0],
+          },
+          {
+            ...s0.players[0],
+            landscape: [
+              [[], [], ['P', 'G12'], ['P'], ['P'], ['P'], ['P', 'LG1'], [], []],
+              [[], [], ['P'], ['P'], ['P', 'LG2'], ['P', 'G01'], ['H', 'LG3'], [], []],
+            ] as Tile[][],
+            landscapeOffset: 0,
+          },
+        ],
+        frame: {
+          ...s0.frame,
+          mainActionUsed: true,
+          neutralBuildingPhase: true,
+          bonusActions: [GameCommandEnum.BUILD],
+        },
+      }
+      const c0 = complete(s1)(['BUILD', BuildingEnum.Market])
+      expect(c0).toStrictEqual(['0 0', '1 0', '2 0', '3 0', '4 0', '0 1', '1 1', '2 1'])
+    })
     it('considers terrain type', () => {
       const s1: GameStatePlaying = {
         ...s0,

--- a/game/src/commands/settle.ts
+++ b/game/src/commands/settle.ts
@@ -1,7 +1,7 @@
 import { filter, pipe, view } from 'ramda'
 import { P, match } from 'ts-pattern'
 import { addErectionAtLandscape } from '../board/erections'
-import { onlyViaBonusActions } from '../board/frame'
+import { clearNeutralBuildingPhase, onlyViaBonusActions } from '../board/frame'
 import { checkLandscapeFree, checkLandTypeMatches, erectableLocations, erectableLocationsCol } from '../board/landscape'
 import { activeLens, payCost, withActivePlayer } from '../board/player'
 import { costEnergy, costFood, parseResourceParam, settlementCostOptions } from '../board/resource'
@@ -47,7 +47,8 @@ export const settle = ({ row, col, settlement, resources }: GameCommandSettlePar
     checkLandTypeMatches(row, col, settlement),
     payForSettlement(settlement, input),
     removeSettlementFromUnbuilt(settlement),
-    addErectionAtLandscape(row, col, settlement)
+    addErectionAtLandscape(row, col, settlement),
+    clearNeutralBuildingPhase
   )
 }
 

--- a/game/src/commands/use.ts
+++ b/game/src/commands/use.ts
@@ -15,7 +15,7 @@ import {
   without,
 } from 'ramda'
 import { P, match } from 'ts-pattern'
-import { oncePerFrame, withFrame } from '../board/frame'
+import { clearNeutralBuildingPhase, oncePerFrame, withFrame } from '../board/frame'
 import {
   allBuiltBuildings,
   allVacantUsableBuildings,
@@ -125,11 +125,6 @@ const checkIfUseCanHappen =
   }
 
 const clearUsableBuildings: StateReducer = withFrame(set(lensPath(['usableBuildings']), []))
-
-const clearNeutralBuildingPhase: StateReducer = withFrame((frame) => {
-  const newFrame = assoc('neutralBuildingPhase', false)(frame)
-  return newFrame
-})
 
 const moveClergyTo =
   (building: BuildingEnum): StateReducer =>

--- a/game/src/commands/workContract.ts
+++ b/game/src/commands/workContract.ts
@@ -21,6 +21,7 @@ import {
   Frame,
   GameCommandEnum,
   GameStatePlaying,
+  NextUseClergy,
   SettlementRound,
   StateReducer,
   Tile,
@@ -116,7 +117,12 @@ export const workContract = (building: BuildingEnum, paymentGift: string): State
   return pipe(
     // Only allow if mainAction not consumed, and consume it
     (state) => {
-      if (state?.frame.neutralBuildingPhase && state?.buildings.length === 0) return state
+      if (
+        state?.frame.neutralBuildingPhase &&
+        state?.buildings.length === 0 &&
+        state?.frame?.nextUse === NextUseClergy.OnlyPrior
+      )
+        return state
       return oncePerFrame(GameCommandEnum.WORK_CONTRACT)(state)
     },
 
@@ -151,7 +157,11 @@ export const complete =
         if (
           !state.frame.bonusActions.includes(GameCommandEnum.WORK_CONTRACT) &&
           state.frame.mainActionUsed &&
-          !(state.frame.neutralBuildingPhase === true && state.buildings.length === 0)
+          !(
+            state.frame.neutralBuildingPhase === true &&
+            state.buildings.length === 0 &&
+            state.frame.nextUse === NextUseClergy.OnlyPrior
+          )
         )
           return []
         const activePlayer = view(activeLens(state), state)
@@ -169,6 +179,9 @@ export const complete =
           )
         )
           return []
+
+        // TODO: if neutral building phase and neutral player doesn't have a clergy free
+
         // no need to check if there are buildings to be used, each player has 3 heartland buildings
         return [GameCommandEnum.WORK_CONTRACT]
       })

--- a/game/src/spiel.ts
+++ b/game/src/spiel.ts
@@ -1,0 +1,9 @@
+import { GameState, initialState, reducer } from '.'
+
+export const spiel = (strings: TemplateStringsArray): GameState | undefined =>
+  strings
+    .join('')
+    .split('\n')
+    .slice(1)
+    .map((s) => s.split(' '))
+    .reduce((state: GameState | undefined, command: string[]) => reducer(state!, command), initialState)


### PR DESCRIPTION
* Adds a test for navigating the single player experience, which checks to ensure that completions are appropriate
* Using javascript template strings, maybe this is a convenient way of writing tests where I just put in a move list? It's much faster than I expected, and less verbose than just declaring what the state should look like, however it also makes that test depend on the entire reducer tree.
* Also enforce that USE (as well as SETTLE) will end the Neutral Building Phase, as there may be a visual change from that flag... after you do a USE (from a WORK_CONTRACT), special rules no longer apply. Similarly after a SETTLE.