### PR TITLE
feature: intuitive modal action execution redirects

### DIFF
--- a/web/src/app/account/connect/page.tsx
+++ b/web/src/app/account/connect/page.tsx
@@ -5,8 +5,10 @@ import { redirect } from 'next/navigation'
 import { Turnstile } from '@marsidev/react-turnstile'
 
 import { connect, skip } from './actions'
+import { useSupabaseContext } from '@/context/SupabaseContext'
 
 const Connect = () => {
+  const { redirectTo } = useSupabaseContext()
   const [response, setResponse] = useState<string>('')
   const [captchaToken, setCaptchaToken] = useState<string>('')
 
@@ -16,7 +18,7 @@ const Connect = () => {
       setResponse(error)
       return
     }
-    redirect('/instance')
+    redirect(redirectTo)
   }
 
   const handleSkip = async (formData: FormData) => {
@@ -25,7 +27,7 @@ const Connect = () => {
       setResponse(error)
       return
     }
-    redirect('/instance')
+    redirect(redirectTo)
   }
 
   return (

--- a/web/src/app/account/settings/actions.ts
+++ b/web/src/app/account/settings/actions.ts
@@ -4,13 +4,13 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 
-export const disconnect = async () => {
+export const disconnect = async (redirectTo: string) => {
   const supabase = await createClient()
   const { error } = await supabase.auth.signOut({ scope: 'local' })
   if (error) {
     return error?.message
   }
-  redirect('/')
+  redirect(redirectTo)
 }
 
 export const changePassword = async (formData: FormData) => {

--- a/web/src/app/account/settings/disconnectButton.tsx
+++ b/web/src/app/account/settings/disconnectButton.tsx
@@ -1,18 +1,24 @@
-'use client';
+'use client'
 
-import { revalidatePath } from "next/cache";
-import { disconnect } from "./actions";
+import { revalidatePath } from 'next/cache'
+import { disconnect } from './actions'
+import { useSupabaseContext } from '@/context/SupabaseContext'
 
 const DisconnectButton = () => {
+  const { redirectTo } = useSupabaseContext()
 
   const disconnectAndReturn = async (_formData: FormData) => {
-    await disconnect()
+    await disconnect(redirectTo)
     revalidatePath('/account/settings')
   }
 
-  return <form>
-    <button formAction={disconnectAndReturn}>Disconnect</button>
-  </form>
+  return (
+    <form>
+      <pre>{JSON.stringify(redirectTo, undefined, 2)}</pre>
+
+      <button formAction={disconnectAndReturn}>Disconnect</button>
+    </form>
+  )
 }
 
 export default DisconnectButton

--- a/web/src/app/account/settings/page.tsx
+++ b/web/src/app/account/settings/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from '@/utils/supabase/server'
 import ChangePassword from './changePassword'
 import { LinkEmail } from './linkEmail'
 import DisconnectButton from './disconnectButton'
+import { useSupabaseContext } from '@/context/SupabaseContext'
 
 const SettingsPage = async () => {
   const supabase = await createClient()
@@ -14,7 +15,7 @@ const SettingsPage = async () => {
     error,
   } = await supabase.auth.getUser()
   if (error || !user) {
-    redirect('/account/login')
+    redirect('/account/connect')
   }
 
   return (

--- a/web/src/app/layout/connect.tsx
+++ b/web/src/app/layout/connect.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useSupabaseContext } from '@/context/SupabaseContext'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export const Connect = () => {
+  const pathName = usePathname()
+  const { setRedirectTo } = useSupabaseContext()
+
+  const handleClick = () => {
+    // this makes navigation a little less deterministic, but i think it's somewhat intuitive
+    // to have this be a tiny bit of modal behavior handled by the client
+    setRedirectTo(pathName)
+  }
+
+  return (
+    <Link href={{ pathname: '/account/connect' }} onClick={handleClick}>
+      Connect
+    </Link>
+  )
+}

--- a/web/src/app/layout/header.tsx
+++ b/web/src/app/layout/header.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { Presence } from './presence'
 import { createClient } from '@/utils/supabase/server'
+import { Connect } from './connect'
+import { Settings } from './settings'
 
 const Header = async () => {
   const supabase = await createClient()
@@ -17,7 +19,7 @@ const Header = async () => {
       {user?.email === undefined && (
         <>
           &nbsp;[&nbsp;
-          <Link href="/account/connect">Connect</Link>
+          <Connect />
           &nbsp;]
         </>
       )}
@@ -26,7 +28,7 @@ const Header = async () => {
           &nbsp;[&nbsp;
           <Link href="/instance/">Instances</Link>
           &nbsp;|&nbsp;
-          <Link href="/account/settings">Settings⚠️</Link> ]
+          <Settings />
         </>
       )}
       {user?.email !== undefined && user?.is_anonymous === false && (
@@ -36,7 +38,7 @@ const Header = async () => {
           &nbsp;|&nbsp;
           <Link href="/instance/">Instances</Link>
           &nbsp;|&nbsp;
-          <Link href="/account/settings">Settings</Link> ]
+          <Settings />
         </>
       )}
     </header>

--- a/web/src/app/layout/settings.tsx
+++ b/web/src/app/layout/settings.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useSupabaseContext } from '@/context/SupabaseContext'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export const Settings = () => {
+  const pathName = usePathname()
+  const { setRedirectTo } = useSupabaseContext()
+
+  const handleClick = () => {
+    // this makes navigation a little less deterministic, but i think it's somewhat intuitive
+    // because going to the settings is usually with some sort of modal task, and i imagine
+    // once the user accomplishes that they usually want to go back
+    setRedirectTo(pathName)
+  }
+
+  return (
+    <Link href={{ pathname: '/account/settings' }} onClick={handleClick}>
+      Settings
+    </Link>
+  )
+}

--- a/web/src/context/SupabaseContext.ts
+++ b/web/src/context/SupabaseContext.ts
@@ -2,27 +2,30 @@
 
 import { createClient } from '@/utils/supabase/client'
 import { SupabaseClient } from '@supabase/supabase-js'
-import { createContext, createElement, ReactNode, useContext, useState } from 'react'
+import { createContext, createElement, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react'
 
 interface SupabaseContextType {
-  supabase?: SupabaseClient
+  supabase: SupabaseClient
+  redirectTo: string
+  setRedirectTo: Dispatch<SetStateAction<string>>
 }
 
 interface SupabaseContextProviderProps {
   children: ReactNode | ReactNode[]
 }
 
-const SupabaseContext = createContext<SupabaseContextType>({})
+const SupabaseContext = createContext<SupabaseContextType>({} as SupabaseContextType)
 
 export const SupabaseContextProvider = ({ children }: SupabaseContextProviderProps) => {
+  const [redirectTo, setRedirectTo] = useState('/')
   const supabase = createClient()
-  return createElement(SupabaseContext.Provider, { value: { supabase } }, children)
+  return createElement(SupabaseContext.Provider, { value: { supabase, redirectTo, setRedirectTo } }, children)
 }
 
 export const useSupabaseContext = () => {
   const context = useContext(SupabaseContext)
   if (!context) {
-    throw new Error('Component must be within the HathoraContext')
+    throw new Error('Component must be within the Supabase Context')
   }
   return context
 }


### PR DESCRIPTION
This makes the actions of "Connect" and "Disconnect" have a modal path to go back to. I am just imagining these are tasks where the user always wants to accomplish and then go back to what they were doing like a stack on iOS.

I'm happy that the implementation of this really just uses a sort of minimal interface, and it's an alternative to passing along a GET param to the connect page.