### PR TITLE
fix: joker comes out in the start in solo

### DIFF
--- a/game/src/__tests__/game.e504cc4e.test.ts
+++ b/game/src/__tests__/game.e504cc4e.test.ts
@@ -168,8 +168,6 @@ describe('game 504cc4e', () => {
       commands
     ) as GameStatePlaying
     expect(midState).not.toBeUndefined()
-    console.log(midState.players[0])
-    console.log(control(midState, ['WORK_CONTRACT', 'F32']))
     const controls = control(midState, ['WORK_CONTRACT', 'F32'])
     expect(controls.completion).toStrictEqual(['PnPn'])
   })

--- a/game/src/__tests__/game.e504cc4e.test.ts
+++ b/game/src/__tests__/game.e504cc4e.test.ts
@@ -2,7 +2,7 @@ import { reduce } from 'ramda'
 import { control } from '..'
 import { reducer } from '../reducer'
 import { initialState } from '../state'
-import { GameState, GameStatePlaying, GameStateSetup } from '../types'
+import { GameState, GameStatePlaying } from '../types'
 
 const commands: string[] = [
   'CONFIG 1 france long',
@@ -149,12 +149,11 @@ const commands: string[] = [
   'SETTLE SR6 3 5 MtCoCo',
   'COMMIT',
   'USE F09',
-  'USE F24 BrBrWnWn',
+  'USE LR3',
   'COMMIT',
-  'BUILD F27 4 0',
-  'BUILD F30 1 0',
-  'BUILD F32 3 1',
-  'WORK_CONTRACT F32 Wn',
+  'BUILD F27 0 1',
+  'BUILD F30 4 0',
+  'BUILD F32 3 0',
 ]
 
 describe('game 504cc4e', () => {
@@ -168,7 +167,10 @@ describe('game 504cc4e', () => {
       initialState as GameState,
       commands
     ) as GameStatePlaying
-    const controls = control(midState, ['USE', 'F32'])
-    expect(controls.completion).toStrictEqual(['Pn', ''])
+    expect(midState).not.toBeUndefined()
+    console.log(midState.players[0])
+    console.log(control(midState, ['WORK_CONTRACT', 'F32']))
+    const controls = control(midState, ['WORK_CONTRACT', 'F32'])
+    expect(controls.completion).toStrictEqual(['PnPn'])
   })
 })

--- a/game/src/board/frame/nextFrameSolo.ts
+++ b/game/src/board/frame/nextFrameSolo.ts
@@ -4,7 +4,6 @@ import { addNeutralPlayer } from './addNeutralPlayer'
 import { gameEnd } from '../state'
 import { returnClergyIfPlaced } from './returnClergyIfPlaced'
 import { rotateRondelWithExpire } from './rotateRondel'
-import { introduceJokerToken, removeJokerToken } from '../rondel'
 import { checkSoloSettlementReady } from './checkSoloSettlementReady'
 import { introduceSettlements } from '../settlements'
 
@@ -29,14 +28,7 @@ export const nextFrameSolo: FrameFlow = {
     startingPlayer: 0,
     currentPlayerIndex: 0,
     settlementRound: SettlementRound.S,
-    upkeep: [
-      rotateRondelWithExpire,
-      returnClergyIfPlaced,
-      introduceBuildings,
-      removeJokerToken,
-      addNeutralPlayer,
-      introduceSettlements,
-    ],
+    upkeep: [rotateRondelWithExpire, returnClergyIfPlaced, introduceBuildings, addNeutralPlayer, introduceSettlements],
     next: 2,
   },
   2: { next: 3 },
@@ -139,7 +131,7 @@ export const nextFrameSolo: FrameFlow = {
       /* determined by checkSoloSettlementReady */
     ],
     settlementRound: SettlementRound.A,
-    upkeep: [returnClergyIfPlaced, introduceJokerToken, checkSoloSettlementReady],
+    upkeep: [returnClergyIfPlaced, checkSoloSettlementReady],
     next: 24,
   },
 

--- a/game/src/board/rondel.ts
+++ b/game/src/board/rondel.ts
@@ -1,4 +1,4 @@
-import { always, assoc, curry, dissoc, equals, isNil, pathSatisfies, pipe, propSatisfies, when } from 'ramda'
+import { always, assoc, curry, equals, isNil, pathSatisfies, propSatisfies, when } from 'ramda'
 import { match } from 'ts-pattern'
 import {
   Rondel,
@@ -60,8 +60,6 @@ export const introduceGrapeToken: StateReducer = when(
 )
 
 export const introduceStoneToken: StateReducer = introduceToken('stone')
-export const introduceJokerToken: StateReducer = introduceToken('joker')
-export const removeJokerToken: StateReducer = withRondel(dissoc('joker'))
 
 export const armValues = ({ length, players }: GameCommandConfigParams) => {
   if (players === 2 && length === 'short') {
@@ -105,7 +103,7 @@ export const standardSesourceGatheringAction = (usingToken: RondelToken, withJok
       rondel: { joker, pointingBefore },
     } = state
     const main = state.rondel[usingToken]
-    const amount = take(pointingBefore, (withJoker ? joker : main ?? joker) ?? pointingBefore, config)
+    const amount = take(pointingBefore, (withJoker ? joker : (main ?? joker)) ?? pointingBefore, config)
     const resource = tokenToResource(usingToken)
     const cost = parseResourceParam(resource)
     const magnitude = multiplyGoods(amount)(cost)


### PR DESCRIPTION
this looks to be an ancient bug since the old [weblabora](https://github.com/philihp/weblabora/blob/master/src/main/java/com/philihp/weblabora/model/BoardModeOneFrance.java#L203C15-L205). i think it stems from this line in the rules

> Add the joker to the rest of the goods indicators on the space with the “A“ symbol.

When I read this now, it looks like maybe I misinterpreted this to mean the settlement-A round. But I think reading it now, I don't know what this sentence is doing, because of course you would put the joker there.