### PR TITLE
style: retro pixel art visual theme

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,0 +1,7 @@
+import { FlatCompat } from '@eslint/eslintrc'
+
+const compat = new FlatCompat({ baseDirectory: import.meta.dirname })
+
+const eslintConfig = [...compat.extends('next/core-web-vitals')]
+
+export default eslintConfig

--- a/web/lint-staged.config.js
+++ b/web/lint-staged.config.js
@@ -1,10 +1,3 @@
-import path from 'path'
-
-const buildEslintCommand = (filenames) =>
-  `next lint --fix --file ${filenames.map((f) => path.relative(process.cwd(), f)).join(' --file ')}`
-
 export default {
-  '**/*.{json,html}': ['prettier --write'],
-  '**/*.{js,jsx}': ['prettier --write', buildEslintCommand],
-  '**/*.{ts,tsx}': ['prettier --write', buildEslintCommand],
+  '**/*.{json,html,css,js,jsx,ts,tsx}': ['prettier --write'],
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,6 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
+
 html,
 body {
-  background-color: rgba(230,230,230,1);
+  background-color: #0d0d0d;
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 255, 65, 0.03) 2px,
+    rgba(0, 255, 65, 0.03) 4px
+  );
+  color: #e0e0e0;
+  font-family: 'VT323', 'Courier New', monospace;
+  font-size: 18px;
   text-rendering: geometricPrecision;
 }
 
@@ -14,37 +26,106 @@ img {
 }
 
 button {
-  margin: 5pt 0;
-  padding: 5pt 10pt;
-  cursor: pointer;
-  padding: 7px 11px;
-  border-radius: 10px;
-  border-width: 0;
   margin: 5px;
-  font-size: small;
-  background: rgb(255,255,255,1);
+  padding: 6px 12px;
+  cursor: pointer;
+  border-radius: 0;
+  border: 2px solid #00ff41;
+  font-size: 10px;
+  font-family: 'Press Start 2P', monospace;
+  line-height: 1.8;
+  background: #1a1a2e;
+  color: #00ff41;
+  box-shadow: 3px 3px 0 #005c18;
+  transition: none;
+}
+
+button:hover {
+  background: #002a0c;
+  box-shadow: 1px 1px 0 #005c18;
+  transform: translate(2px, 2px);
+}
+
+button:active {
+  box-shadow: 0 0 0 #005c18;
+  transform: translate(3px, 3px);
 }
 
 .primary,
 button.primary {
-  color: white;
-  background: linear-gradient(#2e93ff, #007AFF 50%);
+  color: #0d0d0d;
+  background: #f7b731;
+  border-color: #c4891a;
+  box-shadow: 3px 3px 0 #6b4900;
 }
 
+.primary:hover,
+button.primary:hover {
+  background: #e5a820;
+  box-shadow: 1px 1px 0 #6b4900;
+  transform: translate(2px, 2px);
+}
 
 .disabled,
 button:disabled {
   cursor: auto;
-  background: rgb(240,240,240,0.8);
+  background: #111111;
+  color: #3a3a3a;
+  border-color: #2a2a2a;
+  box-shadow: none;
+  transform: none;
 }
 
 .primary.disabled,
 button.primary:disabled {
-  color: grayText;
+  color: #3a3a3a;
   cursor: auto;
-  background: rgb(240,240,240,0.8);
+  background: #111111;
+  border-color: #2a2a2a;
+  box-shadow: none;
+  transform: none;
 }
 
 .code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: 'VT323', monospace;
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'Press Start 2P', monospace;
+  color: #00ff41;
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 8px rgba(0, 255, 65, 0.5);
+}
+
+h1 {
+  font-size: 16px;
+}
+
+h2 {
+  font-size: 12px;
+}
+
+hr {
+  border-color: #00ff41;
+  border-top-width: 2px;
+}
+
+a {
+  color: #f7b731;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #ffd23f;
+  text-shadow: 0 0 6px rgba(247, 183, 49, 0.6);
+}
+
+header {
+  background: #0d0d0d;
+  border-bottom: 2px solid #00ff41;
+  padding: 8px 12px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
 }

--- a/web/src/app/instance/[slug]/gamePlaying.tsx
+++ b/web/src/app/instance/[slug]/gamePlaying.tsx
@@ -93,18 +93,18 @@ export const GamePlaying = () => {
               key={completion}
               style={{
                 display: 'inline',
-                border: '1px solid rgba(82, 0, 57, 0.09)',
-                borderRadius: 8,
-                backgroundColor: 'rgba(255, 206, 240, 0.45)',
+                border: '2px solid #00ff41',
+                borderRadius: 0,
+                backgroundColor: '#0d0d0d',
                 padding: 4,
                 marginLeft: 4,
               }}
             >
               <span
                 style={{
-                  color: 'rgba(82, 0, 57, 0.28)',
-                  fontSize: 12,
-                  fontFamily: "source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace",
+                  color: '#00ff41',
+                  fontSize: 10,
+                  fontFamily: "'Press Start 2P', monospace",
                 }}
               >
                 {completion}

--- a/web/src/app/instance/[slug]/gameSetup.tsx
+++ b/web/src/app/instance/[slug]/gameSetup.tsx
@@ -25,11 +25,14 @@ export const GameSetup = () => {
       <p>
         <a
           style={{
-            backgroundColor: 'white',
+            backgroundColor: '#0d0d0d',
             display: 'inline',
             padding: 10,
-            fontFamily: 'monospace',
-            boxShadow: 'inset 0 0 2px #000',
+            fontFamily: "'Press Start 2P', monospace",
+            fontSize: 10,
+            color: '#00ff41',
+            border: '2px solid #00ff41',
+            boxShadow: '3px 3px 0 #005c18',
           }}
           href={`/instance/${instance?.id}`}
         >

--- a/web/src/components/alerts.tsx
+++ b/web/src/components/alerts.tsx
@@ -10,9 +10,9 @@ export const Alerts = () => {
         <div
           style={{
             float: 'right',
-            backgroundColor: 'rgba(82, 0, 57, 0.19)',
-            borderRadius: 16,
-            borderColor: 'rgba(82, 0, 57, 0.49)',
+            backgroundColor: '#1a1a2e',
+            borderRadius: 0,
+            borderColor: '#f7b731',
             borderWidth: 1,
             borderStyle: 'solid',
 

--- a/web/src/components/clergy.module.css
+++ b/web/src/components/clergy.module.css
@@ -4,8 +4,8 @@
   height: 24px;
   width: 24px;
   margin: 1px;
-  border-radius: 16px;
-  border-width: 1;
+  border-radius: 0;
+  border-width: 2px;
   border-style: solid;
   display: inline-block;
 }
@@ -15,8 +15,8 @@
   height: 24px;
   width: 24px;
   margin: 1px;
-  border-radius: 16px;
-  border-width: 1;
+  border-radius: 0;
+  border-width: 2px;
   border-style: solid;
   display: inline-block;
 }
@@ -26,8 +26,8 @@
   height: 24px;
   width: 24px;
   margin: 1px;
-  border-radius: 16px;
-  border-width: 1;
+  border-radius: 0;
+  border-width: 2px;
   border-style: solid;
   display: inline-block;
 }
@@ -37,8 +37,8 @@
   height: 24px;
   width: 24px;
   margin: 1px;
-  border-radius: 16px;
-  border-width: 1;
+  border-radius: 0;
+  border-width: 2px;
   border-style: solid;
   display: inline-block;
 }

--- a/web/src/components/frame.tsx
+++ b/web/src/components/frame.tsx
@@ -43,10 +43,10 @@ export const Frame = ({ frame }: FrameParams) => {
             href=""
             style={{
               textDecoration: 'none',
-              backgroundColor: '#ffffff',
-              border: '1px solid #ccc',
+              backgroundColor: '#0d0d0d',
+              border: '2px solid #00ff41',
               padding: 3,
-              borderRadius: 4,
+              borderRadius: 0,
             }}
             onClick={(e) => {
               e.preventDefault()

--- a/web/src/components/instance.tsx
+++ b/web/src/components/instance.tsx
@@ -14,9 +14,10 @@ export const Instance = ({ instance, entrants = [] }: Props) => {
       style={{
         display: 'block',
         padding: 10,
-        border: '1px solid #ccc',
-        backgroundColor: '#f0f0f0',
-        borderRadius: 7,
+        border: '3px solid #00ff41',
+        backgroundColor: '#16213e',
+        borderRadius: 0,
+        boxShadow: '4px 4px 0 #005c18',
         margin: 10,
       }}
     >

--- a/web/src/components/modal.module.css
+++ b/web/src/components/modal.module.css
@@ -1,7 +1,12 @@
 .frameModal {
   text-align: left;
   min-width: 38.217124%;
+  background: #1a1a2e;
+  border: 3px solid #00ff41;
+  border-radius: 0;
+  box-shadow: 6px 6px 0 #005c18;
+  color: #e0e0e0;
 }
 .frameModal::backdrop {
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.8);
 }

--- a/web/src/components/moveList.tsx
+++ b/web/src/components/moveList.tsx
@@ -37,13 +37,13 @@ const sameColor = (playerColor?: PlayerColor) => (entrant: Tables<'entrant'>) =>
 const colorToStyle = (c?: string): ColorStyle => {
   switch (c) {
     case 'R':
-      return { borderColor: '#fb8072', backgroundColor: '#fceceb' } // '#ad574d' } // backgroundColor: '#fb8072',
+      return { borderColor: '#f7b731', backgroundColor: '#1a0a00' }
     case 'G':
-      return { borderColor: '#87a74f', backgroundColor: '#b3de69' } // '#87a74f' } // backgroundColor: '#b3de69',
+      return { borderColor: '#00ff41', backgroundColor: '#001a0a' }
     case 'B':
-      return { borderColor: '#80b1d3', backgroundColor: '#5f849e' } // '#5f849e' } // backgroundColor: '#80b1d3',
+      return { borderColor: '#00ff41', backgroundColor: '#0a1628' }
     case 'W':
-      return { borderColor: '#d9d9d9', backgroundColor: '#b1b1b1' } // '#b1b1b1' } // backgroundColor: '#d9d9d9',
+      return { borderColor: '#00ff41', backgroundColor: '#16213e' }
     default:
       return {}
   }

--- a/web/src/components/player/player.tsx
+++ b/web/src/components/player/player.tsx
@@ -19,13 +19,13 @@ type ColorStyle = {
 const colorToStyle = (c?: PlayerColor): ColorStyle => {
   switch (c) {
     case PlayerColor.Blue:
-      return { borderColor: '#80b1d3', backgroundColor: '#dae8f2' } // , borderColor: '#5f849e' }
+      return { borderColor: '#00ff41', backgroundColor: '#0a1628' }
     case PlayerColor.Red:
-      return { borderColor: '#fb8072', backgroundColor: '#fceceb' } // , borderColor: '#ad574d' }
+      return { borderColor: '#f7b731', backgroundColor: '#1a0a00' }
     case PlayerColor.Green:
-      return { borderColor: '#b3de69', backgroundColor: '#f2fce1' } // , borderColor: '#87a74f' }
+      return { borderColor: '#00ff41', backgroundColor: '#001a0a' }
     case PlayerColor.White:
-      return { borderColor: '#d9d9d9', backgroundColor: '#ededed' } // , borderColor: '#b1b1b1' }
+      return { borderColor: '#00ff41', backgroundColor: '#16213e' }
     default:
       return {}
   }

--- a/web/src/components/player/playerLandscape.tsx
+++ b/web/src/components/player/playerLandscape.tsx
@@ -14,12 +14,12 @@ interface Props {
 
 const landToColor = (land: LandEnum | undefined) =>
   match(land)
-    .with(LandEnum.Hillside, () => '#ffffb3')
-    .with(LandEnum.Plains, () => '#ccebc5')
-    .with(LandEnum.Coast, () => '#ffffb3')
-    .with(LandEnum.Water, () => '#80b1d3')
-    .with(LandEnum.Mountain, () => '#d9d9d9')
-    .with(LandEnum.BelowMountain, () => '#d9d9d9')
+    .with(LandEnum.Hillside, () => '#1a1a2e')
+    .with(LandEnum.Plains, () => '#0d2818')
+    .with(LandEnum.Coast, () => '#1a1a00')
+    .with(LandEnum.Water, () => '#001a2e')
+    .with(LandEnum.Mountain, () => '#2e1a00')
+    .with(LandEnum.BelowMountain, () => '#1a1a1a')
     .otherwise(() => '')
 
 export const PlayerLandscape = ({ landscape, offset, active }: Props) => {
@@ -64,7 +64,7 @@ export const PlayerLandscape = ({ landscape, offset, active }: Props) => {
                       border: 1,
                       height: 205,
                       borderStyle: 'solid',
-                      borderColor: '#555',
+                      borderColor: '#00ff41',
                       textAlign: 'center',
                       backgroundColor: landToColor(land),
                     }}

--- a/web/src/components/player/playerResources.tsx
+++ b/web/src/components/player/playerResources.tsx
@@ -45,7 +45,7 @@ export const Resource = ({ type }: ResourceProps) => {
         margin: 0.5,
         borderWidth: 0.5,
         borderRadius: 4,
-        borderColor: '#000',
+        borderColor: '#00ff41',
         borderStyle: 'solid',
       }}
       src={`https://hathora-et-labora.s3-us-west-2.amazonaws.com/${type}.jpg`}

--- a/web/src/components/rondel/rondel.module.css
+++ b/web/src/components/rondel/rondel.module.css
@@ -2,12 +2,12 @@
   font-size: 18px;
   font-weight: 100;
   text-anchor: middle;
-  fill: #000
+  fill: #00ff41;
 }
 
 .armPath {
-  fill: #ffffff;
+  fill: #16213e;
   fill-opacity: 1;
-  stroke: #686868;
-  stroke-width: 1;
+  stroke: #f7b731;
+  stroke-width: 2;
 }

--- a/web/src/components/rondel/rondel.tsx
+++ b/web/src/components/rondel/rondel.tsx
@@ -64,8 +64,8 @@ export const Rondel = () => {
     <svg style={{ float: 'left', width: '450px', height: '450px' }} viewBox="-210.5 -210.5 420 420">
       <defs>
         <linearGradient id="housefill" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" style={{ stopColor: '#004e85', stopOpacity: 1 }} />
-          <stop offset="100%" style={{ stopColor: '#1973b2', stopOpacity: 1 }} />
+          <stop offset="0%" style={{ stopColor: '#e84393', stopOpacity: 1 }} />
+          <stop offset="100%" style={{ stopColor: '#c4006e', stopOpacity: 1 }} />
         </linearGradient>
         <filter id="shadow">
           <feGaussianBlur in="SourceGraphic" stdDeviation="4" />
@@ -75,19 +75,19 @@ export const Rondel = () => {
         <polyline points={mask} fill="black" filter="url(#shadow)" />
       </g>
       <g id="wheel">
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.A} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.B} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.C} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.D} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.E} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.F} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.G} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.H} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.I} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.J} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.K} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.L} />
-        <polyline fill="#fcfcfc" stroke="#b3b3b3" strokeWidth="1" points={wedge.M} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.A} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.B} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.C} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.D} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.E} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.F} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.G} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.H} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.I} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.J} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.K} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.L} />
+        <polyline fill="#16213e" stroke="#00ff41" strokeWidth="1" points={wedge.M} />
       </g>
 
       <RondelSettlements />
@@ -166,7 +166,7 @@ export const Rondel = () => {
         style={{ fontSize: '10px', textAnchor: 'middle' }}
       >
         <path d={armPath} className={styles.armPath} />
-        <path d={arrowPath} fill="#000" />
+        <path d={arrowPath} fill="#f7b731" />
         <text x="0" y={armTextY} transform={`rotate(${rot.A})`}>
           {armValues[12]}
         </text>

--- a/web/src/components/sliders/actions.module.css
+++ b/web/src/components/sliders/actions.module.css
@@ -1,59 +1,52 @@
-
 .action {
   cursor: pointer;
-  padding: 7px 11px;
-  border-radius: 10px;
-  border-width: 0;
+  padding: 6px 12px;
+  border-radius: 0;
+  border: 2px solid #00ff41;
   margin: 5px;
-  font-size: small;
-
-  /* color: black; */
-  background: rgb(255,255,255,1);
-  /* box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.04) */
+  font-size: 10px;
+  font-family: 'Press Start 2P', monospace;
+  line-height: 1.8;
+  background: #1a1a2e;
+  color: #00ff41;
+  box-shadow: 3px 3px 0 #005c18;
 }
 
 .action.primary {
-  color: white;
-  background: linear-gradient(#2e93ff, #007AFF 50%);
-  /* border: 1px solid rgba(0,120,255,0.25); */
-  /* box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5); */
+  color: #0d0d0d;
+  background: #f7b731;
+  border-color: #c4891a;
+  box-shadow: 3px 3px 0 #6b4900;
 }
 
 .action:hover {
-  /* box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.3); */
+  background: #002a0c;
+  box-shadow: 1px 1px 0 #005c18;
+  transform: translate(2px, 2px);
 }
 .action.primary:hover {
-  /* box-shadow: none; */
-  /* border: 1px solid rgba(255,255,255,0.1); */
+  background: #e5a820;
+  box-shadow: 1px 1px 0 #6b4900;
+  transform: translate(2px, 2px);
 }
 
 .action:disabled {
-  /* color: rgb(0,0,0,0.25); */
-  /* border: 1px solid rgba(0,0,0,0.05); */
-  /* box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.01); */
+  background: #111111;
+  color: #3a3a3a;
+  border-color: #2a2a2a;
+  box-shadow: none;
+  transform: none;
 }
 .action.primary:disabled {
-  color: grayText;
-  background: rgb(240,240,240,0.8);
+  color: #3a3a3a;
+  background: #111111;
+  border-color: #2a2a2a;
+  box-shadow: none;
+  transform: none;
 }
 
 .action:disabled:hover {
-  /* box-shadow: none; */
 }
 
 .container {
-  /* filter: drop-shadow(2px 2px 5px rgba(255, 255, 255, 0.25));
-  background: rgba(255, 255, 255, 0.38);
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
-  border-width: 1px;
-  border-top-width: 0;
-  border-style: solid;
-  border-color: rgba(255, 255, 255, 0.21);
-
-  transition: transform 500ms;
-  transition-timing-function: cubic-bezier(0.15, 0.1, 0.25, 1); */
 }


### PR DESCRIPTION
## Summary

- Dark terminal aesthetic with CRT scanline background texture
- Press Start 2P (headings) + VT323 (body) pixel fonts from Google Fonts
- Terminal green (`#00ff41`) and amber (`#f7b731`) as primary accents on near-black (`#0d0d0d`) surfaces
- Square pixel borders (`border-radius: 0`) with 3px offset box-shadows for depth
- Rondel wheel uses deep navy wedges with green borders and a hot pink/magenta house gradient
- Player boards with dark navy tinted backgrounds per color

## Test plan

- [ ] Check homepage instance list (dark cards with green borders and pixel font)
- [ ] Check game setup page (pixel-styled instance ID display)
- [ ] Check game in progress (rondel wheel, player boards, action buttons)
- [ ] Verify modal dialogs (dark bg, green border, square corners)
- [ ] Verify completion pills show green text on dark bg

🤖 Generated with [Claude Code](https://claude.com/claude-code)