### PR TITLE
fix: prevent cloisterCourtyard from accepting disallowed output resources

### DIFF
--- a/game/src/buildings/__tests__/cloisterCourtyard.test.ts
+++ b/game/src/buildings/__tests__/cloisterCourtyard.test.ts
@@ -96,6 +96,10 @@ describe('buildings/cloisterCourtyard', () => {
       const s1 = cloisterCourtyard('ClWoWo', 'Sh')(s0)!
       expect(s1).toBeUndefined()
     })
+    it('fails if output is not an allowed resource', () => {
+      const s1 = cloisterCourtyard('ClWoGn', 'Br')(s0)!
+      expect(s1).toBeUndefined()
+    })
   })
 
   describe('complete', () => {

--- a/game/src/buildings/cloisterCourtyard.ts
+++ b/game/src/buildings/cloisterCourtyard.ts
@@ -20,7 +20,7 @@ export const cloisterCourtyard = (input = '', output = '') => {
   const outputs = parseResourceParam(output)
   if (totalGoods(inputs) !== 3) return () => undefined
   if (differentGoods(inputs) !== 3) return () => undefined
-  if (totalGoods(maskGoods(ALLOWED_OUTPUT)(outputs)) !== 1 && differentGoods(outputs) !== 1) return () => undefined
+  if (totalGoods(maskGoods(ALLOWED_OUTPUT)(outputs)) !== 1 || differentGoods(outputs) !== 1) return () => undefined
   return withActivePlayer(
     pipe(
       //


### PR DESCRIPTION
## Summary

- Adds a test for `cloisterCourtyard` verifying that passing `Br` (bread) as the output parameter correctly returns `undefined`, since bread is not in the allowed output list
- Fixes the guard condition on line 23 of `cloisterCourtyard.ts`: `&&` was changed to `||`, which caused disallowed resources like bread to slip through validation

## Test plan

- [ ] `npx jest cloisterCourtyard` passes all 9 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)