### PR TITLE
feat(game): encode rondel yields alongside positions

### DIFF
--- a/game/src/__tests__/encode.test.ts
+++ b/game/src/__tests__/encode.test.ts
@@ -286,4 +286,36 @@ describe('encode', () => {
     expect(vec[clergyOffset + 2]).toBe(1) // priorUnplaced
     expect(vec[clergyOffset + 3]).toBe(0) // priorPlaced
   })
+
+  it('encodes the yield each rondel token would give if taken now', () => {
+    // 3p long config uses armValues = [0, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 9, 10]
+    // take(armIndex, tokenIndex) = armVals[(armIndex - tokenIndex + 13) % 13]
+    // With pointingBefore=4 and wood at slot 1: (4-1+13)%13 = 3 → armVals[3] = 4
+    // With wood at slot 4 (same as arm): (4-4+13)%13 = 0 → armVals[0] = 0
+    const stateAtFour: GameStatePlaying = {
+      ...baseState,
+      rondel: { ...rondel, pointingBefore: 4, wood: 1, clay: 4 },
+    }
+    const vec = encode(stateAtFour)
+    const yieldsOffset = featureSpec.offsets.shared + featureSpec.vocab.rondelKeys.length
+    const woodIdx = featureSpec.vocab.rondelKeys.indexOf('wood')
+    const clayIdx = featureSpec.vocab.rondelKeys.indexOf('clay')
+    expect(vec[yieldsOffset + woodIdx]).toBeCloseTo(4 / 10)
+    expect(vec[yieldsOffset + clayIdx]).toBe(0)
+  })
+
+  it('yields 0 for rondel tokens not yet on the rondel', () => {
+    const stateNoGrape: GameStatePlaying = {
+      ...baseState,
+      rondel: { pointingBefore: 5, wood: 0, clay: 0, coin: 0, grain: 0, peat: 0, sheep: 0 },
+    }
+    const vec = encode(stateNoGrape)
+    const yieldsOffset = featureSpec.offsets.shared + featureSpec.vocab.rondelKeys.length
+    const grapeIdx = featureSpec.vocab.rondelKeys.indexOf('grape')
+    const stoneIdx = featureSpec.vocab.rondelKeys.indexOf('stone')
+    const jokerIdx = featureSpec.vocab.rondelKeys.indexOf('joker')
+    expect(vec[yieldsOffset + grapeIdx]).toBe(0)
+    expect(vec[yieldsOffset + stoneIdx]).toBe(0)
+    expect(vec[yieldsOffset + jokerIdx]).toBe(0)
+  })
 })

--- a/game/src/encode.ts
+++ b/game/src/encode.ts
@@ -21,6 +21,7 @@ import {
   Tile,
 } from './types'
 import { clergyForColor, isPrior } from './board/player'
+import { take } from './board/rondel'
 
 // Stable enum orderings. New entries get APPENDED; never reorder, or saved
 // model weights will silently misalign with feature slots.
@@ -104,8 +105,13 @@ const FRAME_LEN =
   NEXT_USES.length + // one-hot
   BUILDINGS.length * 2 // usableBuildings + unusableBuildings
 
+// Yields max out at 10 on either arm-value table (see armValues in
+// board/rondel.ts). Normalize by this so the feature sits in [0, 1].
+const MAX_RONDEL_YIELD = 10
+
 const SHARED_LEN =
   RONDEL_KEYS.length + // normalized rondel deltas
+  RONDEL_KEYS.length + // normalized rondel yields (what each token gives if taken now)
   BUILDINGS.length + // still-available buildings mask
   MAX_PRICE_SLOTS * 2 + // plot + district prices (zero-padded)
   1 + // wonders remaining
@@ -264,6 +270,13 @@ const encodeRondelDeltas = (rondel: Rondel): number[] =>
     return delta / RONDEL_PERIOD
   })
 
+const encodeRondelYields = (rondel: Rondel, config: GameCommandConfigParams): number[] =>
+  RONDEL_KEYS.map((key) => {
+    const slot = rondel[key]
+    if (slot === undefined) return 0
+    return take(rondel.pointingBefore, slot, config) / MAX_RONDEL_YIELD
+  })
+
 const padPrices = (prices: readonly number[]): number[] =>
   range(0, MAX_PRICE_SLOTS).map((i) => prices[i] ?? 0)
 
@@ -271,6 +284,7 @@ const encodeShared = (state: GameStatePlaying): number[] => {
   const playerCountOneHot = range(0, MAX_PLAYERS).map((i) => (i === state.config.players - 1 ? 1 : 0))
   const sections: number[][] = [
     encodeRondelDeltas(state.rondel),
+    encodeRondelYields(state.rondel, state.config),
     mask(BUILDINGS, new Set(state.buildings)),
     padPrices(state.plotPurchasePrices),
     padPrices(state.districtPurchasePrices),


### PR DESCRIPTION
## Summary

Extends the rondel section of the state encoder so the model gets the **resource yield** each token would currently produce, not just its position on the rondel.

Before, the shared block only encoded each token's distance from `pointingBefore` (normalized delta mod 13). That's positionally accurate but isn't the signal a player actually uses to decide which rondel action to take — what matters is *"how much would I get if I take this now?"*, which is a non-linear function of distance (the `armValues` table in `board/rondel.ts`).

Now the shared block writes both:
- `shared[0..9]`: normalized deltas (unchanged)
- `shared[9..18]`: normalized yields — `take(pointingBefore, slot, config) / 10` per token

`FEATURE_LEN` grows by 9. Computed via the already-exported `take()` helper, so 2p-short and the default arm tables are both handled correctly. Tokens not yet on the rondel (`grape`/`stone`/`joker` when un-introduced) yield 0.

## Test plan

- [x] 2 new tests in `encode.test.ts` cover the yield slot for tokens at zero distance and at distance 3, plus the "not on rondel" case for `grape`/`stone`/`joker`
- [x] All 12 encode tests pass
- [x] Full suite: 1328 / 1328 pass
- [x] `npm run build` clean

https://claude.ai/code/session_012g8vWmxD3NfWGedLs6YqpK

---
_Generated by [Claude Code](https://claude.ai/code/session_012g8vWmxD3NfWGedLs6YqpK)_