### PR TITLE
chore(deps): migrate from fn-pcg to pcg

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "fast-shuffle": "6.1.1",
-    "fn-pcg": "2.0.1",
+    "pcg": "3.0.0",
     "ramda": "0.32.0",
     "ts-pattern": "5.9.0"
   },

--- a/game/src/__tests__/control.test.ts
+++ b/game/src/__tests__/control.test.ts
@@ -1,4 +1,4 @@
-import { PCGState } from 'fn-pcg/dist/types'
+import { PCGState } from 'pcg'
 import { assocPath } from 'ramda'
 import { control } from '../control'
 import {

--- a/game/src/__tests__/encode.test.ts
+++ b/game/src/__tests__/encode.test.ts
@@ -1,4 +1,4 @@
-import { PCGState } from 'fn-pcg/dist/types'
+import { PCGState } from 'pcg'
 import { encode, featureSpec, FEATURE_LEN } from '../encode'
 import {
   BuildingEnum,

--- a/game/src/board/frame/__tests__/addNeutralPlayer.test.ts
+++ b/game/src/board/frame/__tests__/addNeutralPlayer.test.ts
@@ -1,4 +1,4 @@
-import { createPcg32 } from 'fn-pcg'
+import { createPcg32 } from 'pcg'
 import { initialState } from '../../../state'
 import {
   Clergy,

--- a/game/src/buildings/__tests__/filialChurch.test.ts
+++ b/game/src/buildings/__tests__/filialChurch.test.ts
@@ -1,4 +1,4 @@
-import { createPcg32 } from 'fn-pcg'
+import { createPcg32 } from 'pcg'
 import {
   GameStatePlaying,
   GameStatusEnum,

--- a/game/src/buildings/__tests__/locutory.test.ts
+++ b/game/src/buildings/__tests__/locutory.test.ts
@@ -1,4 +1,4 @@
-import { createPcg32 } from 'fn-pcg'
+import { createPcg32 } from 'pcg'
 import { initialState } from '../../state'
 import {
   Clergy,

--- a/game/src/buildings/__tests__/roundTower.test.ts
+++ b/game/src/buildings/__tests__/roundTower.test.ts
@@ -1,4 +1,4 @@
-import { createPcg32 } from 'fn-pcg'
+import { createPcg32 } from 'pcg'
 import {
   Clergy,
   GameStatePlaying,

--- a/game/src/commands/start.ts
+++ b/game/src/commands/start.ts
@@ -1,5 +1,5 @@
 import { createShuffle } from 'fast-shuffle'
-import { createPcg32, randomInt } from 'fn-pcg'
+import { createPcg32, randomInt } from 'pcg'
 import { pipe, range } from 'ramda'
 import { nextFrame } from '../board/frame'
 import { districtPrices, makeLandscape, plotPrices } from '../board/landscape'

--- a/game/src/state.ts
+++ b/game/src/state.ts
@@ -1,4 +1,4 @@
-import { PCGState } from 'fn-pcg/dist/types'
+import { PCGState } from 'pcg'
 import { GameStateSetup, GameStatusEnum } from './types'
 
 export const initialState: GameStateSetup = {

--- a/game/src/types.ts
+++ b/game/src/types.ts
@@ -1,4 +1,4 @@
-import { PCGState } from 'fn-pcg/dist/types'
+import { PCGState } from 'pcg'
 
 export enum GameCommandEnum {
   CONFIG = 'CONFIG',


### PR DESCRIPTION
## Summary
- Swap `fn-pcg@2.0.1` for the rebranded `pcg@3.0.0` in `game/`.
- Update all imports: `fn-pcg` and `fn-pcg/dist/types` → `pcg` (the `PCGState` type now lives at the package root).
- Public API surface in use here (`createPcg32`, `randomInt`, `PCGState`) is compatible — drop-in swap.

## Test plan
- [x] `npm run build` in `game/` (tsc passes)
- [x] `npm test` in `game/` (1328 tests pass)
- [ ] No code changes needed in `server/` or `web/` — they consume `hathora-et-labora-game` as a published package and will pick up the new dep tree on the next release.

https://claude.ai/code/session_01MQVfPqaSkEoWYLzVokrdVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQVfPqaSkEoWYLzVokrdVu)_