### PR TITLE
MCP: OAuth 2.1 per-user authorization for /api/mcp

### DIFF
--- a/supabase/migrations/20260612120000_create_oauth_tables.sql
+++ b/supabase/migrations/20260612120000_create_oauth_tables.sql
@@ -1,0 +1,38 @@
+-- OAuth 2.1 authorization server tables. Used to authorize external MCP
+-- clients (e.g. Claude.ai connectors) to act on behalf of a Supabase user.
+-- We never store the raw code or token, only the sha-256 hash, hex-encoded.
+
+create table public.oauth_authorization_code (
+  code_hash text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  client_id text not null,
+  redirect_uri text not null,
+  scope text not null default 'play',
+  code_challenge text not null,
+  code_challenge_method text not null default 'S256',
+  resource text,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+create index oauth_authorization_code_expires_at_idx
+  on public.oauth_authorization_code (expires_at);
+
+create table public.oauth_access_token (
+  token_hash text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  client_id text not null,
+  scope text not null default 'play',
+  resource text,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz
+);
+create index oauth_access_token_user_id_idx
+  on public.oauth_access_token (user_id);
+create index oauth_access_token_expires_at_idx
+  on public.oauth_access_token (expires_at);
+
+-- RLS denies all by default; only the service-role client (used by the OAuth
+-- routes and the MCP handler) is allowed to read or write these tables.
+alter table public.oauth_authorization_code enable row level security;
+alter table public.oauth_access_token enable row level security;

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,0 +1,6 @@
+import next from 'eslint-config-next/core-web-vitals'
+
+export default [
+  { ignores: ['.next/**', 'node_modules/**', 'src/supabase.types.ts'] },
+  ...next,
+]

--- a/web/lint-staged.config.js
+++ b/web/lint-staged.config.js
@@ -1,7 +1,7 @@
 import path from 'path'
 
 const buildEslintCommand = (filenames) =>
-  `next lint --fix --file ${filenames.map((f) => path.relative(process.cwd(), f)).join(' --file ')}`
+  `eslint --fix ${filenames.map((f) => `"${path.relative(process.cwd(), f)}"`).join(' ')}`
 
 export default {
   '**/*.{json,html}': ['prettier --write'],

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,7 +40,7 @@
         "@types/ramda": "0.31.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
-        "eslint": "10.4.1",
+        "eslint": "9.39.4",
         "eslint-config-next": "16.2.7",
         "husky": "9.1.7",
         "lint-staged": "17.0.7",
@@ -425,18 +425,36 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/config-array/node_modules/debug": {
@@ -457,6 +475,19 @@
         }
       }
     },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/config-array/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -465,53 +496,159 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2989,13 +3126,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3813,9 +3943,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3932,6 +4062,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -4348,6 +4485,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -4427,6 +4574,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "11.1.0",
@@ -4975,30 +5142,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -5008,7 +5178,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -5016,7 +5187,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -5340,19 +5511,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5369,6 +5538,57 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/debug": {
@@ -5389,6 +5609,32 @@
         }
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5397,18 +5643,31 @@
       "license": "MIT"
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6113,6 +6372,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -6305,6 +6574,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -6839,6 +7125,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7164,6 +7473,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -7829,6 +8145,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8238,6 +8567,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -8992,6 +9331,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -9033,6 +9385,19 @@
         "@supabase/cli-linux-x64-musl": "2.105.0",
         "@supabase/cli-windows-arm64": "2.105.0",
         "@supabase/cli-windows-x64": "2.105.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/web/package.json
+++ b/web/package.json
@@ -46,7 +46,7 @@
     "@types/ramda": "0.31.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "eslint": "10.4.1",
+    "eslint": "9.39.4",
     "eslint-config-next": "16.2.7",
     "husky": "9.1.7",
     "lint-staged": "17.0.7",

--- a/web/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/web/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { issuer, SCOPE } from '@/oauth/config'
+
+// RFC 8414 OAuth 2.0 Authorization Server Metadata. Claude.ai's MCP connector
+// reads this to discover the authorize and token endpoints.
+export const GET = () => {
+  const iss = issuer()
+  return NextResponse.json(
+    {
+      issuer: iss,
+      authorization_endpoint: `${iss}/oauth/authorize`,
+      token_endpoint: `${iss}/oauth/token`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+      scopes_supported: [SCOPE],
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+    },
+  })

--- a/web/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/web/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,9 @@
+import { protectedResourceHandler, metadataCorsOptionsRequestHandler } from 'mcp-handler'
+import { issuer, resourceIdentifier } from '@/oauth/config'
+
+// RFC 9728 Protected Resource Metadata. Points MCP clients at our
+// authorization server when they receive a 401 from /api/mcp.
+export const GET = (req: Request) =>
+  protectedResourceHandler({ authServerUrls: [issuer()], resourceUrl: resourceIdentifier() })(req)
+
+export const OPTIONS = metadataCorsOptionsRequestHandler()

--- a/web/src/app/account/login/page.tsx
+++ b/web/src/app/account/login/page.tsx
@@ -8,6 +8,13 @@ import { login } from './actions'
 import { useSupabaseContext } from '@/context/SupabaseContext'
 import Link from 'next/link'
 
+// Only relative paths on this site, to prevent open-redirect via ?next=.
+const safeNext = (raw: string | null): string | null => {
+  if (!raw) return null
+  if (!raw.startsWith('/') || raw.startsWith('//')) return null
+  return raw
+}
+
 const Login = () => {
   const { redirectTo } = useSupabaseContext()
   const [response, setResponse] = useState<string>('')
@@ -19,17 +26,9 @@ const Login = () => {
       setResponse(error)
       return
     }
-    redirect(redirectTo)
+    const next = safeNext(new URLSearchParams(window.location.search).get('next'))
+    redirect(next ?? redirectTo)
   }
-
-  // const handleSkip = async (formData: FormData) => {
-  //   const error = await skip(formData, captchaToken)
-  //   if (error) {
-  //     setResponse(error)
-  //     return
-  //   }
-  //   redirect(redirectTo)
-  // }
 
   return (
     <>

--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -1,4 +1,3 @@
-import { createHash, timingSafeEqual } from 'node:crypto'
 import { createMcpHandler, withMcpAuth } from 'mcp-handler'
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
 import { z } from 'zod'
@@ -6,6 +5,13 @@ import { listMyGames } from '@/mcp/tools/listMyGames'
 import { getGame } from '@/mcp/tools/getGame'
 import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
 import { makeMove } from '@/mcp/tools/makeMove'
+import { errorResult } from '@/mcp/content'
+import { resolveAccessToken } from '@/oauth/store'
+
+const userIdFrom = (extra: { authInfo?: AuthInfo }): string | undefined =>
+  (extra.authInfo?.extra as { userId?: string } | undefined)?.userId
+
+const unauthenticated = () => errorResult('Unauthenticated: no user is bound to this MCP session.')
 
 const handler = createMcpHandler(
   (server) => {
@@ -13,7 +19,11 @@ const handler = createMcpHandler(
       'list_my_games',
       'List the Ora et Labora games this agent is seated in. Call this first to find a game, or with only_my_turn to check whether any game is waiting on you.',
       { only_my_turn: z.boolean().optional().describe('Only return games where it is currently your turn') },
-      async ({ only_my_turn }) => listMyGames({ onlyMyTurn: only_my_turn ?? false })
+      async ({ only_my_turn }, extra) => {
+        const userId = userIdFrom(extra)
+        if (!userId) return unauthenticated()
+        return listMyGames({ userId, onlyMyTurn: only_my_turn ?? false })
+      }
     )
     server.tool(
       'get_game',
@@ -25,7 +35,11 @@ const handler = createMcpHandler(
           .optional()
           .describe('summary (default) is a curated rendering; full is the raw engine state for debugging'),
       },
-      async ({ instance_id, detail }) => getGame({ instanceId: instance_id, detail: detail ?? 'summary' })
+      async ({ instance_id, detail }, extra) => {
+        const userId = userIdFrom(extra)
+        if (!userId) return unauthenticated()
+        return getGame({ userId, instanceId: instance_id, detail: detail ?? 'summary' })
+      }
     )
     server.tool(
       'get_legal_moves',
@@ -37,7 +51,11 @@ const handler = createMcpHandler(
           .optional()
           .describe('The tokens chosen so far, e.g. [] then ["BUILD"] then ["BUILD","G07"]'),
       },
-      async ({ instance_id, partial }) => getLegalMoves({ instanceId: instance_id, partial: partial ?? [] })
+      async ({ instance_id, partial }, extra) => {
+        const userId = userIdFrom(extra)
+        if (!userId) return unauthenticated()
+        return getLegalMoves({ userId, instanceId: instance_id, partial: partial ?? [] })
+      }
     )
     server.tool(
       'make_move',
@@ -46,20 +64,28 @@ const handler = createMcpHandler(
         instance_id: z.string().uuid().describe('The game instance id'),
         command: z.string().min(1).describe('A complete space-separated command'),
       },
-      async ({ instance_id, command }) => makeMove({ instanceId: instance_id, command })
+      async ({ instance_id, command }, extra) => {
+        const userId = userIdFrom(extra)
+        if (!userId) return unauthenticated()
+        return makeMove({ userId, instanceId: instance_id, command })
+      }
     )
   },
   {},
   { basePath: '/api' }
 )
 
-const sha256 = (value: string): Buffer => createHash('sha256').update(value).digest()
-
 const verifyToken = async (_req: Request, bearerToken?: string): Promise<AuthInfo | undefined> => {
-  const expected = process.env.MCP_AUTH_TOKEN
-  if (!expected || !bearerToken) return undefined
-  if (!timingSafeEqual(sha256(bearerToken), sha256(expected))) return undefined
-  return { token: bearerToken, scopes: ['play'], clientId: 'kennerspiel-agent' }
+  if (!bearerToken) return undefined
+  const resolved = await resolveAccessToken(bearerToken)
+  if (!resolved) return undefined
+  return {
+    token: bearerToken,
+    clientId: resolved.clientId,
+    scopes: resolved.scopes,
+    expiresAt: resolved.expiresAt,
+    extra: { userId: resolved.userId },
+  }
 }
 
 const authHandler = withMcpAuth(handler, verifyToken, { required: true })

--- a/web/src/app/oauth/authorize/actions.ts
+++ b/web/src/app/oauth/authorize/actions.ts
@@ -1,0 +1,57 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/utils/supabase/server'
+import { allowedRedirectUris, isKnownClientId, resourceIdentifier, SCOPE } from '@/oauth/config'
+import { issueAuthorizationCode } from '@/oauth/store'
+
+const fail = (redirectUri: string | null, state: string | null, error: string, description: string): never => {
+  if (!redirectUri) throw new Error(`${error}: ${description}`)
+  const url = new URL(redirectUri)
+  url.searchParams.set('error', error)
+  url.searchParams.set('error_description', description)
+  if (state) url.searchParams.set('state', state)
+  redirect(url.toString())
+}
+
+export const approve = async (formData: FormData) => {
+  const responseType = String(formData.get('response_type') ?? '')
+  const clientId = String(formData.get('client_id') ?? '')
+  const redirectUri = String(formData.get('redirect_uri') ?? '')
+  const state = (formData.get('state') as string | null) ?? null
+  const codeChallenge = String(formData.get('code_challenge') ?? '')
+  const codeChallengeMethod = String(formData.get('code_challenge_method') ?? 'S256')
+  const resource = (formData.get('resource') as string | null) ?? null
+  const scope = String(formData.get('scope') ?? SCOPE)
+
+  if (!redirectUri || !allowedRedirectUris().includes(redirectUri))
+    fail(null, state, 'invalid_request', 'redirect_uri is not allow-listed')
+  if (responseType !== 'code') fail(redirectUri, state, 'unsupported_response_type', 'Only code is supported')
+  if (!isKnownClientId(clientId)) fail(redirectUri, state, 'unauthorized_client', 'Unknown client_id')
+  if (!codeChallenge) fail(redirectUri, state, 'invalid_request', 'PKCE code_challenge is required')
+  if (codeChallengeMethod !== 'S256')
+    fail(redirectUri, state, 'invalid_request', 'Only code_challenge_method=S256 is supported')
+  if (resource && resource.replace(/\/$/, '') !== resourceIdentifier())
+    fail(redirectUri, state, 'invalid_target', 'resource does not match this server')
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) fail(redirectUri, state, 'access_denied', 'User is not authenticated')
+
+  const code = await issueAuthorizationCode({
+    user_id: user!.id,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallengeMethod,
+    resource: resource ?? null,
+  })
+
+  const url = new URL(redirectUri)
+  url.searchParams.set('code', code)
+  if (state) url.searchParams.set('state', state)
+  redirect(url.toString())
+}

--- a/web/src/app/oauth/authorize/page.tsx
+++ b/web/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,77 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/utils/supabase/server'
+import { allowedRedirectUris, isKnownClientId, resourceIdentifier } from '@/oauth/config'
+import { approve } from './actions'
+
+type AuthorizeParams = {
+  response_type?: string
+  client_id?: string
+  redirect_uri?: string
+  scope?: string
+  state?: string
+  code_challenge?: string
+  code_challenge_method?: string
+  resource?: string
+}
+
+const renderError = (message: string) => (
+  <>
+    <h1>Authorization error</h1>
+    <p>{message}</p>
+  </>
+)
+
+const validate = (params: AuthorizeParams): { error: string } | { ok: true } => {
+  if (params.response_type !== 'code') return { error: 'Only response_type=code is supported.' }
+  if (!params.client_id || !isKnownClientId(params.client_id)) return { error: 'Unknown client_id.' }
+  if (!params.redirect_uri || !allowedRedirectUris().includes(params.redirect_uri))
+    return { error: 'redirect_uri is not allow-listed for this client.' }
+  if (!params.code_challenge) return { error: 'Missing PKCE code_challenge (S256 required).' }
+  if (params.code_challenge_method && params.code_challenge_method !== 'S256')
+    return { error: 'Only code_challenge_method=S256 is supported.' }
+  if (params.resource && params.resource.replace(/\/$/, '') !== resourceIdentifier())
+    return { error: 'resource indicator does not match this server.' }
+  return { ok: true }
+}
+
+const Authorize = async ({ searchParams }: { searchParams: Promise<AuthorizeParams> }) => {
+  const params = await searchParams
+  const check = validate(params)
+  if ('error' in check) return renderError(check.error)
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    const here = new URL('/oauth/authorize', 'https://placeholder.local')
+    for (const [k, v] of Object.entries(params)) if (v) here.searchParams.set(k, v)
+    redirect(`/account/login?next=${encodeURIComponent(here.pathname + here.search)}`)
+  }
+
+  // Make sure the profile row exists; tools rely on profile_id == auth user id.
+  await supabase.from('profile').upsert({ id: user.id, email: user.email ?? '' })
+
+  return (
+    <>
+      <h1>Authorize MCP access</h1>
+      <p>
+        An MCP client wants to play Ora et Labora on your behalf as <strong>{user.email}</strong>.
+      </p>
+      <p>Granting access will let this client:</p>
+      <ul>
+        <li>List the games you are seated in</li>
+        <li>Read the board state of those games</li>
+        <li>Make moves in games where it is your turn</li>
+      </ul>
+      <form action={approve}>
+        {Object.entries(params).map(([k, v]) => v && <input key={k} type="hidden" name={k} value={v} />)}
+        <button className="primary" type="submit">
+          Authorize
+        </button>
+      </form>
+    </>
+  )
+}
+
+export default Authorize

--- a/web/src/app/oauth/token/route.ts
+++ b/web/src/app/oauth/token/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import { ACCESS_TOKEN_TTL_SECONDS, resourceIdentifier, verifyClientCredentials } from '@/oauth/config'
+import { consumeAuthorizationCode, issueAccessToken, verifyPkce } from '@/oauth/store'
+
+const errorResponse = (status: number, error: string, description?: string) =>
+  NextResponse.json(
+    { error, ...(description ? { error_description: description } : {}) },
+    { status, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' } }
+  )
+
+const parseClientCredentials = (
+  req: Request,
+  body: URLSearchParams
+): { clientId: string; clientSecret: string } | { error: string } => {
+  const authHeader = req.headers.get('authorization')
+  if (authHeader?.toLowerCase().startsWith('basic ')) {
+    try {
+      const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf-8')
+      const idx = decoded.indexOf(':')
+      if (idx < 0) return { error: 'Malformed Basic credentials' }
+      return {
+        clientId: decodeURIComponent(decoded.slice(0, idx)),
+        clientSecret: decodeURIComponent(decoded.slice(idx + 1)),
+      }
+    } catch {
+      return { error: 'Malformed Basic credentials' }
+    }
+  }
+  const clientId = body.get('client_id')
+  const clientSecret = body.get('client_secret')
+  if (!clientId || !clientSecret) return { error: 'Missing client credentials' }
+  return { clientId, clientSecret }
+}
+
+export const POST = async (req: Request) => {
+  const raw = await req.text()
+  const body = new URLSearchParams(raw)
+
+  const creds = parseClientCredentials(req, body)
+  if ('error' in creds) return errorResponse(401, 'invalid_client', creds.error)
+  if (!verifyClientCredentials(creds.clientId, creds.clientSecret))
+    return errorResponse(401, 'invalid_client', 'client_id / client_secret mismatch')
+
+  const grantType = body.get('grant_type')
+  if (grantType !== 'authorization_code')
+    return errorResponse(400, 'unsupported_grant_type', `grant_type=${grantType} is not supported`)
+
+  const code = body.get('code')
+  const redirectUri = body.get('redirect_uri')
+  const codeVerifier = body.get('code_verifier')
+  if (!code) return errorResponse(400, 'invalid_request', 'Missing code')
+  if (!redirectUri) return errorResponse(400, 'invalid_request', 'Missing redirect_uri')
+  if (!codeVerifier) return errorResponse(400, 'invalid_request', 'Missing code_verifier')
+
+  const consumed = await consumeAuthorizationCode(code)
+  if ('error' in consumed) return errorResponse(400, 'invalid_grant', consumed.error)
+
+  if (consumed.client_id !== creds.clientId)
+    return errorResponse(400, 'invalid_grant', 'Code was issued to a different client')
+  if (consumed.redirect_uri !== redirectUri)
+    return errorResponse(400, 'invalid_grant', 'redirect_uri does not match the authorization request')
+  if (!verifyPkce(codeVerifier, consumed.code_challenge, consumed.code_challenge_method))
+    return errorResponse(400, 'invalid_grant', 'PKCE verification failed')
+
+  const { token, expiresIn } = await issueAccessToken({
+    userId: consumed.user_id,
+    clientId: consumed.client_id,
+    scope: consumed.scope,
+    resource: consumed.resource ?? resourceIdentifier(),
+  })
+
+  return NextResponse.json(
+    {
+      access_token: token,
+      token_type: 'Bearer',
+      expires_in: expiresIn ?? ACCESS_TOKEN_TTL_SECONDS,
+      scope: consumed.scope,
+    },
+    { headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' } }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    },
+  })

--- a/web/src/mcp/content.ts
+++ b/web/src/mcp/content.ts
@@ -13,9 +13,3 @@ export const errorResult = (message: string): ToolResult => ({
   isError: true,
   content: [{ type: 'text', text: message }],
 })
-
-export const agentProfileId = (): string => {
-  const id = process.env.AGENT_PROFILE_ID
-  if (!id) throw new Error('AGENT_PROFILE_ID is not configured')
-  return id
-}

--- a/web/src/mcp/tools/fetchInstance.ts
+++ b/web/src/mcp/tools/fetchInstance.ts
@@ -1,7 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import { Database, Tables } from '@/supabase.types'
 import { createServiceClient } from '@/utils/supabase/service'
-import { agentProfileId } from '../content'
 
 type FetchedInstance = {
   supabase: SupabaseClient<Database>
@@ -10,11 +9,14 @@ type FetchedInstance = {
   me?: Tables<'entrant'>
 }
 
-export const fetchInstance = async (instanceId: string): Promise<FetchedInstance | { error: string }> => {
+export const fetchInstance = async (
+  userId: string,
+  instanceId: string
+): Promise<FetchedInstance | { error: string }> => {
   const supabase = createServiceClient()
   const { data, error } = await supabase.from('instance').select('*, entrant(*)').eq('id', instanceId).single()
   if (error || data === null) return { error: `Failed to fetch instance ${instanceId}: ${error?.message}` }
   const { entrant: entrants, ...instance } = data
-  const me = entrants.find((entrant) => entrant.profile_id === agentProfileId())
+  const me = entrants.find((entrant) => entrant.profile_id === userId)
   return { supabase, instance, entrants, me }
 }

--- a/web/src/mcp/tools/getGame.ts
+++ b/web/src/mcp/tools/getGame.ts
@@ -4,13 +4,15 @@ import { errorResult, jsonResult, ToolResult } from '../content'
 import { fetchInstance } from './fetchInstance'
 
 export const getGame = async ({
+  userId,
   instanceId,
   detail,
 }: {
+  userId: string
   instanceId: string
   detail: 'summary' | 'full'
 }): Promise<ToolResult> => {
-  const fetched = await fetchInstance(instanceId)
+  const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
   const { instance, entrants, me } = fetched
 

--- a/web/src/mcp/tools/getLegalMoves.ts
+++ b/web/src/mcp/tools/getLegalMoves.ts
@@ -7,13 +7,15 @@ import { fetchInstance } from './fetchInstance'
 const MAX_COMPLETIONS = 200
 
 export const getLegalMoves = async ({
+  userId,
   instanceId,
   partial,
 }: {
+  userId: string
   instanceId: string
   partial: string[]
 }): Promise<ToolResult> => {
-  const fetched = await fetchInstance(instanceId)
+  const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
   const { instance, me } = fetched
 

--- a/web/src/mcp/tools/listMyGames.ts
+++ b/web/src/mcp/tools/listMyGames.ts
@@ -1,14 +1,20 @@
 import { GameStatusEnum } from 'hathora-et-labora-game/dist/types'
 import { createServiceClient } from '@/utils/supabase/service'
 import { activePlayerColor, asPlaying, engineColorToEntrantColor, replay } from '../engine'
-import { agentProfileId, errorResult, jsonResult, ToolResult } from '../content'
+import { errorResult, jsonResult, ToolResult } from '../content'
 
-export const listMyGames = async ({ onlyMyTurn }: { onlyMyTurn: boolean }): Promise<ToolResult> => {
+export const listMyGames = async ({
+  userId,
+  onlyMyTurn,
+}: {
+  userId: string
+  onlyMyTurn: boolean
+}): Promise<ToolResult> => {
   const supabase = createServiceClient()
   const { data, error } = await supabase
     .from('entrant')
     .select('color, instance(id, commands, updated_at)')
-    .eq('profile_id', agentProfileId())
+    .eq('profile_id', userId)
   if (error) return errorResult(`Failed to list games: ${error.message}`)
 
   const games = (data ?? [])

--- a/web/src/mcp/tools/makeMove.ts
+++ b/web/src/mcp/tools/makeMove.ts
@@ -5,13 +5,15 @@ import { errorResult, jsonResult, ToolResult } from '../content'
 import { fetchInstance } from './fetchInstance'
 
 export const makeMove = async ({
+  userId,
   instanceId,
   command,
 }: {
+  userId: string
   instanceId: string
   command: string
 }): Promise<ToolResult> => {
-  const fetched = await fetchInstance(instanceId)
+  const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
   const { supabase, instance, me } = fetched
 

--- a/web/src/oauth/config.ts
+++ b/web/src/oauth/config.ts
@@ -1,0 +1,38 @@
+// OAuth 2.1 authorization-server configuration. Both the authorize page and
+// the token endpoint read from here so they agree on what counts as a valid
+// client + redirect.
+
+export const ACCESS_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30
+export const AUTHORIZATION_CODE_TTL_SECONDS = 60 * 10
+export const SCOPE = 'play'
+
+export const issuer = (): string => {
+  const fromEnv = process.env.OAUTH_ISSUER
+  if (fromEnv) return fromEnv.replace(/\/$/, '')
+  const site = process.env.NEXT_PUBLIC_SITE_URL
+  if (site) return site.replace(/\/$/, '')
+  throw new Error('OAUTH_ISSUER (or NEXT_PUBLIC_SITE_URL) is not configured')
+}
+
+export const resourceIdentifier = (): string => `${issuer()}/api/mcp`
+
+export const allowedRedirectUris = (): string[] => {
+  const raw = process.env.OAUTH_REDIRECT_URIS
+  if (!raw) throw new Error('OAUTH_REDIRECT_URIS is not configured')
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+export const verifyClientCredentials = (clientId: string, clientSecret?: string): boolean => {
+  const expectedId = process.env.OAUTH_CLIENT_ID
+  const expectedSecret = process.env.OAUTH_CLIENT_SECRET
+  if (!expectedId || !expectedSecret) throw new Error('OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET not configured')
+  return clientId === expectedId && clientSecret === expectedSecret
+}
+
+export const isKnownClientId = (clientId: string): boolean => {
+  const expectedId = process.env.OAUTH_CLIENT_ID
+  return Boolean(expectedId) && clientId === expectedId
+}

--- a/web/src/oauth/store.ts
+++ b/web/src/oauth/store.ts
@@ -1,0 +1,130 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import { ACCESS_TOKEN_TTL_SECONDS, AUTHORIZATION_CODE_TTL_SECONDS } from './config'
+
+// The OAuth tables are not in the generated Database type, so we use a plain
+// service-role client here. All access bypasses RLS and is enforced by code.
+const oauthClient = () =>
+  createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+const hash = (value: string): string => createHash('sha256').update(value).digest('hex')
+
+const base64url = (buf: Buffer): string =>
+  buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+
+const randomToken = (bytes = 32): string => base64url(randomBytes(bytes))
+
+export type AuthorizationCodeRecord = {
+  user_id: string
+  client_id: string
+  redirect_uri: string
+  scope: string
+  code_challenge: string
+  code_challenge_method: string
+  resource: string | null
+}
+
+export const issueAuthorizationCode = async (record: AuthorizationCodeRecord): Promise<string> => {
+  const code = randomToken()
+  const expiresAt = new Date(Date.now() + AUTHORIZATION_CODE_TTL_SECONDS * 1000).toISOString()
+  const { error } = await oauthClient()
+    .from('oauth_authorization_code')
+    .insert({ ...record, code_hash: hash(code), expires_at: expiresAt })
+  if (error) throw new Error(`Failed to issue authorization code: ${error.message}`)
+  return code
+}
+
+export const consumeAuthorizationCode = async (code: string): Promise<AuthorizationCodeRecord | { error: string }> => {
+  const client = oauthClient()
+  const { data, error } = await client
+    .from('oauth_authorization_code')
+    .delete()
+    .eq('code_hash', hash(code))
+    .select()
+    .maybeSingle()
+  if (error) return { error: error.message }
+  if (!data) return { error: 'Authorization code is unknown or already used' }
+  if (new Date(data.expires_at).getTime() < Date.now()) return { error: 'Authorization code has expired' }
+  return {
+    user_id: data.user_id,
+    client_id: data.client_id,
+    redirect_uri: data.redirect_uri,
+    scope: data.scope,
+    code_challenge: data.code_challenge,
+    code_challenge_method: data.code_challenge_method,
+    resource: data.resource,
+  }
+}
+
+export type IssuedAccessToken = {
+  token: string
+  expiresIn: number
+}
+
+export const issueAccessToken = async ({
+  userId,
+  clientId,
+  scope,
+  resource,
+}: {
+  userId: string
+  clientId: string
+  scope: string
+  resource: string | null
+}): Promise<IssuedAccessToken> => {
+  const token = randomToken(48)
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_TTL_SECONDS * 1000).toISOString()
+  const { error } = await oauthClient()
+    .from('oauth_access_token')
+    .insert({
+      token_hash: hash(token),
+      user_id: userId,
+      client_id: clientId,
+      scope,
+      resource,
+      expires_at: expiresAt,
+    })
+  if (error) throw new Error(`Failed to issue access token: ${error.message}`)
+  return { token, expiresIn: ACCESS_TOKEN_TTL_SECONDS }
+}
+
+export type ResolvedAccessToken = {
+  userId: string
+  clientId: string
+  scopes: string[]
+  expiresAt: number
+  resource: string | null
+}
+
+export const resolveAccessToken = async (token: string): Promise<ResolvedAccessToken | undefined> => {
+  const client = oauthClient()
+  const { data, error } = await client
+    .from('oauth_access_token')
+    .select('user_id, client_id, scope, expires_at, resource')
+    .eq('token_hash', hash(token))
+    .maybeSingle()
+  if (error || !data) return undefined
+  const expiresAtMs = new Date(data.expires_at).getTime()
+  if (expiresAtMs < Date.now()) return undefined
+  // Best-effort last_used_at update; ignore failures.
+  void client
+    .from('oauth_access_token')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('token_hash', hash(token))
+  return {
+    userId: data.user_id,
+    clientId: data.client_id,
+    scopes: data.scope.split(' ').filter(Boolean),
+    expiresAt: Math.floor(expiresAtMs / 1000),
+    resource: data.resource,
+  }
+}
+
+export const verifyPkce = (codeVerifier: string, codeChallenge: string, method: string): boolean => {
+  if (method !== 'S256') return false
+  const expected = base64url(createHash('sha256').update(codeVerifier).digest())
+  if (expected.length !== codeChallenge.length) return false
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(codeChallenge))
+}


### PR DESCRIPTION
## Summary
- Replace the single shared `MCP_AUTH_TOKEN` with an OAuth 2.1 (auth-code + PKCE) flow so Claude.ai can connect via its native connector UI.
- Each Claude.ai user authorizes with their existing Supabase account; MCP tools (`list_my_games`, `get_game`, `get_legal_moves`, `make_move`) now act as that user instead of a single shared agent profile (`AGENT_PROFILE_ID` is no longer used).
- Also unblocks the pre-commit hook for Next 16: migrates the legacy `.eslintrc` to a flat `eslint.config.mjs`, pins `eslint` to 9.x (eslint-config-next 16 / eslint-plugin-react don't yet support eslint 10), and points `lint-staged` at `eslint` directly instead of the removed `next lint --fix`.

## What's added
- `supabase/migrations/20260612120000_create_oauth_tables.sql` — `oauth_authorization_code` and `oauth_access_token` tables (we store only sha-256 of code/token).
- `web/src/app/.well-known/oauth-authorization-server` — RFC 8414 metadata.
- `web/src/app/.well-known/oauth-protected-resource` — RFC 9728 metadata (via `mcp-handler`'s `protectedResourceHandler`).
- `web/src/app/oauth/authorize` — consent page; requires a Supabase session (redirects to `/account/login?next=…`), shows what the client is asking for, and issues a single-use authorization code on approval.
- `web/src/app/oauth/token` — token endpoint. Validates client creds (Basic or form), consumes the code, verifies PKCE (S256), and mints a 30-day access token.
- `web/src/oauth/{config,store}.ts` — env-driven config and token issuance/resolution helpers.
- `web/src/app/api/[transport]/route.ts` — `verifyToken` now resolves bearer tokens against `oauth_access_token` and threads the user id into each tool via `AuthInfo.extra.userId`.

## New env vars
| Var | Purpose |
|---|---|
| `OAUTH_ISSUER` (or `NEXT_PUBLIC_SITE_URL`) | Base URL for issuer / endpoints |
| `OAUTH_CLIENT_ID` | Static client id (pasted into Claude.ai's connector UI) |
| `OAUTH_CLIENT_SECRET` | Static client secret |
| `OAUTH_REDIRECT_URIS` | Comma-separated allow-list of redirect URIs |

`AGENT_PROFILE_ID` and `MCP_AUTH_TOKEN` are no longer used and can be removed from Vercel.

## Test plan
- [ ] Apply migration: `supabase db push` (or via Supabase dashboard).
- [ ] Set the four new env vars in Vercel preview/prod, deploy.
- [ ] `curl https://kennerspiel.com/.well-known/oauth-authorization-server` returns valid metadata.
- [ ] `curl https://kennerspiel.com/.well-known/oauth-protected-resource` returns valid metadata.
- [ ] In Claude.ai → Connectors, add a custom connector pointed at `https://kennerspiel.com/api/mcp` with the configured client id/secret; complete the consent flow.
- [ ] Verify the connector lists *your* games (not the legacy agent's) and can make a move on your behalf.
- [ ] Confirm an old MCP_AUTH_TOKEN-style request returns 401 with a `WWW-Authenticate` header pointing at the resource metadata.

## Notes / out of scope
- The `mcp-server-design.md` doc still describes the single-agent model and will be updated separately.
- No dynamic client registration (DCR) — the Claude.ai UI accepts a static client id/secret, so we don't need `/oauth/register` yet.
- No refresh tokens — access tokens are long-lived (30d); user re-authorizes on expiry.

https://claude.ai/code/session_01BMeHWGVWwn2E47t7cYp3uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMeHWGVWwn2E47t7cYp3uu)_