### PR TITLE
MCP server: add join_game tool to claim a lobby seat

### DIFF
--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -5,6 +5,7 @@ import { listMyGames } from '@/mcp/tools/listMyGames'
 import { getGame } from '@/mcp/tools/getGame'
 import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
 import { makeMove } from '@/mcp/tools/makeMove'
+import { joinGame } from '@/mcp/tools/joinGame'
 import { errorResult } from '@/mcp/content'
 import { resolveAccessToken } from '@/oauth/store'
 
@@ -55,6 +56,24 @@ const handler = createMcpHandler(
         const userId = userIdFrom(extra)
         if (!userId) return unauthenticated()
         return getLegalMoves({ userId, instanceId: instance_id, partial: partial ?? [] })
+      }
+    )
+    server.tool(
+      'join_game',
+      'Claim a seat in an Ora et Labora lobby that has not yet started. Pass either the game instance id or its URL (e.g. https://kennerspiel.com/instance/<uuid>) along with the color you want to play. If you already have a seat in that game, your color is updated. Wait for the human to choose the variant and press START on the website before calling get_game.',
+      {
+        instance: z
+          .string()
+          .min(1)
+          .describe(
+            'Either the game instance UUID or a URL containing it, e.g. https://kennerspiel.com/instance/<uuid>'
+          ),
+        color: z.enum(['red', 'green', 'blue', 'white']).describe('Which seat color to claim'),
+      },
+      async ({ instance, color }, extra) => {
+        const userId = userIdFrom(extra)
+        if (!userId) return unauthenticated()
+        return joinGame({ userId, instanceRef: instance, color })
       }
     )
     server.tool(

--- a/web/src/mcp/tools/joinGame.ts
+++ b/web/src/mcp/tools/joinGame.ts
@@ -1,0 +1,74 @@
+import { Enums } from '@/supabase.types'
+import { createServiceClient } from '@/utils/supabase/service'
+import { errorResult, jsonResult, ToolResult } from '../content'
+
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+const parseInstanceRef = (raw: string): string | undefined => raw.match(UUID_PATTERN)?.[0]
+
+export const joinGame = async ({
+  userId,
+  instanceRef,
+  color,
+}: {
+  userId: string
+  instanceRef: string
+  color: Enums<'color'>
+}): Promise<ToolResult> => {
+  const instanceId = parseInstanceRef(instanceRef)
+  if (!instanceId) return errorResult(`Could not parse a game instance id from "${instanceRef}".`)
+
+  const supabase = createServiceClient()
+
+  const { data: instance, error: instanceError } = await supabase
+    .from('instance')
+    .select('id, commands, entrant(id, profile_id, color)')
+    .eq('id', instanceId)
+    .single()
+  if (instanceError || !instance) return errorResult(`Instance ${instanceId} not found.`)
+
+  // The game lobby (one CONFIG command, then START to begin) accepts new
+  // entrants until START is appended. Refuse to mutate seats after that.
+  const hasStarted = instance.commands.some((c) => c.startsWith('START '))
+  if (hasStarted) return errorResult('Game has already started; seats can no longer change.')
+
+  const conflict = instance.entrant.find((e) => e.color === color && e.profile_id !== userId)
+  if (conflict) return errorResult(`Color ${color} is already taken in this game.`)
+
+  const { error: upsertError } = await supabase
+    .from('entrant')
+    .upsert(
+      { instance_id: instanceId, profile_id: userId, color, updated_at: new Date().toISOString() },
+      { onConflict: 'instance_id, profile_id' }
+    )
+  if (upsertError) return errorResult(`Failed to claim seat: ${upsertError.message}`)
+
+  // Mirror the website lobby: if there's already a CONFIG command, rewrite its
+  // player count to match the new seat total so START will accept it.
+  const configIdx = instance.commands.findIndex((c) => c.startsWith('CONFIG '))
+  if (configIdx >= 0) {
+    const { count: seatCount } = await supabase
+      .from('entrant')
+      .select('id', { count: 'exact', head: true })
+      .eq('instance_id', instanceId)
+    if (seatCount && seatCount > 0) {
+      const oldTokens = instance.commands[configIdx].split(' ')
+      const newCommands = [...instance.commands]
+      newCommands[configIdx] = ['CONFIG', String(seatCount), oldTokens[2], oldTokens[3]].join(' ')
+      await supabase
+        .from('instance')
+        .update({ commands: newCommands, updated_at: new Date().toISOString() })
+        .eq('id', instanceId)
+    }
+  }
+
+  const { data: seats } = await supabase.from('entrant').select('color, profile_id').eq('instance_id', instanceId)
+
+  return jsonResult({
+    ok: true,
+    instance_id: instanceId,
+    my_color: color,
+    seats: (seats ?? []).map((s) => ({ color: s.color, is_me: s.profile_id === userId })),
+    note: 'Seat claimed. Wait for the lobby owner to choose the mode/variant and press START on the website.',
+  })
+}


### PR DESCRIPTION
## Summary
Adds a fifth MCP tool, `join_game`, so the agent can claim a seat in a lobby without the human having to add it manually through the website.

Input:
- `instance` — either the bare UUID (`580cf4d9-…`) or any URL containing one (`https://kennerspiel.com/instance/580cf4d9-…`).
- `color` — `red`, `green`, `blue`, or `white`.

Behavior mirrors the website lobby's join action (`web/src/app/instance/[slug]/actions.ts`):
- Refuses to mutate seats once `START` has been appended.
- Rejects an already-taken color (when held by a different user).
- Idempotent for the caller — calling it again with the same color is a no-op; calling with a different color swaps the caller's seat.
- If a `CONFIG` command already exists, rewrites its player count so `START` will still validate.

The reply tells the model to **stop and wait** for the human to choose the variant and press `START` before calling `get_game`.

## Test plan
- [ ] Create a lobby on the website, share its URL with the agent in Claude chat.
- [ ] Ask the agent to "join as blue" — verify it picks up the seat in the website UI.
- [ ] Ask the agent to "actually take green" — verify the seat swaps.
- [ ] Press START on the website, then ask the agent to `list_my_games` / `get_game` — verify it sees the live state.
- [ ] Try to join a game where you've already pressed START — should return an error.
- [ ] Try to take a color another human already holds — should return an error.

https://claude.ai/code/session_01BMeHWGVWwn2E47t7cYp3uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMeHWGVWwn2E47t7cYp3uu)_