### PR TITLE
fix: correct rondel wedge index direction for token placement

### DIFF
--- a/web/src/components/rondel/tokenPositions.ts
+++ b/web/src/components/rondel/tokenPositions.ts
@@ -29,8 +29,8 @@ export const isGrapeUsed = (config: GameCommandConfigParams): boolean =>
     .otherwise(() => false)
 
 export const getWedgePolygon = (pos: number): [number, number][] => {
-  const a = (12 - pos + N_WEDGES) % N_WEDGES
-  const b = (13 - pos + N_WEDGES) % N_WEDGES
+  const a = pos % N_WEDGES
+  const b = (pos + 1) % N_WEDGES
   return [
     wedgePoint(a, TOKEN_INNER_RADIUS),
     wedgePoint(a, TOKEN_OUTER_RADIUS),


### PR DESCRIPTION
## Summary

- Tokens were appearing in the horizontally-mirrored wedge of where they should be
- Root cause: `getWedgePolygon` used `(12 - pos)` and `(13 - pos)` as point indices, which is correct only if `points[]` increases clockwise — but it increases **counterclockwise** (due to the `-sin` in the x formula), while `oraDeg()` is clockwise
- Fix: use `pos` and `(pos + 1) % 13` directly as the start/end indices

## Test plan

- [ ] Load a game and verify tokens appear in the correct wedge (matching the arm's position labels)
- [ ] Advance the rondel and confirm tokens move to the right wedge after each step
- [ ] All 17 unit tests still pass (`pnpm test`)

https://claude.ai/code/session_01C313HZnPWCkyrux9gGZjPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01C313HZnPWCkyrux9gGZjPF)_