### PR TITLE
fix: re-enable game d.ts emit and unblock vercel

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.0",
+  "version": "0.20.1",
   "name": "hathora-et-labora-game",
   "type": "module",
   "sideEffects": false,
@@ -39,7 +39,8 @@
     "fast-shuffle": "6.2.0",
     "pcg": "3.0.0",
     "ramda": "0.32.0",
-    "ts-pattern": "5.9.0"
+    "ts-pattern": "5.9.0",
+    "ts-toolbelt": "9.6.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/game/pnpm-lock.yaml
+++ b/game/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ts-pattern:
         specifier: 5.9.0
         version: 5.9.0
+      ts-toolbelt:
+        specifier: 9.6.0
+        version: 9.6.0
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1

--- a/game/tsconfig.json
+++ b/game/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "target": "es2022",
     "types": ["node"],
-    "declaration": false,
+    "declaration": true,
     "sourceMap": true,
     "module": "preserve",
     "moduleResolution": "Bundler"

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "dotenv": "17.4.2",
     "flags": "4.1.0",
     "form-urlencoded": "6.1.7",
-    "hathora-et-labora-game": "0.20.0",
+    "hathora-et-labora-game": "0.19.1",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "mcp-handler": "1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 6.1.7
         version: 6.1.7
       hathora-et-labora-game:
-        specifier: 0.20.0
-        version: 0.20.0
+        specifier: 0.19.1
+        version: 0.19.1
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -1805,9 +1805,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-shuffle@6.2.0:
-    resolution: {integrity: sha512-Y7MexltTgkdI2UzeRx7zVIWiHSuQ41dD+2PPwukkIZW2b1wCSaciISyKNSKFVW6ImkH+QQivlDsmY552EO22Ig==}
-    engines: {node: '>=14'}
+  fast-shuffle@6.1.1:
+    resolution: {integrity: sha512-HPxFJxEi18KPmVQuK5Hi5l4KSl3u50jtaxseRrPqrxewqfvU+sTPTaUpP33Hj+NdJoLuJP5ipx3ybTr+fa6dEw==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
@@ -1866,6 +1865,10 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fn-pcg@2.0.1:
+    resolution: {integrity: sha512-a7OHtEqIk4WRufEjqGepbX3YATjU6AXnjQt0HuPqjVe6YGIc6+9KxDqhPsUIWOGBUPGmvKCCQxguyQJchg0Gog==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -1971,8 +1974,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hathora-et-labora-game@0.20.0:
-    resolution: {integrity: sha512-QHkxMECPfHegIbn4/ksH2+foQFBi6q/1J76n5u2Sx/pFJOG9j0eAkExCBAffDHw28PxVccvsGv6DAvzbKC/GAg==}
+  hathora-et-labora-game@0.19.1:
+    resolution: {integrity: sha512-QTZgT12+1l8++nANlcczLoQr8ZNztPjkHR0jlEYtk1VPl1BC3VjuQonLBuv8kRFswxMiBFG2E+wcsgEkWxE3xg==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2269,6 +2272,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2469,9 +2475,8 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
-  pcg@3.0.0:
-    resolution: {integrity: sha512-lHETDr3c//q4xs0iZk9+LRFgmvjLtaUDIE3ztE2KN4IhwyHLcJ3H5VBv93SGop1XHZalC1UFSwoJepoZSMSVLQ==}
-    engines: {node: '>=18'}
+  pcg@1.1.0:
+    resolution: {integrity: sha512-S+bYs8CV6l2lj01PRN4g9EiHDktcXJKD9FdE/FqpdXSuy1zImsRq8A8T5UK6gkXdI9O5YFdAgH40uPoR8Bk8aQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2532,6 +2537,15 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  ramda@0.29.0:
+    resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
+
+  ramda@0.29.1:
+    resolution: {integrity: sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==}
+
+  ramda@0.30.1:
+    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
 
   ramda@0.32.0:
     resolution: {integrity: sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==}
@@ -2813,6 +2827,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-pattern@5.7.0:
+    resolution: {integrity: sha512-0/FvIG4g3kNkYgbNwBBW5pZBkfpeYQnH+2AA3xmjkCAit/DSDPKmgwC3fKof4oYUq6gupClVOJlFl+939VRBMg==}
 
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
@@ -4690,7 +4707,7 @@ snapshots:
       eslint: 10.5.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0))(eslint@10.5.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.5.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0))(eslint@10.5.0))(eslint@10.5.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.5.0)
       eslint-plugin-react: 7.37.5(eslint@10.5.0)
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0)
@@ -4723,7 +4740,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.5.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0))(eslint@10.5.0))(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4738,7 +4755,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.5.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0))(eslint@10.5.0))(eslint@10.5.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4945,9 +4962,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-shuffle@6.2.0:
+  fast-shuffle@6.1.1:
     dependencies:
-      pcg: 3.0.0
+      pcg: 1.1.0
 
   fast-uri@3.1.2: {}
 
@@ -4998,6 +5015,11 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  fn-pcg@2.0.1:
+    dependencies:
+      long: 5.2.3
+      ramda: 0.29.0
 
   for-each@0.3.5:
     dependencies:
@@ -5101,12 +5123,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hathora-et-labora-game@0.20.0:
+  hathora-et-labora-game@0.19.1:
     dependencies:
-      fast-shuffle: 6.2.0
-      pcg: 3.0.0
-      ramda: 0.32.0
-      ts-pattern: 5.9.0
+      fast-shuffle: 6.1.1
+      fn-pcg: 2.0.1
+      ramda: 0.30.1
+      ts-pattern: 5.7.0
 
   hermes-estree@0.25.1: {}
 
@@ -5414,6 +5436,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  long@5.2.3: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5605,7 +5629,10 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
-  pcg@3.0.0: {}
+  pcg@1.1.0:
+    dependencies:
+      long: 5.2.3
+      ramda: 0.29.1
 
   picocolors@1.1.1: {}
 
@@ -5657,6 +5684,12 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
+
+  ramda@0.29.0: {}
+
+  ramda@0.29.1: {}
+
+  ramda@0.30.1: {}
 
   ramda@0.32.0: {}
 
@@ -6040,6 +6073,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-pattern@5.7.0: {}
 
   ts-pattern@5.9.0: {}
 


### PR DESCRIPTION
## Summary

Vercel deploys were silently dropping pushes earlier today; an empty commit (`f363a30`) confirmed the webhook still works — the real problem was that `hathora-et-labora-game@0.20.0` was published without `.d.ts` files (declaration emit had been disabled in `06f1db5` to work around TS2883 from `@types/ramda`'s `Curry` references via the `.pnpm` symlink path). The web build fails because ~75 files import from `hathora-et-labora-game/dist/types`.

This PR:
- `game`: adds `ts-toolbelt` as a direct dependency so `Curry` resolves via a portable path (`node_modules/ts-toolbelt/...` instead of `node_modules/.pnpm/ts-toolbelt@9.6.0/...`), which clears all TS2883 errors.
- `game`: re-enables `declaration: true` in `tsconfig.json`.
- `game`: bumps to `0.20.1`.
- `web`: temporarily downgrades `hathora-et-labora-game` to `0.19.1` so production deploys succeed *now*. Once `0.20.1` is cut as a GitHub release and the `publish` workflow ships it to npm, bump `web` back up in a follow-up.

## Test plan
- [ ] `cd game && pnpm install && pnpm run build` succeeds with `dist/*.d.ts` emitted
- [ ] Vercel deploy on merge goes green
- [ ] Cut `v0.20.1` release → npm publishes `hathora-et-labora-game@0.20.1`
- [ ] Follow-up PR bumps `web/package.json` to `0.20.1`

---
_Generated by [Claude Code](https://claude.ai/code/session_017pD13Le9aHN2DUmE9vukFp)_