### PR TITLE
chore(web): bump hathora-et-labora-game to 0.20.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "dotenv": "17.4.2",
     "flags": "4.1.0",
     "form-urlencoded": "6.1.7",
-    "hathora-et-labora-game": "0.19.1",
+    "hathora-et-labora-game": "0.20.1",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "mcp-handler": "1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 6.1.7
         version: 6.1.7
       hathora-et-labora-game:
-        specifier: 0.19.1
-        version: 0.19.1
+        specifier: 0.20.1
+        version: 0.20.1
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -1805,8 +1805,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-shuffle@6.1.1:
-    resolution: {integrity: sha512-HPxFJxEi18KPmVQuK5Hi5l4KSl3u50jtaxseRrPqrxewqfvU+sTPTaUpP33Hj+NdJoLuJP5ipx3ybTr+fa6dEw==}
+  fast-shuffle@6.2.0:
+    resolution: {integrity: sha512-Y7MexltTgkdI2UzeRx7zVIWiHSuQ41dD+2PPwukkIZW2b1wCSaciISyKNSKFVW6ImkH+QQivlDsmY552EO22Ig==}
+    engines: {node: '>=14'}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
@@ -1865,10 +1866,6 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  fn-pcg@2.0.1:
-    resolution: {integrity: sha512-a7OHtEqIk4WRufEjqGepbX3YATjU6AXnjQt0HuPqjVe6YGIc6+9KxDqhPsUIWOGBUPGmvKCCQxguyQJchg0Gog==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -1974,8 +1971,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hathora-et-labora-game@0.19.1:
-    resolution: {integrity: sha512-QTZgT12+1l8++nANlcczLoQr8ZNztPjkHR0jlEYtk1VPl1BC3VjuQonLBuv8kRFswxMiBFG2E+wcsgEkWxE3xg==}
+  hathora-et-labora-game@0.20.1:
+    resolution: {integrity: sha512-P57Rtsi74NwLGNdZjDdhdrxxUWsM6PMqpgT91ubmpAJu/BE6e/kBowrfpnUVGYxO0yPpUCSm0dB/Kj0+GcuE6A==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2272,9 +2269,6 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  long@5.2.3:
-    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2475,8 +2469,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
-  pcg@1.1.0:
-    resolution: {integrity: sha512-S+bYs8CV6l2lj01PRN4g9EiHDktcXJKD9FdE/FqpdXSuy1zImsRq8A8T5UK6gkXdI9O5YFdAgH40uPoR8Bk8aQ==}
+  pcg@3.0.0:
+    resolution: {integrity: sha512-lHETDr3c//q4xs0iZk9+LRFgmvjLtaUDIE3ztE2KN4IhwyHLcJ3H5VBv93SGop1XHZalC1UFSwoJepoZSMSVLQ==}
+    engines: {node: '>=18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2537,15 +2532,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  ramda@0.29.0:
-    resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
-
-  ramda@0.29.1:
-    resolution: {integrity: sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==}
-
-  ramda@0.30.1:
-    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
 
   ramda@0.32.0:
     resolution: {integrity: sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==}
@@ -2827,9 +2813,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-pattern@5.7.0:
-    resolution: {integrity: sha512-0/FvIG4g3kNkYgbNwBBW5pZBkfpeYQnH+2AA3xmjkCAit/DSDPKmgwC3fKof4oYUq6gupClVOJlFl+939VRBMg==}
 
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
@@ -4962,9 +4945,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-shuffle@6.1.1:
+  fast-shuffle@6.2.0:
     dependencies:
-      pcg: 1.1.0
+      pcg: 3.0.0
 
   fast-uri@3.1.2: {}
 
@@ -5015,11 +4998,6 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
-
-  fn-pcg@2.0.1:
-    dependencies:
-      long: 5.2.3
-      ramda: 0.29.0
 
   for-each@0.3.5:
     dependencies:
@@ -5123,12 +5101,13 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hathora-et-labora-game@0.19.1:
+  hathora-et-labora-game@0.20.1:
     dependencies:
-      fast-shuffle: 6.1.1
-      fn-pcg: 2.0.1
-      ramda: 0.30.1
-      ts-pattern: 5.7.0
+      fast-shuffle: 6.2.0
+      pcg: 3.0.0
+      ramda: 0.32.0
+      ts-pattern: 5.9.0
+      ts-toolbelt: 9.6.0
 
   hermes-estree@0.25.1: {}
 
@@ -5436,8 +5415,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  long@5.2.3: {}
-
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5629,10 +5606,7 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
-  pcg@1.1.0:
-    dependencies:
-      long: 5.2.3
-      ramda: 0.29.1
+  pcg@3.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -5684,12 +5658,6 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
-
-  ramda@0.29.0: {}
-
-  ramda@0.29.1: {}
-
-  ramda@0.30.1: {}
 
   ramda@0.32.0: {}
 
@@ -6073,8 +6041,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
-
-  ts-pattern@5.7.0: {}
 
   ts-pattern@5.9.0: {}
 


### PR DESCRIPTION
Follow-up to #1783. Now that `hathora-et-labora-game@0.20.1` is on npm (with `.d.ts` files), bump `web` back up so it picks up the rondel wedge fix and ships with types intact.

## Test plan
- [ ] Vercel deploy goes green
- [ ] Rondel token placement renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_017pD13Le9aHN2DUmE9vukFp)_