### PR TITLE
feat(mcp): allow one profile to hold multiple seats per instance

### DIFF
--- a/supabase/migrations/20260614100000_entrant_multiseat.sql
+++ b/supabase/migrations/20260614100000_entrant_multiseat.sql
@@ -1,0 +1,33 @@
+-- Relax entrant uniqueness so one profile can hold multiple seats (colors) in
+-- the same instance. The MCP server uses this for AI agents that play multiple
+-- colors in one game. The web join flow still enforces one-seat-per-profile in
+-- application code.
+--
+-- The real game-rules invariant is one color per instance; switch the unique
+-- constraint over to (instance_id, color).
+
+do $$
+declare
+  dup_count integer;
+begin
+  select count(*) into dup_count
+  from (
+    select instance_id, color
+    from public.entrant
+    where color is not null
+    group by instance_id, color
+    having count(*) > 1
+  ) d;
+  if dup_count > 0 then
+    raise exception 'entrant has % (instance_id, color) duplicates; refusing to add unique constraint', dup_count;
+  end if;
+end $$;
+
+alter table public.entrant
+  drop constraint entrant_instance_id_profile_id_key;
+
+alter table public.entrant
+  add constraint entrant_instance_id_color_key unique (instance_id, color);
+
+create index if not exists entrant_instance_profile_idx
+  on public.entrant (instance_id, profile_id);

--- a/web/src/app/instance/[slug]/actions.ts
+++ b/web/src/app/instance/[slug]/actions.ts
@@ -46,19 +46,36 @@ export const join = async (
       return [[], undefined]
     }
 
-    // otherwise update this instance+profile with the color
-    const { data, error: upsertError } = await supabase
+    // The web flow enforces one-seat-per-profile in app code. If this profile
+    // already has a seat in this instance, change its color; otherwise insert.
+    const { data: existing } = await supabase
       .from('entrant')
-      .upsert(
-        { instance_id: instance?.id, profile_id: user.id, color, updated_at: new Date().toISOString() },
-        { onConflict: 'instance_id, profile_id' }
-      )
-      .select()
-    if (upsertError) {
-      console.error(upsertError)
-      return [[], undefined]
+      .select('id')
+      .eq('instance_id', instance.id)
+      .eq('profile_id', user.id)
+      .maybeSingle()
+    if (existing) {
+      const { data, error: updateError } = await supabase
+        .from('entrant')
+        .update({ color, updated_at: new Date().toISOString() })
+        .eq('id', existing.id)
+        .select()
+      if (updateError) {
+        console.error(updateError)
+        return [[], undefined]
+      }
+      console.log('update ', data)
+    } else {
+      const { data, error: insertError } = await supabase
+        .from('entrant')
+        .insert({ instance_id: instance.id, profile_id: user.id, color, updated_at: new Date().toISOString() })
+        .select()
+      if (insertError) {
+        console.error(insertError)
+        return [[], undefined]
+      }
+      console.log('insert ', data)
     }
-    console.log('upsert ', data)
   } else {
     const { data: entrant, error: deleteError } = await supabase
       .from('entrant')

--- a/web/src/mcp/tools/fetchInstance.ts
+++ b/web/src/mcp/tools/fetchInstance.ts
@@ -6,7 +6,7 @@ type FetchedInstance = {
   supabase: SupabaseClient<Database>
   instance: Tables<'instance'>
   entrants: Tables<'entrant'>[]
-  me?: Tables<'entrant'>
+  mySeats: Tables<'entrant'>[]
 }
 
 export const fetchInstance = async (
@@ -17,6 +17,6 @@ export const fetchInstance = async (
   const { data, error } = await supabase.from('instance').select('*, entrant(*)').eq('id', instanceId).single()
   if (error || data === null) return { error: `Failed to fetch instance ${instanceId}: ${error?.message}` }
   const { entrant: entrants, ...instance } = data
-  const me = entrants.find((entrant) => entrant.profile_id === userId)
-  return { supabase, instance, entrants, me }
+  const mySeats = entrants.filter((entrant) => entrant.profile_id === userId)
+  return { supabase, instance, entrants, mySeats }
 }

--- a/web/src/mcp/tools/getGame.ts
+++ b/web/src/mcp/tools/getGame.ts
@@ -1,4 +1,4 @@
-import { replay, asPlaying } from '../engine'
+import { activePlayerColor, asPlaying, engineColorToEntrantColor, replay } from '../engine'
 import { renderSummary } from '../render'
 import { errorResult, jsonResult, ToolResult } from '../content'
 import { fetchInstance } from './fetchInstance'
@@ -14,7 +14,10 @@ export const getGame = async ({
 }): Promise<ToolResult> => {
   const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
-  const { instance, entrants, me } = fetched
+  const { instance, entrants, mySeats } = fetched
+
+  const myColors = mySeats.map((s) => s.color)
+  const mySeatIds = new Set(mySeats.map((s) => s.id))
 
   const state = replay(instance.commands)
   const playing = asPlaying(state)
@@ -24,13 +27,23 @@ export const getGame = async ({
       status: state?.status ?? 'UNKNOWN',
       note: 'Game has not started; it has no board state yet. Seats are managed from the website lobby.',
       commands: instance.commands,
-      seats: entrants.map((entrant) => ({ color: entrant.color, is_me: entrant.id === me?.id })),
+      seats: entrants.map((entrant) => ({ color: entrant.color, is_me: mySeatIds.has(entrant.id) })),
     })
   }
 
   if (detail === 'full') {
     const { randGen: _randGen, ...fullState } = playing
-    return jsonResult({ instance_id: instance.id, my_color: me?.color, state: fullState })
+    return jsonResult({ instance_id: instance.id, my_colors: myColors, state: fullState })
   }
-  return jsonResult({ instance_id: instance.id, ...renderSummary(playing, instance.commands, me?.color) })
+
+  // When the agent controls multiple seats, render from whichever of its seats
+  // is currently active (so my_turn reflects the right perspective); fall back
+  // to the first seat, or undefined if it controls none.
+  const active = engineColorToEntrantColor(activePlayerColor(playing))
+  const renderColor = myColors.find((c) => c === active) ?? myColors[0]
+  return jsonResult({
+    instance_id: instance.id,
+    my_colors: myColors,
+    ...renderSummary(playing, instance.commands, renderColor),
+  })
 }

--- a/web/src/mcp/tools/getLegalMoves.ts
+++ b/web/src/mcp/tools/getLegalMoves.ts
@@ -17,7 +17,7 @@ export const getLegalMoves = async ({
 }): Promise<ToolResult> => {
   const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
-  const { instance, me } = fetched
+  const { instance, mySeats } = fetched
 
   const playing = asPlaying(replay(instance.commands))
   if (playing === undefined) return errorResult('Game has not started yet; there are no moves to make.')
@@ -29,7 +29,7 @@ export const getLegalMoves = async ({
   const completions = control(playing, partial).completion ?? []
   return jsonResult({
     active_color: activeColor,
-    my_turn: me !== undefined && me.color === activeColor,
+    my_turn: activeColor !== undefined && mySeats.some((s) => s.color === activeColor),
     partial,
     partial_is_complete_command: partial.length > 0 && applyCommand(playing, partial) !== undefined,
     completions: completions.slice(0, MAX_COMPLETIONS),

--- a/web/src/mcp/tools/joinGame.ts
+++ b/web/src/mcp/tools/joinGame.ts
@@ -35,13 +35,18 @@ export const joinGame = async ({
   const conflict = instance.entrant.find((e) => e.color === color && e.profile_id !== userId)
   if (conflict) return errorResult(`Color ${color} is already taken in this game.`)
 
-  const { error: upsertError } = await supabase
-    .from('entrant')
-    .upsert(
-      { instance_id: instanceId, profile_id: userId, color, updated_at: new Date().toISOString() },
-      { onConflict: 'instance_id, profile_id' }
-    )
-  if (upsertError) return errorResult(`Failed to claim seat: ${upsertError.message}`)
+  // MCP path lets one profile hold multiple seats in the same instance, so we
+  // key off (instance_id, color) — the DB unique — rather than upserting on
+  // (instance_id, profile_id).
+  const existing = instance.entrant.find((e) => e.profile_id === userId && e.color === color)
+  if (existing) {
+    await supabase.from('entrant').update({ updated_at: new Date().toISOString() }).eq('id', existing.id)
+  } else {
+    const { error: insertError } = await supabase
+      .from('entrant')
+      .insert({ instance_id: instanceId, profile_id: userId, color, updated_at: new Date().toISOString() })
+    if (insertError) return errorResult(`Failed to claim seat: ${insertError.message}`)
+  }
 
   // Mirror the website lobby: if there's already a CONFIG command, rewrite its
   // player count to match the new seat total so START will accept it.
@@ -68,6 +73,7 @@ export const joinGame = async ({
     ok: true,
     instance_id: instanceId,
     my_color: color,
+    my_colors: (seats ?? []).filter((s) => s.profile_id === userId).map((s) => s.color),
     seats: (seats ?? []).map((s) => ({ color: s.color, is_me: s.profile_id === userId })),
     note: 'Seat claimed. Wait for the lobby owner to choose the mode/variant and press START on the website.',
   })

--- a/web/src/mcp/tools/listMyGames.ts
+++ b/web/src/mcp/tools/listMyGames.ts
@@ -1,4 +1,5 @@
 import { GameStatusEnum } from 'hathora-et-labora-game/dist/types'
+import { Enums } from '@/supabase.types'
 import { createServiceClient } from '@/utils/supabase/service'
 import { activePlayerColor, asPlaying, engineColorToEntrantColor, replay } from '../engine'
 import { errorResult, jsonResult, ToolResult } from '../content'
@@ -17,23 +18,43 @@ export const listMyGames = async ({
     .eq('profile_id', userId)
   if (error) return errorResult(`Failed to list games: ${error.message}`)
 
-  const games = (data ?? [])
-    .flatMap(({ color, instance }) => {
-      if (instance === null) return []
-      const state = replay(instance.commands)
+  // One profile can hold several seats in the same instance (MCP only), so
+  // group by instance and union the colors.
+  const byInstance = new Map<
+    string,
+    { commands: string[]; updated_at: string; colors: Enums<'color'>[] }
+  >()
+  for (const row of data ?? []) {
+    if (row.instance === null) continue
+    const existing = byInstance.get(row.instance.id)
+    if (existing) {
+      existing.colors.push(row.color)
+    } else {
+      byInstance.set(row.instance.id, {
+        commands: row.instance.commands,
+        updated_at: row.instance.updated_at,
+        colors: [row.color],
+      })
+    }
+  }
+
+  const games = Array.from(byInstance.entries())
+    .map(([instanceId, { commands, updated_at, colors }]) => {
+      const state = replay(commands)
       const playing = asPlaying(state)
       const activeColor = playing && engineColorToEntrantColor(activePlayerColor(playing))
-      return [
-        {
-          instance_id: instance.id,
-          my_color: color,
-          status: state?.status ?? 'UNKNOWN',
-          active_color: activeColor,
-          my_turn: playing?.status === GameStatusEnum.PLAYING && activeColor === color,
-          move_count: instance.commands.length,
-          updated_at: instance.updated_at,
-        },
-      ]
+      return {
+        instance_id: instanceId,
+        my_colors: colors,
+        status: state?.status ?? 'UNKNOWN',
+        active_color: activeColor,
+        my_turn:
+          playing?.status === GameStatusEnum.PLAYING &&
+          activeColor !== undefined &&
+          colors.includes(activeColor),
+        move_count: commands.length,
+        updated_at,
+      }
     })
     .filter((game) => !onlyMyTurn || game.my_turn)
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at))

--- a/web/src/mcp/tools/makeMove.ts
+++ b/web/src/mcp/tools/makeMove.ts
@@ -15,10 +15,10 @@ export const makeMove = async ({
 }): Promise<ToolResult> => {
   const fetched = await fetchInstance(userId, instanceId)
   if ('error' in fetched) return errorResult(fetched.error)
-  const { supabase, instance, me } = fetched
+  const { supabase, instance, mySeats } = fetched
 
   // 1. seat check
-  if (me === undefined) return errorResult('You are not seated in this game.')
+  if (mySeats.length === 0) return errorResult('You are not seated in this game.')
 
   // 2. status check
   const playing = asPlaying(replay(instance.commands))
@@ -26,10 +26,12 @@ export const makeMove = async ({
     return errorResult('Game has not started yet; seats and setup are managed from the website lobby.')
   if (playing.status === GameStatusEnum.FINISHED) return errorResult('Game is already finished.')
 
-  // 3. turn check
+  // 3. turn check — any of the agent's seats may be the active player
   const activeColor = engineColorToEntrantColor(activePlayerColor(playing))
-  if (activeColor !== me.color) {
-    return errorResult(`It is not your turn: you are ${me.color}, and ${activeColor} is the active player.`)
+  const activeSeat = mySeats.find((s) => s.color === activeColor)
+  if (!activeSeat) {
+    const mine = mySeats.map((s) => s.color).join(', ')
+    return errorResult(`It is not your turn: you are ${mine}, and ${activeColor} is the active player.`)
   }
 
   // 4. legality check
@@ -58,6 +60,6 @@ export const makeMove = async ({
   return jsonResult({
     ok: true,
     played: tokens.join(' '),
-    state: renderSummary(updatedState, updated.commands, me.color),
+    state: renderSummary(updatedState, updated.commands, activeSeat.color),
   })
 }


### PR DESCRIPTION
## Summary
Lets an AI agent (over MCP) join the same game in multiple seats — e.g. Blue + Green + White all bound to the same userId — while the web flow continues to enforce one seat per profile. All information is open in Ora et Labora, so this is just an ergonomics change for agent play, not a fairness concern.

## Schema
- Migration `20260614100000_entrant_multiseat.sql`:
  - Guard: aborts if any historical `(instance_id, color)` duplicates exist.
  - Drop `UNIQUE (instance_id, profile_id)`.
  - Add `UNIQUE (instance_id, color)` — the actual game-rules invariant.
  - Add non-unique index `(instance_id, profile_id)` for lookups.
- RLS unchanged. MCP tools use the service-role client and bypass policy; web tools still hit `auth.uid() = profile_id` rules.

## MCP changes
- `fetchInstance` returns `mySeats: Tables<'entrant'>[]` instead of a single `me`.
- `joinGame` stops using the dropped `onConflict: 'instance_id, profile_id'` upsert; does an explicit lookup-then-insert keyed by `(instance_id, profile_id, color)`. Color-already-taken-by-someone-else check stays.
- `makeMove` resolves the active seat from `mySeats.find(s => s.color === activeColor)`; renders from that seat.
- `getGame` returns `my_colors: string[]`; renders from the agent's active-on-turn seat when possible, else the first seat.
- `listMyGames` groups rows by instance, reports `my_colors`, and `my_turn` lights up if any of the agent's seats is active.

## Web changes
- `app/instance/[slug]/actions.ts#join` no longer relies on the dropped unique. It looks up the existing entrant for this `(instance_id, profile_id)` and updates the color, or inserts a fresh row — preserving one-seat-per-profile in app code.

## Test plan
- [ ] Run the migration locally; confirm guard passes on existing data and the new unique exists.
- [ ] As an MCP agent, `join_game` with three different colors against the same instance; verify three `entrant` rows share `profile_id`.
- [ ] On the web, change seat color in a lobby — should still update the same row, not create a duplicate.
- [ ] On a started multi-seat game, `make_move` on whichever color is active works; trying to act for a non-active seat returns the "not your turn" error listing all owned colors.
- [ ] `list_my_games` shows one row per instance with `my_colors` listing every seat the agent holds.

https://claude.ai/code/session_011DqQ88QJcF6D32tEegzZh2

---
_Generated by [Claude Code](https://claude.ai/code/session_011DqQ88QJcF6D32tEegzZh2)_