### PR TITLE
fix(game): reject Bathhouse USE without a payment

### DIFF
--- a/game/src/buildings/__tests__/bathhouse.test.ts
+++ b/game/src/buildings/__tests__/bathhouse.test.ts
@@ -99,14 +99,14 @@ describe('buildings/bathhouse', () => {
       ])
     })
 
-    it('allows noop with undefined', () => {
-      const s1 = bathhouse()(s0)!
-      expect(s1).toBe(s0)
+    it('rejects with undefined when no payment is provided', () => {
+      const s1 = bathhouse()(s0)
+      expect(s1).toBeUndefined()
     })
 
-    it('allows noop with empty string', () => {
-      const s1 = bathhouse('')(s0)!
-      expect(s1).toBe(s0)
+    it('rejects with empty string when no payment is provided', () => {
+      const s1 = bathhouse('')(s0)
+      expect(s1).toBeUndefined()
     })
 
     it('will not move someone elses piece', () => {
@@ -150,7 +150,7 @@ describe('buildings/bathhouse', () => {
           ...s0.players.slice(1),
         ],
       }
-      const s2 = bathhouse()(s1)!
+      const s2 = bathhouse('Pn')(s1)!
       expect(s1.players[0].clergy).toBe(s2.players[0].clergy)
       expect(s1.players[0].landscape).toBe(s2.players[0].landscape)
     })
@@ -163,7 +163,7 @@ describe('buildings/bathhouse', () => {
   })
 
   describe('complete', () => {
-    it('when no money, only noop', () => {
+    it('when no money, no legal completions', () => {
       const s1 = {
         ...s0,
         players: [
@@ -175,9 +175,9 @@ describe('buildings/bathhouse', () => {
         ],
       } as GameStatePlaying
       const c0 = complete([])(s1)
-      expect(c0).toStrictEqual([''])
+      expect(c0).toStrictEqual([])
     })
-    it('when money, allow offer', () => {
+    it('when money, require payment', () => {
       const s1 = {
         ...s0,
         players: [
@@ -189,7 +189,7 @@ describe('buildings/bathhouse', () => {
         ],
       } as GameStatePlaying
       const c0 = complete([])(s1)
-      expect(c0).toStrictEqual(['Pn', ''])
+      expect(c0).toStrictEqual(['Pn'])
     })
   })
 })

--- a/game/src/buildings/bathhouse.ts
+++ b/game/src/buildings/bathhouse.ts
@@ -32,9 +32,9 @@ export const bathhouse =
   (param = ''): StateReducer =>
   (state) => {
     if (state === undefined) return undefined
-    if (param === '') return state
+    if (param === '') return undefined
     const input = parseResourceParam(param)
-    if (costMoney(input) < 1) return state
+    if (costMoney(input) < 1) return undefined
     return withActivePlayer(
       pipe(
         //
@@ -47,7 +47,7 @@ export const bathhouse =
 
 export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
   match(partial)
-    .with([], () => (view(activeLens(state), state).penny ? ['Pn', ''] : ['']))
+    .with([], () => (view(activeLens(state), state).penny ? ['Pn'] : []))
     .with([P._], always(['']))
     .otherwise(always([]))
 )


### PR DESCRIPTION
## The bug

In solo game [`446d3727-9fca-4599-8724-6d55954af0c1`](https://kennerspiel.com/instance/446d3727-9fca-4599-8724-6d55954af0c1), the active player built the Bathhouse (F23), then used the free post-build prior activation on it, expecting all of their clergymen to be recalled. None of the clergy were returned, and the recent command log shows the move that was accepted was literally `USE F23` (no parameter).

Reading `game/src/buildings/bathhouse.ts` shows why:

```ts
export const bathhouse =
  (param = ''): StateReducer =>
  (state) => {
    if (state === undefined) return undefined
    if (param === '') return state              // <-- silent no-op
    const input = parseResourceParam(param)
    if (costMoney(input) < 1) return state      // <-- silent no-op
    ...
```

```ts
export const complete = curry((partial: string[], state: GameStatePlaying): string[] =>
  match(partial)
    .with([], () => (view(activeLens(state), state).penny ? ['Pn', ''] : ['']))
    ...
```

The Bathhouse activation requires flipping at least 1 coin (per the rulebook and the existing `costMoney(input) >= 1` guard inside the reducer). But the `complete([])` function offered `''` as a legal completion regardless of whether the player could pay, and the reducer treated `bathhouse('')` as a no-op rather than an illegal move. The player in the linked game had `penny: 0`, so the legal-moves API told them `USE F23` was a complete command on its own; submitting it spent their post-build prior, placed `PRIR` on F23 via `moveClergyToOwnBuilding`, but then the bathhouse reducer ran and silently returned the input state — no payment, no `+1 book`, no `+1 ceramic`, and (the visible bug) no clergy recalled.

## The fix

Treat a parameterless or zero-cost `USE F23` as illegal:

- `bathhouse('')` and `bathhouse(<insufficient cost>)` now return `undefined` instead of the input state, so the whole `use` pipeline returns `undefined` and `makeMove` rejects the command.
- `complete([])` now returns `['Pn']` when the player has at least one penny and `[]` when they do not, instead of always offering `''`. A future improvement would be to also offer `Ni`/`Wn`/`Wh` (the other money tokens accepted by `costMoney`), like `financedEstate` does, but that's beyond the scope of this bug.

Existing bathhouse tests that asserted the no-op behavior have been updated to assert the new rejection behavior. All 1341 tests in `game/` still pass, lint is clean, and `tsc -p tsconfig.build.json` succeeds.

## Test plan

- [x] `pnpm test` in `game/` — 1341 / 1341 passing
- [x] `pnpm lint` in `game/` — clean
- [x] `pnpm build` in `game/` — clean
- [ ] Manual: in a solo game, build the Bathhouse with the player holding 0 pennies; confirm `USE F23` is no longer offered by `get_legal_moves` and is rejected by `make_move`
- [ ] Manual: with at least 1 penny, confirm `USE F23 Pn` recalls all clergy and grants `+1 book` / `+1 ceramic` as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfnB98QJW23uckLibstrZg)_