### PR TITLE
feat(mcp): let wait_for_my_turn target a specific seat color

### DIFF
--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -102,9 +102,15 @@ const handler = createMcpHandler(
     )
     server.tool(
       'wait_for_my_turn',
-      'Block until it becomes your turn in the given game, the game ends, or the timeout elapses. Use this instead of repeatedly polling get_game/list_my_games while waiting on other players. Returns the same shape as list_my_games plus a timed_out flag.',
+      'Block until it becomes your turn in the given game, the game ends, or the timeout elapses. Use this instead of repeatedly polling get_game/list_my_games while waiting on other players. Pass color to wait for one specific seat (useful when this agent holds multiple seats in the same game and a sibling agent is playing the other color). Returns the same shape as list_my_games plus a timed_out flag.',
       {
         instance_id: z.string().uuid().describe('The game instance id'),
+        color: z
+          .enum(['red', 'green', 'blue', 'white'])
+          .optional()
+          .describe(
+            'Wait until this specific seat becomes active. Must be a color you are seated as. Omit to wait for any of your seats.'
+          ),
         timeout_sec: z
           .number()
           .int()
@@ -113,11 +119,11 @@ const handler = createMcpHandler(
           .optional()
           .describe('How long to wait before returning, in seconds (default 50, max 55 — request maxDuration is 60s)'),
       },
-      async ({ instance_id, timeout_sec }, extra) => {
+      async ({ instance_id, color, timeout_sec }, extra) => {
         const userId = userIdFrom(extra)
         trackToolCall('wait_for_my_turn', userId)
         if (!userId) return unauthenticated()
-        return waitForMyTurn({ userId, instanceId: instance_id, timeoutSec: timeout_sec ?? 50 })
+        return waitForMyTurn({ userId, instanceId: instance_id, color, timeoutSec: timeout_sec ?? 50 })
       }
     )
   },

--- a/web/src/mcp/tools/waitForMyTurn.ts
+++ b/web/src/mcp/tools/waitForMyTurn.ts
@@ -1,4 +1,5 @@
 import { GameStatusEnum } from 'hathora-et-labora-game/dist/types'
+import { Enums } from '@/supabase.types'
 import { createServiceClient } from '@/utils/supabase/service'
 import { activePlayerColor, asPlaying, engineColorToEntrantColor, replay } from '../engine'
 import { errorResult, jsonResult, ToolResult } from '../content'
@@ -9,17 +10,18 @@ export const waitForMyTurn = async ({
   userId,
   instanceId,
   timeoutSec,
+  color,
   pollMs = 2000,
 }: {
   userId: string
   instanceId: string
   timeoutSec: number
+  color?: Enums<'color'>
   pollMs?: number
 }): Promise<ToolResult> => {
   const supabase = createServiceClient()
   const deadline = Date.now() + timeoutSec * 1000
 
-   
   while (true) {
     const { data, error } = await supabase
       .from('instance')
@@ -34,19 +36,25 @@ export const waitForMyTurn = async ({
     if (myColors.length === 0) {
       return errorResult(`You are not seated in instance ${instanceId}`)
     }
+    if (color !== undefined && !myColors.includes(color)) {
+      return errorResult(`You are not seated as ${color} in instance ${instanceId}`)
+    }
+
+    const waitColors = color !== undefined ? [color] : myColors
 
     const state = replay(data.commands)
     const playing = asPlaying(state)
     const activeColor = playing && engineColorToEntrantColor(activePlayerColor(playing))
     const status = state?.status ?? 'UNKNOWN'
     const myTurn =
-      playing?.status === GameStatusEnum.PLAYING && activeColor !== undefined && myColors.includes(activeColor)
+      playing?.status === GameStatusEnum.PLAYING && activeColor !== undefined && waitColors.includes(activeColor)
     const gameOver = status !== GameStatusEnum.PLAYING && status !== 'UNKNOWN'
 
     if (myTurn || gameOver || Date.now() >= deadline) {
       return jsonResult({
         instance_id: data.id,
         my_colors: myColors,
+        waiting_for_color: color,
         status,
         active_color: activeColor,
         my_turn: myTurn,


### PR DESCRIPTION
## Summary
- `wait_for_my_turn` now accepts an optional `color` so an agent that holds multiple seats in the same instance (one window per color) can block on its own seat instead of any of them
- The color is validated against the caller's seats and echoed back as `waiting_for_color` in the response; omitting it preserves the previous "any of my seats" behavior

## Test plan
- [ ] Open two MCP sessions for the same profile, one per color in a shared game, and confirm each can `wait_for_my_turn` with its own `color` without unblocking on the sibling's turn
- [ ] Confirm calling without `color` still returns when any seated color is active
- [ ] Confirm calling with a color the caller does not hold returns an error

https://claude.ai/code/session_01KxhJctKzPVbcPpA66ANAHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxhJctKzPVbcPpA66ANAHy)_