### PR TITLE
feat(oauth): dynamic client registration for the MCP connector

### DIFF
--- a/supabase/migrations/20260615220000_create_oauth_client_table.sql
+++ b/supabase/migrations/20260615220000_create_oauth_client_table.sql
@@ -1,0 +1,19 @@
+-- Dynamic Client Registration (RFC 7591). Each row is one OAuth client that
+-- has registered itself against this authorization server. The MCP connector
+-- in Claude.ai will hit /register on first connect and never prompt the user
+-- for a client_id / client_secret again.
+
+create table public.oauth_client (
+  client_id text primary key,
+  client_secret_hash text,
+  client_name text,
+  redirect_uris text[] not null,
+  token_endpoint_auth_method text not null default 'client_secret_post',
+  scope text not null default 'play',
+  created_at timestamptz not null default now()
+);
+create index oauth_client_created_at_idx on public.oauth_client (created_at);
+
+-- RLS denies all by default; only the service-role client (used by the OAuth
+-- routes) is allowed to read or write these rows.
+alter table public.oauth_client enable row level security;

--- a/web/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/web/src/app/.well-known/oauth-authorization-server/route.ts
@@ -10,10 +10,11 @@ export const GET = () => {
       issuer: iss,
       authorization_endpoint: `${iss}/authorize`,
       token_endpoint: `${iss}/token`,
+      registration_endpoint: `${iss}/register`,
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code'],
       code_challenge_methods_supported: ['S256'],
-      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+      token_endpoint_auth_methods_supported: ['none', 'client_secret_basic', 'client_secret_post'],
       scopes_supported: [SCOPE],
     },
     {

--- a/web/src/app/authorize/actions.ts
+++ b/web/src/app/authorize/actions.ts
@@ -2,8 +2,8 @@
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
-import { allowedRedirectUris, isKnownClientId, resourceIdentifier, SCOPE } from '@/oauth/config'
-import { issueAuthorizationCode } from '@/oauth/store'
+import { resourceIdentifier, SCOPE } from '@/oauth/config'
+import { findClient, issueAuthorizationCode } from '@/oauth/store'
 
 const fail = (redirectUri: string | null, state: string | null, error: string, description: string): never => {
   if (!redirectUri) throw new Error(`${error}: ${description}`)
@@ -24,10 +24,11 @@ export const approve = async (formData: FormData) => {
   const resource = (formData.get('resource') as string | null) ?? null
   const scope = String(formData.get('scope') ?? SCOPE)
 
-  if (!redirectUri || !allowedRedirectUris().includes(redirectUri))
-    fail(null, state, 'invalid_request', 'redirect_uri is not allow-listed')
+  const client = clientId ? await findClient(clientId) : undefined
+  if (!client) fail(null, state, 'unauthorized_client', 'Unknown client_id')
+  if (!redirectUri || !client!.redirectUris.includes(redirectUri))
+    fail(null, state, 'invalid_request', 'redirect_uri is not registered for this client')
   if (responseType !== 'code') fail(redirectUri, state, 'unsupported_response_type', 'Only code is supported')
-  if (!isKnownClientId(clientId)) fail(redirectUri, state, 'unauthorized_client', 'Unknown client_id')
   if (!codeChallenge) fail(redirectUri, state, 'invalid_request', 'PKCE code_challenge is required')
   if (codeChallengeMethod !== 'S256')
     fail(redirectUri, state, 'invalid_request', 'Only code_challenge_method=S256 is supported')

--- a/web/src/app/authorize/page.tsx
+++ b/web/src/app/authorize/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
-import { allowedRedirectUris, isKnownClientId, resourceIdentifier } from '@/oauth/config'
+import { resourceIdentifier } from '@/oauth/config'
+import { findClient } from '@/oauth/store'
 import { approve } from './actions'
 
 type AuthorizeParams = {
@@ -21,23 +22,20 @@ const renderError = (message: string) => (
   </>
 )
 
-const validate = (params: AuthorizeParams): { error: string } | { ok: true } => {
-  if (params.response_type !== 'code') return { error: 'Only response_type=code is supported.' }
-  if (!params.client_id || !isKnownClientId(params.client_id)) return { error: 'Unknown client_id.' }
-  if (!params.redirect_uri || !allowedRedirectUris().includes(params.redirect_uri))
-    return { error: 'redirect_uri is not allow-listed for this client.' }
-  if (!params.code_challenge) return { error: 'Missing PKCE code_challenge (S256 required).' }
-  if (params.code_challenge_method && params.code_challenge_method !== 'S256')
-    return { error: 'Only code_challenge_method=S256 is supported.' }
-  if (params.resource && params.resource.replace(/\/$/, '') !== resourceIdentifier())
-    return { error: 'resource indicator does not match this server.' }
-  return { ok: true }
-}
-
 const Authorize = async ({ searchParams }: { searchParams: Promise<AuthorizeParams> }) => {
   const params = await searchParams
-  const check = validate(params)
-  if ('error' in check) return renderError(check.error)
+
+  if (params.response_type !== 'code') return renderError('Only response_type=code is supported.')
+  if (!params.client_id) return renderError('Missing client_id.')
+  const client = await findClient(params.client_id)
+  if (!client) return renderError('Unknown client_id.')
+  if (!params.redirect_uri || !client.redirectUris.includes(params.redirect_uri))
+    return renderError('redirect_uri is not registered for this client.')
+  if (!params.code_challenge) return renderError('Missing PKCE code_challenge (S256 required).')
+  if (params.code_challenge_method && params.code_challenge_method !== 'S256')
+    return renderError('Only code_challenge_method=S256 is supported.')
+  if (params.resource && params.resource.replace(/\/$/, '') !== resourceIdentifier())
+    return renderError('resource indicator does not match this server.')
 
   const supabase = await createClient()
   const {
@@ -52,11 +50,13 @@ const Authorize = async ({ searchParams }: { searchParams: Promise<AuthorizePara
   // Make sure the profile row exists; tools rely on profile_id == auth user id.
   await supabase.from('profile').upsert({ id: user.id, email: user.email ?? '' })
 
+  const clientLabel = client.clientName ?? 'An MCP client'
+
   return (
     <>
       <h1>Authorize MCP access</h1>
       <p>
-        An MCP client wants to play Ora et Labora on your behalf as <strong>{user.email}</strong>.
+        <strong>{clientLabel}</strong> wants to play Ora et Labora on your behalf as <strong>{user.email}</strong>.
       </p>
       <p>Granting access will let this client:</p>
       <ul>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,11 +13,31 @@ const Home = () => {
         You&apos;ll probably want to start out by creating an <Link href="/instance/">instance</Link>, and either play a
         solo game or invite some friends.
       </p>
+      <h2>Play with Claude</h2>
+      <p>
+        You can also let Claude take a seat at your table. Add Kennerspiel as a custom connector in Claude and it can
+        list your games, read the board, and play moves on your behalf — useful for solo learning, AI-vs-AI matches, or
+        just having a patient opponent at 2am.
+      </p>
+      <ol>
+        <li>
+          In Claude, open <strong>Settings → Connectors → Add custom connector</strong>.
+        </li>
+        <li>
+          Paste this URL: <code>https://kennerspiel.com/api/mcp</code>
+        </li>
+        <li>Click Add, then sign in to Kennerspiel when Claude opens the authorization page.</li>
+      </ol>
+      <p>
+        That&apos;s it — no client IDs, no secrets, no copy-pasting. After authorizing, ask Claude something like
+        &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find this server&apos;s tools.
+      </p>
       <p>
         Source code is available at{' '}
         <Link href="https://github.com/philihp/kennerspiel">github.com/philihp/kennerspiel</Link>
       </p>
-    </main>  )
+    </main>
+  )
 }
 
 export default Home

--- a/web/src/app/register/route.ts
+++ b/web/src/app/register/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { registerClient } from '@/oauth/store'
+
+// RFC 7591 Dynamic Client Registration. MCP connectors (Claude.ai's included)
+// POST here on first connect to mint their own client_id and (optionally) a
+// client_secret — so the human installing the connector never sees either one.
+
+const errorResponse = (status: number, error: string, description: string) =>
+  NextResponse.json(
+    { error, error_description: description },
+    { status, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' } }
+  )
+
+export const POST = async (req: Request) => {
+  let body: Record<string, unknown>
+  try {
+    body = (await req.json()) as Record<string, unknown>
+  } catch {
+    return errorResponse(400, 'invalid_client_metadata', 'Request body must be JSON')
+  }
+
+  const redirectUris = body.redirect_uris
+  if (!Array.isArray(redirectUris) || !redirectUris.every((u): u is string => typeof u === 'string'))
+    return errorResponse(400, 'invalid_redirect_uri', 'redirect_uris must be an array of strings')
+
+  const tokenEndpointAuthMethod =
+    typeof body.token_endpoint_auth_method === 'string' ? body.token_endpoint_auth_method : undefined
+  const clientName = typeof body.client_name === 'string' ? body.client_name : undefined
+  const scope = typeof body.scope === 'string' ? body.scope : undefined
+
+  const result = await registerClient({ redirectUris, tokenEndpointAuthMethod, clientName, scope })
+  if ('error' in result) return errorResponse(400, 'invalid_client_metadata', result.error)
+
+  return NextResponse.json(
+    {
+      client_id: result.client.clientId,
+      ...(result.clientSecret ? { client_secret: result.clientSecret } : {}),
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: result.client.redirectUris,
+      token_endpoint_auth_method: result.client.tokenEndpointAuthMethod,
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      scope: result.client.scope,
+      ...(result.client.clientName ? { client_name: result.client.clientName } : {}),
+    },
+    { status: 201, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' } }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  })

--- a/web/src/app/token/route.ts
+++ b/web/src/app/token/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { ACCESS_TOKEN_TTL_SECONDS, resourceIdentifier, verifyClientCredentials } from '@/oauth/config'
-import { consumeAuthorizationCode, issueAccessToken, verifyPkce } from '@/oauth/store'
+import { ACCESS_TOKEN_TTL_SECONDS, resourceIdentifier } from '@/oauth/config'
+import { consumeAuthorizationCode, findClient, issueAccessToken, verifyClientSecret, verifyPkce } from '@/oauth/store'
 
 const errorResponse = (status: number, error: string, description?: string) =>
   NextResponse.json(
@@ -8,10 +8,9 @@ const errorResponse = (status: number, error: string, description?: string) =>
     { status, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' } }
   )
 
-const parseClientCredentials = (
-  req: Request,
-  body: URLSearchParams
-): { clientId: string; clientSecret: string } | { error: string } => {
+type ParsedCredentials = { clientId: string; clientSecret: string | null }
+
+const parseClientCredentials = (req: Request, body: URLSearchParams): ParsedCredentials | { error: string } => {
   const authHeader = req.headers.get('authorization')
   if (authHeader?.toLowerCase().startsWith('basic ')) {
     try {
@@ -27,9 +26,8 @@ const parseClientCredentials = (
     }
   }
   const clientId = body.get('client_id')
-  const clientSecret = body.get('client_secret')
-  if (!clientId || !clientSecret) return { error: 'Missing client credentials' }
-  return { clientId, clientSecret }
+  if (!clientId) return { error: 'Missing client_id' }
+  return { clientId, clientSecret: body.get('client_secret') }
 }
 
 export const POST = async (req: Request) => {
@@ -38,8 +36,17 @@ export const POST = async (req: Request) => {
 
   const creds = parseClientCredentials(req, body)
   if ('error' in creds) return errorResponse(401, 'invalid_client', creds.error)
-  if (!verifyClientCredentials(creds.clientId, creds.clientSecret))
-    return errorResponse(401, 'invalid_client', 'client_id / client_secret mismatch')
+
+  const client = await findClient(creds.clientId)
+  if (!client) return errorResponse(401, 'invalid_client', 'Unknown client_id')
+
+  if (client.tokenEndpointAuthMethod === 'none') {
+    if (creds.clientSecret) return errorResponse(401, 'invalid_client', 'Client is public; do not send a client_secret')
+  } else {
+    if (!creds.clientSecret) return errorResponse(401, 'invalid_client', 'Missing client_secret')
+    if (!(await verifyClientSecret(creds.clientId, creds.clientSecret)))
+      return errorResponse(401, 'invalid_client', 'client_secret mismatch')
+  }
 
   const grantType = body.get('grant_type')
   if (grantType !== 'authorization_code')

--- a/web/src/oauth/config.ts
+++ b/web/src/oauth/config.ts
@@ -1,10 +1,13 @@
-// OAuth 2.1 authorization-server configuration. Both the authorize page and
-// the token endpoint read from here so they agree on what counts as a valid
-// client + redirect.
+// OAuth 2.1 authorization-server configuration. Clients self-register via the
+// Dynamic Client Registration endpoint (RFC 7591); per-client allow-listing
+// happens against the oauth_client table, not env vars.
 
 export const ACCESS_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30
 export const AUTHORIZATION_CODE_TTL_SECONDS = 60 * 10
 export const SCOPE = 'play'
+
+export const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = ['none', 'client_secret_basic', 'client_secret_post'] as const
+export type TokenEndpointAuthMethod = (typeof SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS)[number]
 
 export const issuer = (): string => {
   const fromEnv = process.env.OAUTH_ISSUER
@@ -15,24 +18,3 @@ export const issuer = (): string => {
 }
 
 export const resourceIdentifier = (): string => `${issuer()}/api/mcp`
-
-export const allowedRedirectUris = (): string[] => {
-  const raw = process.env.OAUTH_REDIRECT_URIS
-  if (!raw) throw new Error('OAUTH_REDIRECT_URIS is not configured')
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-}
-
-export const verifyClientCredentials = (clientId: string, clientSecret?: string): boolean => {
-  const expectedId = process.env.OAUTH_CLIENT_ID
-  const expectedSecret = process.env.OAUTH_CLIENT_SECRET
-  if (!expectedId || !expectedSecret) throw new Error('OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET not configured')
-  return clientId === expectedId && clientSecret === expectedSecret
-}
-
-export const isKnownClientId = (clientId: string): boolean => {
-  const expectedId = process.env.OAUTH_CLIENT_ID
-  return Boolean(expectedId) && clientId === expectedId
-}

--- a/web/src/oauth/store.ts
+++ b/web/src/oauth/store.ts
@@ -1,6 +1,12 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
-import { ACCESS_TOKEN_TTL_SECONDS, AUTHORIZATION_CODE_TTL_SECONDS } from './config'
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  AUTHORIZATION_CODE_TTL_SECONDS,
+  SCOPE,
+  SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
+  TokenEndpointAuthMethod,
+} from './config'
 
 // The OAuth tables are not in the generated Database type, so we use a plain
 // service-role client here. All access bypasses RLS and is enforced by code.
@@ -127,4 +133,109 @@ export const verifyPkce = (codeVerifier: string, codeChallenge: string, method: 
   const expected = base64url(createHash('sha256').update(codeVerifier).digest())
   if (expected.length !== codeChallenge.length) return false
   return timingSafeEqual(Buffer.from(expected), Buffer.from(codeChallenge))
+}
+
+export type RegisteredClient = {
+  clientId: string
+  redirectUris: string[]
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod
+  scope: string
+  clientName: string | null
+  hasSecret: boolean
+}
+
+export type ClientRegistrationInput = {
+  redirectUris: string[]
+  tokenEndpointAuthMethod?: string
+  clientName?: string
+  scope?: string
+}
+
+export type ClientRegistrationResult = {
+  client: RegisteredClient
+  clientSecret: string | null
+}
+
+const normalizeAuthMethod = (raw: string | undefined): TokenEndpointAuthMethod | { error: string } => {
+  const method = raw ?? 'client_secret_post'
+  if (!SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS.includes(method as TokenEndpointAuthMethod))
+    return { error: `token_endpoint_auth_method "${method}" is not supported` }
+  return method as TokenEndpointAuthMethod
+}
+
+export const registerClient = async (
+  input: ClientRegistrationInput
+): Promise<ClientRegistrationResult | { error: string }> => {
+  if (!input.redirectUris.length) return { error: 'redirect_uris must contain at least one URI' }
+  for (const uri of input.redirectUris) {
+    try {
+      const url = new URL(uri)
+      if (url.protocol !== 'https:' && url.hostname !== 'localhost' && url.hostname !== '127.0.0.1')
+        return { error: `redirect_uri must be https or localhost: ${uri}` }
+    } catch {
+      return { error: `redirect_uri is not a valid URL: ${uri}` }
+    }
+  }
+
+  const authMethod = normalizeAuthMethod(input.tokenEndpointAuthMethod)
+  if (typeof authMethod === 'object') return authMethod
+
+  const clientId = `mcp_${randomToken(18)}`
+  const clientSecret = authMethod === 'none' ? null : randomToken(32)
+  const clientSecretHash = clientSecret ? hash(clientSecret) : null
+  const scope = input.scope?.trim() || SCOPE
+
+  const { error } = await oauthClient()
+    .from('oauth_client')
+    .insert({
+      client_id: clientId,
+      client_secret_hash: clientSecretHash,
+      client_name: input.clientName ?? null,
+      redirect_uris: input.redirectUris,
+      token_endpoint_auth_method: authMethod,
+      scope,
+    })
+  if (error) throw new Error(`Failed to register client: ${error.message}`)
+
+  return {
+    client: {
+      clientId,
+      redirectUris: input.redirectUris,
+      tokenEndpointAuthMethod: authMethod,
+      scope,
+      clientName: input.clientName ?? null,
+      hasSecret: clientSecret !== null,
+    },
+    clientSecret,
+  }
+}
+
+export const findClient = async (clientId: string): Promise<RegisteredClient | undefined> => {
+  const { data, error } = await oauthClient()
+    .from('oauth_client')
+    .select('client_id, client_secret_hash, client_name, redirect_uris, token_endpoint_auth_method, scope')
+    .eq('client_id', clientId)
+    .maybeSingle()
+  if (error || !data) return undefined
+  return {
+    clientId: data.client_id,
+    redirectUris: data.redirect_uris,
+    tokenEndpointAuthMethod: data.token_endpoint_auth_method as TokenEndpointAuthMethod,
+    scope: data.scope,
+    clientName: data.client_name,
+    hasSecret: data.client_secret_hash !== null,
+  }
+}
+
+export const verifyClientSecret = async (clientId: string, clientSecret: string): Promise<boolean> => {
+  const { data, error } = await oauthClient()
+    .from('oauth_client')
+    .select('client_secret_hash')
+    .eq('client_id', clientId)
+    .maybeSingle()
+  if (error || !data?.client_secret_hash) return false
+  const expected = Buffer.from(data.client_secret_hash)
+  const actual = Buffer.from(hash(clientSecret))
+  if (expected.length !== actual.length) return false
+  return timingSafeEqual(expected, actual)
 }


### PR DESCRIPTION
## Summary

- Adds an RFC 7591 Dynamic Client Registration endpoint at `/register` and advertises it in the AS metadata. MCP clients (Claude.ai's connector included) now mint their own `client_id` on first connect, so the human installing the connector never has to paste OAuth credentials.
- Supports `token_endpoint_auth_method: "none"` for public PKCE-only clients alongside the existing `client_secret_*` methods. Public clients skip the secret entirely; confidential clients still get a hashed secret issued at registration time.
- Replaces the single-env-client model (`OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `OAUTH_REDIRECT_URIS`) with a per-client `oauth_client` table. `/authorize` and `/token` now look up clients (and their registered redirect URIs) by id.
- Adds a "Play with Claude" section to the homepage walking users through adding Kennerspiel as a custom connector — three steps, no IDs.

## What changed

- `supabase/migrations/20260615220000_create_oauth_client_table.sql` — new `oauth_client` table.
- `web/src/app/register/route.ts` — DCR endpoint.
- `web/src/app/.well-known/oauth-authorization-server/route.ts` — advertise `registration_endpoint` and the `none` auth method.
- `web/src/oauth/store.ts` — `registerClient`, `findClient`, `verifyClientSecret`.
- `web/src/oauth/config.ts` — drop env-based singleton client helpers.
- `web/src/app/authorize/{page,actions}.tsx` and `web/src/app/token/route.ts` — DB lookups; token endpoint accepts no-secret requests when the client is public.
- `web/src/app/page.tsx` — homepage instructions.

## Test plan

- [ ] Apply migration locally (`supabase db reset` or push).
- [ ] In Claude.ai, add `https://<host>/api/mcp` as a custom connector — confirm no Client ID/Secret prompt.
- [ ] Walk through the consent screen, then exercise `list_my_games`/`get_game` end-to-end.
- [ ] Verify the AS metadata at `/.well-known/oauth-authorization-server` includes `registration_endpoint` and `none` in `token_endpoint_auth_methods_supported`.
- [ ] `POST /register` with a redirect_uri that isn't https/localhost and confirm it's rejected.
- [ ] Confirm an old issued access token still resolves (existing rows unaffected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2d1F6n5Mb6ak2dDqft4Uh)_