### PR TITLE
feat(mcp): add undo_move tool

### DIFF
--- a/supabase/migrations/20260615000000_create_pop_command_function.sql
+++ b/supabase/migrations/20260615000000_create_pop_command_function.sql
@@ -1,0 +1,22 @@
+-- Atomically remove the last command from an instance, but only if the
+-- caller's view of the game is still current (compare-and-swap on the command
+-- count). Zero rows returned means someone else moved or undid first; re-read
+-- and re-validate.
+--
+-- Refuses to pop below 2 commands so CONFIG and START are never removed by an
+-- undo; that floor is the lobby/setup boundary. The MCP server additionally
+-- self-enforces that the agent only undoes its own moves.
+create or replace function public.pop_command(
+  p_instance_id uuid,
+  p_expected_count int
+) returns setof public.instance
+language sql
+as $$
+  update public.instance
+  set commands = commands[1:cardinality(commands)-1],
+      updated_at = now()
+  where id = p_instance_id
+    and cardinality(commands) = p_expected_count
+    and cardinality(commands) > 2
+  returning *;
+$$;

--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -6,6 +6,7 @@ import { listMyGames } from '@/mcp/tools/listMyGames'
 import { getGame } from '@/mcp/tools/getGame'
 import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
 import { makeMove } from '@/mcp/tools/makeMove'
+import { undoMove } from '@/mcp/tools/undoMove'
 import { joinGame } from '@/mcp/tools/joinGame'
 import { waitForMyTurn } from '@/mcp/tools/waitForMyTurn'
 import { errorResult } from '@/mcp/content'
@@ -98,6 +99,19 @@ const handler = createMcpHandler(
         trackToolCall('make_move', userId)
         if (!userId) return unauthenticated()
         return makeMove({ userId, instanceId: instance_id, command })
+      }
+    )
+    server.tool(
+      'undo_move',
+      'Undo your most recently played command in a game. This is not part of normal play — only use it when the human asks you to, e.g. to retract a sub-optimal move so they can teach a better one. Removes one command at a time (call repeatedly to roll back a multi-command turn). Only the most recent command can be undone, and only if it was your own (active when it was played). Returns the resulting state.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id'),
+      },
+      async ({ instance_id }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('undo_move', userId)
+        if (!userId) return unauthenticated()
+        return undoMove({ userId, instanceId: instance_id })
       }
     )
     server.tool(

--- a/web/src/mcp/tools/undoMove.ts
+++ b/web/src/mcp/tools/undoMove.ts
@@ -1,0 +1,56 @@
+import { GameStatusEnum } from 'hathora-et-labora-game/dist/types'
+import { activePlayerColor, asPlaying, engineColorToEntrantColor, replay } from '../engine'
+import { renderSummary } from '../render'
+import { errorResult, jsonResult, ToolResult } from '../content'
+import { fetchInstance } from './fetchInstance'
+
+export const undoMove = async ({ userId, instanceId }: { userId: string; instanceId: string }): Promise<ToolResult> => {
+  const fetched = await fetchInstance(userId, instanceId)
+  if ('error' in fetched) return errorResult(fetched.error)
+  const { supabase, instance, mySeats } = fetched
+
+  // 1. seat check
+  if (mySeats.length === 0) return errorResult('You are not seated in this game.')
+
+  // 2. floor check — the first two commands are CONFIG and START
+  if (instance.commands.length <= 2) {
+    return errorResult('Nothing to undo: the game has not had any moves played yet.')
+  }
+
+  // 3. ownership check — replay everything except the last command and read
+  // whose turn it was; only that player could have appended it
+  const priorState = asPlaying(replay(instance.commands.slice(0, -1)))
+  if (priorState === undefined) {
+    return errorResult('Cannot undo: prior state could not be replayed.')
+  }
+  if (priorState.status === GameStatusEnum.FINISHED) {
+    return errorResult('Cannot undo: prior state is already FINISHED.')
+  }
+  const lastMoveColor = engineColorToEntrantColor(activePlayerColor(priorState))
+  const lastMoveSeat = mySeats.find((s) => s.color === lastMoveColor)
+  if (!lastMoveSeat) {
+    const mine = mySeats.map((s) => s.color).join(', ')
+    return errorResult(
+      `Cannot undo: the last move was made by ${lastMoveColor}, and you are ${mine}. You can only undo your own moves.`
+    )
+  }
+
+  // 4. atomic pop — only if no one else has moved or undone since we replayed
+  const { data, error } = await supabase.rpc('pop_command', {
+    p_instance_id: instance.id,
+    p_expected_count: instance.commands.length,
+  })
+  if (error) return errorResult(`Failed to undo move: ${error.message}`)
+  if (!data || data.length === 0) {
+    return errorResult('Conflict: the game changed while you were deciding. Re-read it with get_game and try again.')
+  }
+
+  const [updated] = data
+  const updatedState = asPlaying(replay(updated.commands))
+  if (updatedState === undefined) return errorResult('Undo was applied, but the resulting state could not be replayed.')
+  return jsonResult({
+    ok: true,
+    undone: instance.commands[instance.commands.length - 1],
+    state: renderSummary(updatedState, updated.commands, lastMoveSeat.color),
+  })
+}

--- a/web/src/supabase.types.ts
+++ b/web/src/supabase.types.ts
@@ -1,10 +1,4 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export type Database = {
   graphql_public: {
@@ -36,7 +30,7 @@ export type Database = {
     Tables: {
       entrant: {
         Row: {
-          color: Database["public"]["Enums"]["color"]
+          color: Database['public']['Enums']['color']
           created_at: string | null
           id: string
           instance_id: string | null
@@ -44,7 +38,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
-          color: Database["public"]["Enums"]["color"]
+          color: Database['public']['Enums']['color']
           created_at?: string | null
           id?: string
           instance_id?: string | null
@@ -52,7 +46,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
-          color?: Database["public"]["Enums"]["color"]
+          color?: Database['public']['Enums']['color']
           created_at?: string | null
           id?: string
           instance_id?: string | null
@@ -61,18 +55,18 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "entrant_instance_id_fkey"
-            columns: ["instance_id"]
+            foreignKeyName: 'entrant_instance_id_fkey'
+            columns: ['instance_id']
             isOneToOne: false
-            referencedRelation: "instance"
-            referencedColumns: ["id"]
+            referencedRelation: 'instance'
+            referencedColumns: ['id']
           },
           {
-            foreignKeyName: "entrant_profile_id_fkey"
-            columns: ["profile_id"]
+            foreignKeyName: 'entrant_profile_id_fkey'
+            columns: ['profile_id']
             isOneToOne: false
-            referencedRelation: "profile"
-            referencedColumns: ["id"]
+            referencedRelation: 'profile'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -103,11 +97,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "instance_owner_id_fkey"
-            columns: ["owner_id"]
+            foreignKeyName: 'instance_owner_id_fkey'
+            columns: ['owner_id']
             isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -126,11 +120,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "profile_id_fkey"
-            columns: ["id"]
+            foreignKeyName: 'profile_id_fkey'
+            columns: ['id']
             isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            referencedRelation: 'users'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -154,9 +148,23 @@ export type Database = {
           updated_at: string
         }[]
       }
+      pop_command: {
+        Args: {
+          p_expected_count: number
+          p_instance_id: string
+        }
+        Returns: {
+          commands: string[]
+          created_at: string
+          hidden: boolean | null
+          id: string
+          owner_id: string
+          updated_at: string
+        }[]
+      }
     }
     Enums: {
-      color: "red" | "green" | "blue" | "white"
+      color: 'red' | 'green' | 'blue' | 'white'
     }
     CompositeTypes: {
       [_ in never]: never
@@ -164,27 +172,23 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, 'public'>]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -192,20 +196,18 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -213,20 +215,18 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -234,15 +234,12 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
-    | { schema: keyof Database },
+  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+    ? PublicSchema['Enums'][PublicEnumNameOrOptions]
     : never
-


### PR DESCRIPTION
## Summary

Adds an `undo_move` MCP tool so the human can ask the agent to retract a sub-optimal command and try a different line — useful for teaching, not normal play.

- **New tool `undo_move`** (`web/src/mcp/tools/undoMove.ts`, registered in `web/src/app/api/[transport]/route.ts`): takes `{ instance_id }`, removes the most recent command, returns the resulting board summary. Description in the tool registration is explicit that this is teaching-only and not part of normal play.
- **Ownership enforcement**: replays the game minus the last command and reads the active player at that point. The undo is rejected unless that color is one of the agent's seats — the agent cannot undo a move that wasn't its own.
- **Floor**: refuses to pop below 2 commands so `CONFIG` and `START` are never removed (lobby/setup boundary). Also rejects undo when the prior state is `FINISHED`.
- **Atomicity**: new `pop_command` Postgres RPC mirrors `append_command`'s CAS pattern — `update ... where cardinality(commands) = p_expected_count` — so an undo that races with a concurrent move (or another undo) fails cleanly instead of clobbering. The RPC also enforces `cardinality(commands) > 2` as a belt-and-suspenders for the floor.
- **Realtime**: like `make_move`, the undo writes through `update instance`, so existing realtime broadcast triggers fan it out to humans' browsers without extra work.
- `web/src/supabase.types.ts` updated with the new RPC's signature (hand-edited to match what `gentypes` would emit once the migration is applied).

## Test plan

- [ ] `pnpm` (or `npm`) typecheck and lint clean on the web app — done locally
- [ ] Existing web tests still pass — done locally (17/17)
- [ ] Apply the migration in a Supabase environment and call `pop_command(uuid, expected_count)`; verify zero rows when expected_count is wrong and when commands ≤ 2
- [ ] From an MCP client, play a turn then call `undo_move`; verify the last command is removed and `get_game` reflects it
- [ ] Verify `undo_move` is rejected when (a) you're not seated, (b) the last move was someone else's, (c) the game has only CONFIG+START
- [ ] Verify the realtime trigger pushes the undo to a watching browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tss7uiMESm2QbEnUMbAa3Y)_