### PR TITLE
fix: round tower should be 2 dwelling not 9

### DIFF
--- a/game/src/board/__tests__/erections.test.ts
+++ b/game/src/board/__tests__/erections.test.ts
@@ -112,7 +112,7 @@ describe('board/erections', () => {
         [BuildingEnum.CoalHarbor, 12, 0],
         [BuildingEnum.FilialChurch, 6, 7],
         [BuildingEnum.Cooperage, 5, 3],
-        [BuildingEnum.RoundTower, 6, 9],
+        [BuildingEnum.RoundTower, 6, 2],
         [BuildingEnum.Camera, 5, 3],
         [BuildingEnum.Bulwark, 8, 6],
         [BuildingEnum.FestivalGround, 3, 7],

--- a/game/src/board/erections.ts
+++ b/game/src/board/erections.ts
@@ -227,7 +227,7 @@ export const pointsForDwelling = (building: ErectionEnum): number =>
     .with(BuildingEnum.CoalHarbor, () => 0)
     .with(BuildingEnum.Bulwark, () => 6)
     .with(BuildingEnum.FestivalGround, () => 7)
-    .with(BuildingEnum.RoundTower, () => 9)
+    .with(BuildingEnum.RoundTower, () => 2)
     .with(BuildingEnum.Camera, () => 3)
     .with(BuildingEnum.Guesthouse, () => 5)
     .with(BuildingEnum.ClayMoundR, () => 3)


### PR DESCRIPTION
https://github.com/philihp/kennerspiel/blob/4619c22/docs/ora-et-labora-strategy-SKILL.md#kennerspiel-engine-quirks--suspected-bugs had suspected a problem with RoundTower after scanning through the source code. interesting. this should fix it.