### PR TITLE
chore(game): bump to 0.20.2 and add CHANGELOG

### DIFF
--- a/game/CHANGELOG.md
+++ b/game/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [0.20.2] - 2026-06-16
+
+### Fixed
+- Round Tower corrected to award 2 dwelling points (was incorrectly 9) (#1800)
+- Forger's Workshop move enumeration now generates all affordable reliquary tiers (5, 15, 25, 35, 45 coins) instead of capping at 2 reliquaries (#1798)
+
+## [0.20.1] - 2026-06-14
+
+### Fixed
+- Re-enabled TypeScript declaration file (`.d.ts`) emit that had been accidentally disabled, unblocking Vercel deploys (#1783)
+
+## [0.20.0] - 2026-06-14
+
+### Changed
+- Repository rebranded from `hathora-et-labora` to `kennerspiel`; README badges and CI links updated accordingly
+
+### Fixed
+- Bonus round no longer offers a phantom `USE` action for `buildContinuation` when the prior is not free (#1775)

--- a/game/package.json
+++ b/game/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.1",
+  "version": "0.20.2",
   "name": "hathora-et-labora-game",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- Bumps `hathora-et-labora-game` from 0.20.1 → 0.20.2
- Adds `game/CHANGELOG.md` covering 0.20.0, 0.20.1, and 0.20.2

## Changelog entries

**0.20.2** (patch — two bug fixes):
- Round Tower corrected to 2 dwelling points (was 9) (#1800)
- Forger's Workshop move enumeration now covers all affordable reliquary tiers up to 5 (#1798)

**0.20.1** (patch — build fix):
- Re-enabled `.d.ts` emit that had been accidentally disabled (#1783)

**0.20.0** (minor — rebrand + bug fix):
- Repo rebranded from `hathora-et-labora` to `kennerspiel`
- Fixed phantom `USE` bonus action in `buildContinuation` when prior is not free (#1775)

https://claude.ai/code/session_01Ro86kdnMZspYqPpxj5JUHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ro86kdnMZspYqPpxj5JUHw)_