### PR TITLE
docs: add Claude MCP connection guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This is an implementation of Uwe Rosenberg's game [Ora et Labora](https://amzn.t
 - [`game`](https://github.com/philihp/kennerspiel/tree/main/game) - a stateless game logic library, available on [npm](https://www.npmjs.com/package/hathora-et-labora-game) licensed under GPL-3.
 - [`web`](https://github.com/philihp/kennerspiel/blob/main/web/) - this is the website that gets shot up to Vercel.
 
-## Playing with Claude
+## Playing with AI
 
-Kennerspiel has an [MCP](https://modelcontextprotocol.io/) server at `https://kennerspiel.com/api/mcp` that lets Claude play Ora et Labora on your behalf. Claude will read the board, consult the strategy guide, enumerate legal moves, and play — all as your account.
+Kennerspiel exposes an [MCP](https://modelcontextprotocol.io/) server at `https://kennerspiel.com/api/mcp`. Any MCP-compatible AI client can connect, read the board, consult the built-in strategy guide, enumerate legal moves, and play — all as your Kennerspiel account. Authentication uses standard OAuth 2.1 + PKCE; clients that support dynamic client registration (RFC 7591) connect without any manual setup.
 
 ### Connect via claude.ai
 
@@ -27,9 +27,53 @@ Kennerspiel has an [MCP](https://modelcontextprotocol.io/) server at `https://ke
 claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp
 ```
 
-Claude Code will open a browser for the same OAuth login and redirect back automatically. Once connected, you can ask Claude to join a lobby by sharing the game URL, or to check its pending games with `list_my_games`.
+Claude Code opens a browser for the OAuth flow and redirects back automatically. Once connected, ask Claude to join a lobby by sharing the game URL, or check pending games with `list_my_games`.
 
-### What Claude can do
+### Connect via ChatGPT
+
+ChatGPT supports MCP connectors for Plus, Pro, Business, and Enterprise accounts.
+
+1. Sign in at [kennerspiel.com](https://kennerspiel.com) first.
+2. In [chatgpt.com](https://chatgpt.com), open **Settings → Connectors → Create**.
+3. Enter the MCP server URL: `https://kennerspiel.com/api/mcp`
+4. ChatGPT discovers the OAuth endpoints automatically and redirects you to Kennerspiel to authorize.
+5. Done. Open a new chat and ask ChatGPT to join or play a game.
+
+> Developer mode must be enabled in your workspace (**Workspace Settings → Permissions & Roles → Connected Data → Developer mode**) before custom MCP connectors appear.
+
+### Connect via OpenAI Responses API
+
+First complete the OAuth flow to obtain an access token (30-day TTL):
+
+1. Register your client at `https://kennerspiel.com/register` (RFC 7591 dynamic registration).
+2. Send the user through the authorization flow at `https://kennerspiel.com/authorize` with `response_type=code`, `code_challenge_method=S256`, and `scope=play`.
+3. Exchange the returned code for a token at `https://kennerspiel.com/token`.
+
+Then pass the token in every Responses API call:
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+response = client.responses.create(
+    model="gpt-4o",
+    tools=[{
+        "type": "mcp",
+        "server_label": "kennerspiel",
+        "server_url": "https://kennerspiel.com/api/mcp",
+        "require_approval": "never",
+        "headers": {
+            "Authorization": "Bearer <your-access-token>"
+        }
+    }],
+    input="List my Ora et Labora games and make a move if it's my turn."
+)
+print(response.output_text)
+```
+
+The OAuth server metadata is published at `https://kennerspiel.com/.well-known/oauth-authorization-server` for clients that auto-discover endpoints.
+
+### Available tools
 
 | Tool | What it does |
 |---|---|
@@ -38,11 +82,11 @@ Claude Code will open a browser for the same OAuth login and redirect back autom
 | `get_game` | Read the current board state: rondel, tableaus, scores, turn order |
 | `get_legal_moves` | Enumerate legal next tokens for a move (interactive drill-down) |
 | `make_move` | Play one command, e.g. `USE LR2` or `BUILD G07 3 2` or `COMMIT` |
-| `undo_move` | Retract the most recent command (use when teaching Claude a better line) |
+| `undo_move` | Retract the most recent command (use when teaching the model a better line) |
 | `wait_for_my_turn` | Long-poll until it's your turn, rather than polling repeatedly |
-| `get_strategy_guide` | Load the full France/long-2p coaching guide Claude consults for decisions |
+| `get_strategy_guide` | Load the full France/long-2p coaching guide the model consults for decisions |
 
-Claude holds seats and makes moves as your Kennerspiel account — human opponents see your moves appear live in their browser just like any other player's.
+The AI holds seats and makes moves as your Kennerspiel account — human opponents see moves appear live in their browser just like any other player's.
 
 ## To Update Game Logic
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,41 @@ This is an implementation of Uwe Rosenberg's game [Ora et Labora](https://amzn.t
 - [`game`](https://github.com/philihp/kennerspiel/tree/main/game) - a stateless game logic library, available on [npm](https://www.npmjs.com/package/hathora-et-labora-game) licensed under GPL-3.
 - [`web`](https://github.com/philihp/kennerspiel/blob/main/web/) - this is the website that gets shot up to Vercel.
 
+## Playing with Claude
+
+Kennerspiel has an [MCP](https://modelcontextprotocol.io/) server at `https://kennerspiel.com/api/mcp` that lets Claude play Ora et Labora on your behalf. Claude will read the board, consult the strategy guide, enumerate legal moves, and play — all as your account.
+
+### Connect via claude.ai
+
+1. Sign in at [kennerspiel.com](https://kennerspiel.com) and create an account if you don't have one.
+2. In [claude.ai](https://claude.ai), open **Settings → Integrations** and click **Add integration**.
+3. Enter the MCP server URL: `https://kennerspiel.com/api/mcp`
+4. Claude will redirect you to Kennerspiel to log in and confirm access. Click **Authorize**.
+5. Done. Start a new conversation and tell Claude which game to join or play.
+
+### Connect via Claude Code
+
+```sh
+claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp
+```
+
+Claude Code will open a browser for the same OAuth login and redirect back automatically. Once connected, you can ask Claude to join a lobby by sharing the game URL, or to check its pending games with `list_my_games`.
+
+### What Claude can do
+
+| Tool | What it does |
+|---|---|
+| `list_my_games` | Find all games you're seated in; filter to games waiting on your move |
+| `join_game` | Claim a seat in an open lobby (pass the game URL or UUID) |
+| `get_game` | Read the current board state: rondel, tableaus, scores, turn order |
+| `get_legal_moves` | Enumerate legal next tokens for a move (interactive drill-down) |
+| `make_move` | Play one command, e.g. `USE LR2` or `BUILD G07 3 2` or `COMMIT` |
+| `undo_move` | Retract the most recent command (use when teaching Claude a better line) |
+| `wait_for_my_turn` | Long-poll until it's your turn, rather than polling repeatedly |
+| `get_strategy_guide` | Load the full France/long-2p coaching guide Claude consults for decisions |
+
+Claude holds seats and makes moves as your Kennerspiel account — human opponents see your moves appear live in their browser just like any other player's.
+
 ## To Update Game Logic
 
 The game logic must be published separately from the Docker image.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,25 +13,44 @@ const Home = () => {
         You&apos;ll probably want to start out by creating an <Link href="/instance/">instance</Link>, and either play a
         solo game or invite some friends.
       </p>
-      <h2>Play with Claude</h2>
+      <h2>Play with an AI</h2>
       <p>
-        You can also let Claude take a seat at your table. Add Kennerspiel as a custom connector in Claude and it can
-        list your games, read the board, and play moves on your behalf — useful for solo learning, AI-vs-AI matches, or
-        just having a patient opponent at 2am.
+        Kennerspiel has an <Link href="https://modelcontextprotocol.io/">MCP</Link> server at{' '}
+        <code>https://kennerspiel.com/api/mcp</code>. Any MCP-compatible AI can take a seat at your table — it will
+        read the board, consult a built-in strategy guide, and play moves on your behalf. Useful for solo learning,
+        AI-vs-AI matches, or just having a patient opponent at 2am.
       </p>
+      <h3>Claude (claude.ai)</h3>
       <ol>
         <li>
-          In Claude, open <strong>Settings → Connectors → Add custom connector</strong>.
+          Open <strong>Settings → Integrations → Add integration</strong>.
         </li>
         <li>
           Paste this URL: <code>https://kennerspiel.com/api/mcp</code>
         </li>
-        <li>Click Add, then sign in to Kennerspiel when Claude opens the authorization page.</li>
+        <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
       </ol>
       <p>
-        That&apos;s it — no client IDs, no secrets, no copy-pasting. After authorizing, ask Claude something like
-        &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find this server&apos;s tools.
+        No client IDs, no secrets, no copy-pasting. Ask Claude something like &ldquo;list my Ora et Labora
+        games&rdquo; and it&apos;ll find the tools automatically.
       </p>
+      <h3>Claude Code</h3>
+      <p>Run this once in your terminal:</p>
+      <pre>
+        <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
+      </pre>
+      <p>Claude Code will open a browser for the OAuth flow and redirect back automatically.</p>
+      <h3>ChatGPT</h3>
+      <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
+      <ol>
+        <li>
+          Open <strong>Settings → Connectors → Create</strong>.
+        </li>
+        <li>
+          Paste this URL: <code>https://kennerspiel.com/api/mcp</code>
+        </li>
+        <li>ChatGPT discovers the OAuth endpoints automatically and redirects you here to authorize.</li>
+      </ol>
       <p>
         Source code is available at{' '}
         <Link href="https://github.com/philihp/kennerspiel">github.com/philihp/kennerspiel</Link>
@@ -41,3 +60,4 @@ const Home = () => {
 }
 
 export default Home
+


### PR DESCRIPTION
## Summary

- Adds a "Playing with Claude" section to the README explaining how to connect a Claude account to Kennerspiel via OAuth
- Covers both claude.ai (Settings → Integrations) and Claude Code (`claude mcp add`) connection flows
- Includes a tool reference table summarizing what Claude can do once connected

## Test plan

- [ ] Read through the steps on a fresh machine to verify they're accurate and complete
- [ ] Confirm the MCP server URL (`https://kennerspiel.com/api/mcp`) resolves and the OAuth flow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUGcARxMQbjc6cRSYF2R6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUGcARxMQbjc6cRSYF2R6u)_