### PR TITLE
fix(mcp): resolve strategy guide path on Vercel runtime

### DIFF
--- a/web/src/mcp/tools/getStrategyGuide.ts
+++ b/web/src/mcp/tools/getStrategyGuide.ts
@@ -2,12 +2,14 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 import { ToolResult } from '../content'
 
-// Lazy-loaded so the readFileSync runs at request time (Vercel runtime, /var/task),
-// not at build time (process.cwd() differs between build and runtime environments).
-// The file is bundled via outputFileTracingIncludes in next.config.mjs.
+// Lazy-loaded so the readFileSync runs at request time, not at build time.
+// next.config.mjs sets outputFileTracingRoot to the monorepo root and bundles
+// docs/ora-et-labora-strategy-SKILL.md relative to it, so the file ships to
+// <root>/docs/... . On Vercel the function's cwd is the Next app dir (<root>/web),
+// so resolve up one level to reach the tracing root where docs/ lives.
 let guide: string | undefined
 const loadGuide = (): string => {
-  if (!guide) guide = readFileSync(join(process.cwd(), 'docs/ora-et-labora-strategy-SKILL.md'), 'utf-8')
+  if (!guide) guide = readFileSync(join(process.cwd(), '..', 'docs/ora-et-labora-strategy-SKILL.md'), 'utf-8')
   return guide
 }
 


### PR DESCRIPTION
## Summary

- `process.cwd()` on Vercel at runtime is the Next.js app directory (`<root>/web`), not the monorepo root
- `outputFileTracingRoot` bundles `docs/` relative to the monorepo root, so the file lands at `<root>/docs/...`
- Fix: resolve `..` from `cwd()` to reach the tracing root before joining `docs/`

## Test plan

- [ ] Deploy to Vercel and call `get_strategy_guide` via MCP — should return guide content instead of ENOENT
- [ ] Local `next dev` still works (resolving `../docs/` from `web/` correctly reaches `docs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3ph7ANzyF8PVYTRNGqaLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3ph7ANzyF8PVYTRNGqaLc)_