### PR TITLE
feat(web): expose MCP, OpenAPI, agents.txt, and llms.txt discovery files

### DIFF
--- a/web/src/app/.well-known/agents.json/route.ts
+++ b/web/src/app/.well-known/agents.json/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { issuer } from '@/oauth/config'
+
+// agents-txt.com 1.0 capability surface. Declares the MCP transport and the
+// OAuth endpoints that gate it, so well-behaved agents can discover the
+// sanctioned channel without scraping pages.
+export const GET = () => {
+  const iss = issuer()
+  return NextResponse.json(
+    {
+      specVersion: '1.0',
+      site: {
+        name: 'Kennerspiel',
+        url: iss,
+        description: "Digital tabletop for Uwe Rosenberg's Ora et Labora.",
+      },
+      capabilities: [
+        {
+          id: 'play-ora-et-labora',
+          description:
+            'MCP server: list seats, read board state, enumerate legal moves, play moves, consult the strategy guide.',
+          endpoint: `${iss}/api/mcp`,
+          method: 'POST',
+          protocol: 'MCP',
+          auth: 'oauth2',
+          authEndpoint: `${iss}/authorize`,
+          authDocs: `${iss}/.well-known/oauth-authorization-server`,
+          scopes: ['play'],
+        },
+        {
+          id: 'mcp-discovery',
+          description: 'MCP server card describing the transport, auth, and tool catalog.',
+          endpoint: `${iss}/.well-known/mcp.json`,
+          method: 'GET',
+          protocol: 'REST',
+          auth: 'none',
+        },
+        {
+          id: 'openapi-spec',
+          description: 'OpenAPI 3.1 description of the HTTP surface.',
+          endpoint: `${iss}/openapi.json`,
+          method: 'GET',
+          protocol: 'REST',
+          auth: 'none',
+        },
+      ],
+      agents: {
+        '*': {
+          rateLimit: { requests: 60, window: 'minute' },
+        },
+      },
+      allow: ['/api/mcp', '/.well-known/*', '/openapi.json', '/llms.txt', '/agents.txt', '/agents.json'],
+      disallow: ['/account/*', '/private/*'],
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': 'public, max-age=3600',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+    },
+  })

--- a/web/src/app/.well-known/agents.txt/route.ts
+++ b/web/src/app/.well-known/agents.txt/route.ts
@@ -1,0 +1,66 @@
+import { issuer } from '@/oauth/config'
+
+// agents-txt.com 1.0 plain-text fallback for clients that don't read agents.json.
+export const GET = () => {
+  const iss = issuer()
+  const body = `Spec-Version: 1.0
+
+Site-Name: Kennerspiel
+Site-URL: ${iss}
+Site-Description: Digital tabletop for Uwe Rosenberg's Ora et Labora.
+
+Capability: play-ora-et-labora
+  Endpoint: ${iss}/api/mcp
+  Method: POST
+  Protocol: MCP
+  Auth: oauth2
+  Auth-Endpoint: ${iss}/authorize
+  Auth-Docs: ${iss}/.well-known/oauth-authorization-server
+  Scopes: play
+  Description: List seats, read board state, enumerate legal moves, play moves, consult the strategy guide.
+
+Capability: mcp-discovery
+  Endpoint: ${iss}/.well-known/mcp.json
+  Method: GET
+  Protocol: REST
+  Auth: none
+  Description: MCP server card.
+
+Capability: openapi-spec
+  Endpoint: ${iss}/openapi.json
+  Method: GET
+  Protocol: REST
+  Auth: none
+  Description: OpenAPI 3.1 description of the HTTP surface.
+
+Allow: /api/mcp
+Allow: /.well-known/*
+Allow: /openapi.json
+Allow: /llms.txt
+Allow: /agents.txt
+Allow: /agents.json
+Disallow: /account/*
+Disallow: /private/*
+
+Agent: *
+  Rate-Limit: 60/minute
+`
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+    },
+  })

--- a/web/src/app/.well-known/mcp.json/route.ts
+++ b/web/src/app/.well-known/mcp.json/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server'
+import { issuer, SCOPE } from '@/oauth/config'
+
+// Discovery document for the Kennerspiel MCP server. Combines the shape of the
+// SEP-1649 "server card" with the SEP-1960 manifest so either flavor of MCP
+// client can locate the transport endpoint, the OAuth metadata, and the tool
+// catalog without first completing a JSON-RPC handshake.
+export const GET = () => {
+  const iss = issuer()
+  const mcpUrl = `${iss}/api/mcp`
+  return NextResponse.json(
+    {
+      $schema: 'https://modelcontextprotocol.io/schemas/server-card/v1.0',
+      version: '1.0',
+      protocolVersion: '2025-06-18',
+      serverInfo: {
+        name: 'Kennerspiel',
+        version: '1.0.0',
+        description:
+          "MCP server for Uwe Rosenberg's Ora et Labora on kennerspiel.com — read the board, enumerate legal moves, and play as the authenticated user.",
+        homepage: iss,
+        vendor: 'Kennerspiel',
+        license: 'GPL-3.0',
+        repository: 'https://github.com/philihp/kennerspiel',
+      },
+      transport: {
+        type: 'streamable-http',
+        url: mcpUrl,
+      },
+      endpoints: [
+        {
+          url: mcpUrl,
+          transport: 'streamable-http',
+          capabilities: ['tools'],
+          auth: {
+            type: 'oauth2',
+            authorization_server: `${iss}/.well-known/oauth-authorization-server`,
+            protected_resource: `${iss}/.well-known/oauth-protected-resource`,
+            scopes: [SCOPE],
+          },
+        },
+      ],
+      capabilities: {
+        tools: true,
+        resources: false,
+        prompts: false,
+      },
+      auth: {
+        type: 'oauth2',
+        authorization_server: `${iss}/.well-known/oauth-authorization-server`,
+        protected_resource: `${iss}/.well-known/oauth-protected-resource`,
+        scopes: [SCOPE],
+      },
+      tools: [
+        {
+          name: 'list_my_games',
+          description:
+            'List the Ora et Labora games this agent is seated in. Filter to games waiting on your move with only_my_turn.',
+        },
+        {
+          name: 'get_game',
+          description:
+            'Read the current board state of one game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves.',
+        },
+        {
+          name: 'get_legal_moves',
+          description:
+            'Enumerate legal next tokens of a move command. Interactive drill-down from an empty partial to a complete command.',
+        },
+        {
+          name: 'join_game',
+          description: 'Claim a seat in an Ora et Labora lobby that has not yet started, by game UUID or URL.',
+        },
+        {
+          name: 'make_move',
+          description:
+            'Play one complete move command in a game where it is your turn (e.g. USE LR2, BUILD G07 3 2, COMMIT).',
+        },
+        {
+          name: 'undo_move',
+          description: 'Retract the most recent command. Only the active player can undo, one command at a time.',
+        },
+        {
+          name: 'get_strategy_guide',
+          description: 'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p).',
+        },
+        {
+          name: 'wait_for_my_turn',
+          description: 'Long-poll until it becomes your turn in the given game, the game ends, or the timeout elapses.',
+        },
+      ],
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': 'public, max-age=3600',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+    },
+  })

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -33,6 +33,10 @@ const RootLayout = async ({
   return (
     <SupabaseContextProvider>
       <html lang="en">
+        <head>
+          <link rel="service" type="application/mcp+json" href="/.well-known/mcp.json" />
+          <link rel="service-desc" href="/openapi.json" />
+        </head>
         <body>
           <Header />
           <hr />

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -1,0 +1,50 @@
+import { issuer } from '@/oauth/config'
+
+// llmstxt.org structured markdown index. Points LLMs at the MCP server, OAuth
+// flow, and the strategy guide rather than scraping the React UI.
+export const GET = () => {
+  const iss = issuer()
+  const body = `# Kennerspiel
+
+> Digital tabletop for Uwe Rosenberg's Ora et Labora. Humans play in a browser; AI agents play through a hosted MCP server using the same accounts as humans.
+
+Kennerspiel exposes an MCP server at \`${iss}/api/mcp\`. Any MCP-compatible client can connect, authenticate the user via OAuth 2.1 + PKCE (with RFC 7591 dynamic client registration), and play as that account. The full strategy guide is loaded by the \`get_strategy_guide\` tool; prefer calling that over scraping pages.
+
+## Machine-readable surface
+
+- [MCP server card](${iss}/.well-known/mcp.json): Discovery document — transport, auth, tool catalog.
+- [OpenAPI 3.1 spec](${iss}/openapi.json): HTTP surface (MCP transport + OAuth endpoints).
+- [agents.json](${iss}/.well-known/agents.json): agents-txt.com capability surface.
+- [OAuth authorization-server metadata](${iss}/.well-known/oauth-authorization-server): RFC 8414.
+- [OAuth protected-resource metadata](${iss}/.well-known/oauth-protected-resource): RFC 9728.
+
+## MCP tools
+
+- \`list_my_games\`: Find all games you're seated in; filter to games waiting on your move.
+- \`join_game\`: Claim a seat in an open lobby (pass the game URL or UUID).
+- \`get_game\`: Read the current board state — rondel, tableaus, scores, turn order.
+- \`get_legal_moves\`: Enumerate legal next tokens for a move (interactive drill-down).
+- \`make_move\`: Play one command (e.g. \`USE LR2\`, \`BUILD G07 3 2\`, \`COMMIT\`).
+- \`undo_move\`: Retract the most recent command.
+- \`wait_for_my_turn\`: Long-poll until it is your turn — preferred over repeated polling.
+- \`get_strategy_guide\`: Load the full France/long-2p coaching guide.
+
+## Connecting
+
+- [Source code](https://github.com/philihp/kennerspiel): Repository, including the game-logic library and web app.
+- [README](https://github.com/philihp/kennerspiel#readme): Step-by-step instructions for claude.ai, Claude Code, ChatGPT connectors, and the OpenAI Responses API.
+
+## Optional
+
+- [npm: hathora-et-labora-game](https://www.npmjs.com/package/hathora-et-labora-game): Stateless game-logic library (GPL-3.0).
+- [Ora et Labora on BoardGameGeek](https://boardgamegeek.com/boardgame/70149/ora-et-labora): The published game this implements.
+`
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })
+}

--- a/web/src/app/openapi.json/route.ts
+++ b/web/src/app/openapi.json/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from 'next/server'
+import { issuer, SCOPE } from '@/oauth/config'
+
+// OpenAPI 3.1 description of the HTTP surface exposed by kennerspiel.com:
+// the MCP transport endpoint plus the OAuth 2.1 authorization-server endpoints
+// that gate access to it. Linked from page <head> via rel="service-desc".
+export const GET = () => {
+  const iss = issuer()
+  return NextResponse.json(
+    {
+      openapi: '3.1.0',
+      info: {
+        title: 'Kennerspiel',
+        version: '1.0.0',
+        summary: 'Kennerspiel MCP server and OAuth 2.1 endpoints.',
+        description:
+          'HTTP surface for kennerspiel.com — the MCP transport at /api/mcp plus the OAuth 2.1 + PKCE authorization-server endpoints (RFC 7591 dynamic registration, RFC 8414 metadata, RFC 9728 protected-resource metadata) that gate it.',
+        license: { name: 'GPL-3.0', identifier: 'GPL-3.0' },
+        contact: { name: 'philihp', url: 'https://github.com/philihp/kennerspiel' },
+      },
+      servers: [{ url: iss }],
+      components: {
+        securitySchemes: {
+          oauth2: {
+            type: 'oauth2',
+            description: 'OAuth 2.1 authorization code with PKCE. Tokens have a 30-day TTL.',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: `${iss}/authorize`,
+                tokenUrl: `${iss}/token`,
+                scopes: { [SCOPE]: 'Play Ora et Labora as the signed-in Kennerspiel user.' },
+              },
+            },
+          },
+        },
+      },
+      paths: {
+        '/api/mcp': {
+          post: {
+            operationId: 'mcpRpc',
+            summary: 'Model Context Protocol transport.',
+            description:
+              'Streamable-HTTP MCP transport. Send JSON-RPC requests for tools/list, tools/call, etc. Tools: list_my_games, get_game, get_legal_moves, join_game, make_move, undo_move, get_strategy_guide, wait_for_my_turn.',
+            security: [{ oauth2: [SCOPE] }],
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: {
+              200: {
+                description: 'JSON-RPC response.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              401: { description: 'Missing or invalid bearer token.' },
+            },
+          },
+        },
+        '/register': {
+          post: {
+            operationId: 'registerClient',
+            summary: 'RFC 7591 dynamic client registration.',
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: {
+              201: {
+                description: 'Client registered.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+            },
+          },
+        },
+        '/authorize': {
+          get: {
+            operationId: 'authorize',
+            summary: 'OAuth 2.1 authorization endpoint (PKCE required).',
+            parameters: [
+              { name: 'response_type', in: 'query', required: true, schema: { type: 'string', enum: ['code'] } },
+              { name: 'client_id', in: 'query', required: true, schema: { type: 'string' } },
+              { name: 'redirect_uri', in: 'query', required: true, schema: { type: 'string', format: 'uri' } },
+              { name: 'code_challenge', in: 'query', required: true, schema: { type: 'string' } },
+              {
+                name: 'code_challenge_method',
+                in: 'query',
+                required: true,
+                schema: { type: 'string', enum: ['S256'] },
+              },
+              { name: 'scope', in: 'query', required: false, schema: { type: 'string', default: SCOPE } },
+              { name: 'state', in: 'query', required: false, schema: { type: 'string' } },
+              { name: 'resource', in: 'query', required: false, schema: { type: 'string', format: 'uri' } },
+            ],
+            responses: {
+              302: { description: 'Redirect back to the client with code and state.' },
+              200: { description: 'Authorization consent page (when the user is not yet signed in).' },
+            },
+          },
+        },
+        '/token': {
+          post: {
+            operationId: 'token',
+            summary: 'OAuth 2.1 token endpoint (authorization_code grant).',
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['grant_type', 'code', 'redirect_uri', 'client_id', 'code_verifier'],
+                    properties: {
+                      grant_type: { type: 'string', enum: ['authorization_code'] },
+                      code: { type: 'string' },
+                      redirect_uri: { type: 'string', format: 'uri' },
+                      client_id: { type: 'string' },
+                      code_verifier: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              200: {
+                description: 'Access token issued.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              400: { description: 'Invalid grant.' },
+            },
+          },
+        },
+        '/.well-known/oauth-authorization-server': {
+          get: {
+            operationId: 'oauthAuthorizationServerMetadata',
+            summary: 'RFC 8414 authorization server metadata.',
+            responses: {
+              200: { description: 'JSON metadata.', content: { 'application/json': { schema: { type: 'object' } } } },
+            },
+          },
+        },
+        '/.well-known/oauth-protected-resource': {
+          get: {
+            operationId: 'oauthProtectedResourceMetadata',
+            summary: 'RFC 9728 protected resource metadata.',
+            responses: {
+              200: { description: 'JSON metadata.', content: { 'application/json': { schema: { type: 'object' } } } },
+            },
+          },
+        },
+        '/.well-known/mcp.json': {
+          get: {
+            operationId: 'mcpDiscovery',
+            summary: 'MCP server discovery document.',
+            responses: {
+              200: {
+                description: 'JSON server card.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': 'public, max-age=3600',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }
+  )
+}
+
+export const OPTIONS = () =>
+  new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+    },
+  })


### PR DESCRIPTION
## Summary

Adds machine-readable discovery surfaces so MCP clients and AI agents can locate the Kennerspiel MCP server, its OAuth flow, and its tool catalog without scraping the React UI.

New routes (all served with `Access-Control-Allow-Origin: *`, `Cache-Control: public, max-age=3600`, and `X-Content-Type-Options: nosniff`):

- `/.well-known/mcp.json` — MCP server card (SEP-1649 + SEP-1960 shape): transport URL, OAuth metadata pointers, capabilities, and tool list.
- `/openapi.json` — OpenAPI 3.1 description of the HTTP surface: `/api/mcp`, `/register`, `/authorize`, `/token`, and the OAuth `.well-known` endpoints, with an `oauth2` security scheme.
- `/.well-known/agents.json` and `/.well-known/agents.txt` — agents-txt.com 1.0 capability surface (JSON + plain-text fallback).
- `/llms.txt` — llmstxt.org structured markdown index pointing at the MCP server, tool list, OAuth metadata, README, and the source repository.

`app/layout.tsx` renders two `<link>` tags inside `<head>` so clients can auto-discover the MCP card and OpenAPI spec from any page:

```html
<link rel="service" type="application/mcp+json" href="/.well-known/mcp.json" />
<link rel="service-desc" href="/openapi.json" />
```

All URLs in the documents are computed from the existing `issuer()` helper, so dev/preview/prod each emit the right origin.

## Test plan

- [ ] `pnpm dev` → load `/`, view source, confirm both `<link rel="service*">` tags are present in `<head>`.
- [ ] `curl https://kennerspiel.com/.well-known/mcp.json | jq` returns the server card with transport `https://kennerspiel.com/api/mcp` and the eight tools.
- [ ] `curl https://kennerspiel.com/openapi.json | jq .openapi` returns `"3.1.0"`; paths include `/api/mcp`, `/authorize`, `/token`, `/register`, and the three `.well-known` endpoints.
- [ ] `curl https://kennerspiel.com/.well-known/agents.json | jq .specVersion` returns `"1.0"`; capabilities list includes `play-ora-et-labora` with `protocol: "MCP"`.
- [ ] `curl https://kennerspiel.com/.well-known/agents.txt` returns plain-text with `Spec-Version: 1.0` and the same capabilities.
- [ ] `curl https://kennerspiel.com/llms.txt` returns markdown starting with `# Kennerspiel` and a blockquote summary.
- [ ] `curl -I https://kennerspiel.com/.well-known/mcp.json` shows `access-control-allow-origin: *` and `cache-control: public, max-age=3600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY

---
_Generated by [Claude Code](https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY)_