### PR TITLE
chore(web): allow agent discovery files through robots.txt

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,1 +1,7 @@
-User-agent: * Disallow: /
+User-agent: *
+Disallow: /
+Allow: /.well-known/
+Allow: /llms.txt
+Allow: /openapi.json
+Allow: /agents.txt
+Allow: /agents.json


### PR DESCRIPTION
## Summary

Follow-up to #1808. The site-wide `Disallow: /` in `robots.txt` would tell strict crawlers to skip `/llms.txt` and `/openapi.json` (and could be read as covering `/.well-known/`), which defeats the point of publishing them. This adds `Allow` carve-outs for the discovery surface so well-behaved agents that honor `robots.txt` can still fetch the MCP card, OpenAPI spec, agents.json/txt, and llms.txt.

MCP clients (claude.ai, ChatGPT, Claude Code) don't consult `robots.txt`, so the `/api/mcp` transport is unaffected either way.

## Test plan

- [ ] `curl https://kennerspiel.com/robots.txt` shows the new Allow rules.
- [ ] Verify with [Google's robots.txt tester](https://support.google.com/webmasters/answer/6062598) that `/llms.txt`, `/openapi.json`, `/agents.txt`, `/agents.json`, and `/.well-known/mcp.json` are Allowed and `/` and `/instance/...` are still Disallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY

---
_Generated by [Claude Code](https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY)_