### PR TITLE
feat(mcp): add per-instance MCP endpoint at /instance/&lt;id&gt;/mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ This is an implementation of Uwe Rosenberg's game [Ora et Labora](https://amzn.t
 
 ## Playing with AI
 
-Kennerspiel exposes an [MCP](https://modelcontextprotocol.io/) server at `https://kennerspiel.com/api/mcp`. Any MCP-compatible AI client can connect, read the board, consult the built-in strategy guide, enumerate legal moves, and play — all as your Kennerspiel account. Authentication uses standard OAuth 2.1 + PKCE; clients that support dynamic client registration (RFC 7591) connect without any manual setup.
+Kennerspiel exposes an [MCP](https://modelcontextprotocol.io/) server with two endpoints:
+
+- **Hub**: `https://kennerspiel.com/api/mcp` — exposes `list_my_games`. Use it to discover your seats.
+- **Per-game**: `https://kennerspiel.com/instance/<uuid>/mcp` — exposes `get_game`, `join_game`, `get_legal_moves`, `make_move`, `undo_move`, `wait_for_my_turn`, and `get_strategy_guide`. The `/mcp` suffix is optional: pasting plain `https://kennerspiel.com/instance/<uuid>` into Claude or ChatGPT works too (POST/JSON requests are routed to the MCP handler; browsers still get the HTML game page).
+
+Authentication uses standard OAuth 2.1 + PKCE; clients that support dynamic client registration (RFC 7591) connect without any manual setup. A single access token covers both the hub and every per-game endpoint, so the user only authorizes once.
 
 ### Connect via claude.ai
 
@@ -28,6 +33,14 @@ claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp
 ```
 
 Claude Code opens a browser for the OAuth flow and redirects back automatically. Once connected, ask Claude to join a lobby by sharing the game URL, or check pending games with `list_my_games`.
+
+To bind a Claude Code project to one specific game:
+
+```sh
+claude mcp add --transport http my-game https://kennerspiel.com/instance/<uuid>
+```
+
+The same OAuth session is reused — no second authorization prompt.
 
 ### Connect via ChatGPT
 
@@ -75,16 +88,16 @@ The OAuth server metadata is published at `https://kennerspiel.com/.well-known/o
 
 ### Available tools
 
-| Tool | What it does |
-|---|---|
-| `list_my_games` | Find all games you're seated in; filter to games waiting on your move |
-| `join_game` | Claim a seat in an open lobby (pass the game URL or UUID) |
-| `get_game` | Read the current board state: rondel, tableaus, scores, turn order |
-| `get_legal_moves` | Enumerate legal next tokens for a move (interactive drill-down) |
-| `make_move` | Play one command, e.g. `USE LR2` or `BUILD G07 3 2` or `COMMIT` |
-| `undo_move` | Retract the most recent command (use when teaching the model a better line) |
-| `wait_for_my_turn` | Long-poll until it's your turn, rather than polling repeatedly |
-| `get_strategy_guide` | Load the full France/long-2p coaching guide the model consults for decisions |
+| Tool | Endpoint | What it does |
+|---|---|---|
+| `list_my_games` | hub | Find all games you're seated in; filter to games waiting on your move |
+| `join_game` | per-game | Claim a seat in this game's lobby |
+| `get_game` | per-game | Read the current board state: rondel, tableaus, scores, turn order |
+| `get_legal_moves` | per-game | Enumerate legal next tokens for a move (interactive drill-down) |
+| `make_move` | per-game | Play one command, e.g. `USE LR2` or `BUILD G07 3 2` or `COMMIT` |
+| `undo_move` | per-game | Retract the most recent command (use when teaching the model a better line) |
+| `wait_for_my_turn` | per-game | Long-poll until it's your turn, rather than polling repeatedly |
+| `get_strategy_guide` | per-game | Load the full France/long-2p coaching guide the model consults for decisions |
 
 The AI holds seats and makes moves as your Kennerspiel account — human opponents see moves appear live in their browser just like any other player's.
 

--- a/web/src/app/.well-known/agents.json/route.ts
+++ b/web/src/app/.well-known/agents.json/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
 import { issuer } from '@/oauth/config'
 
-// agents-txt.com 1.0 capability surface. Declares the MCP transport and the
-// OAuth endpoints that gate it, so well-behaved agents can discover the
-// sanctioned channel without scraping pages.
+// agents-txt.com 1.0 capability surface. Declares the MCP transports (the
+// hub plus per-instance) and the OAuth endpoints that gate them, so
+// well-behaved agents can discover the sanctioned channel without scraping.
 export const GET = () => {
   const iss = issuer()
   return NextResponse.json(
@@ -16,9 +16,8 @@ export const GET = () => {
       },
       capabilities: [
         {
-          id: 'play-ora-et-labora',
-          description:
-            'MCP server: list seats, read board state, enumerate legal moves, play moves, consult the strategy guide.',
+          id: 'play-ora-et-labora-hub',
+          description: 'Cross-instance MCP hub. Exposes list_my_games.',
           endpoint: `${iss}/api/mcp`,
           method: 'POST',
           protocol: 'MCP',
@@ -28,8 +27,20 @@ export const GET = () => {
           scopes: ['play'],
         },
         {
+          id: 'play-ora-et-labora-instance',
+          description:
+            'Per-game MCP endpoint. Exposes get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. The /mcp suffix is optional — POST/JSON requests to /instance/<uuid> are routed here.',
+          endpoint_template: `${iss}/instance/{instance_id}/mcp`,
+          method: 'POST',
+          protocol: 'MCP',
+          auth: 'oauth2',
+          authEndpoint: `${iss}/authorize`,
+          authDocs: `${iss}/.well-known/oauth-authorization-server`,
+          scopes: ['play'],
+        },
+        {
           id: 'mcp-discovery',
-          description: 'MCP server card describing the transport, auth, and tool catalog.',
+          description: 'MCP server card describing the transports, auth, and tool catalog.',
           endpoint: `${iss}/.well-known/mcp.json`,
           method: 'GET',
           protocol: 'REST',
@@ -49,7 +60,16 @@ export const GET = () => {
           rateLimit: { requests: 60, window: 'minute' },
         },
       },
-      allow: ['/api/mcp', '/.well-known/*', '/openapi.json', '/llms.txt', '/agents.txt', '/agents.json'],
+      allow: [
+        '/api/mcp',
+        '/instance/*/mcp',
+        '/instance/*',
+        '/.well-known/*',
+        '/openapi.json',
+        '/llms.txt',
+        '/agents.txt',
+        '/agents.json',
+      ],
       disallow: ['/account/*', '/private/*'],
     },
     {

--- a/web/src/app/.well-known/agents.txt/route.ts
+++ b/web/src/app/.well-known/agents.txt/route.ts
@@ -9,7 +9,7 @@ Site-Name: Kennerspiel
 Site-URL: ${iss}
 Site-Description: Digital tabletop for Uwe Rosenberg's Ora et Labora.
 
-Capability: play-ora-et-labora
+Capability: play-ora-et-labora-hub
   Endpoint: ${iss}/api/mcp
   Method: POST
   Protocol: MCP
@@ -17,7 +17,17 @@ Capability: play-ora-et-labora
   Auth-Endpoint: ${iss}/authorize
   Auth-Docs: ${iss}/.well-known/oauth-authorization-server
   Scopes: play
-  Description: List seats, read board state, enumerate legal moves, play moves, consult the strategy guide.
+  Description: Cross-instance hub. Exposes list_my_games.
+
+Capability: play-ora-et-labora-instance
+  Endpoint-Template: ${iss}/instance/{instance_id}/mcp
+  Method: POST
+  Protocol: MCP
+  Auth: oauth2
+  Auth-Endpoint: ${iss}/authorize
+  Auth-Docs: ${iss}/.well-known/oauth-authorization-server
+  Scopes: play
+  Description: Per-game endpoint. The /mcp suffix is optional. Tools: get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide.
 
 Capability: mcp-discovery
   Endpoint: ${iss}/.well-known/mcp.json
@@ -34,6 +44,8 @@ Capability: openapi-spec
   Description: OpenAPI 3.1 description of the HTTP surface.
 
 Allow: /api/mcp
+Allow: /instance/*/mcp
+Allow: /instance/*
 Allow: /.well-known/*
 Allow: /openapi.json
 Allow: /llms.txt

--- a/web/src/app/.well-known/mcp.json/route.ts
+++ b/web/src/app/.well-known/mcp.json/route.ts
@@ -5,9 +5,21 @@ import { issuer, SCOPE } from '@/oauth/config'
 // SEP-1649 "server card" with the SEP-1960 manifest so either flavor of MCP
 // client can locate the transport endpoint, the OAuth metadata, and the tool
 // catalog without first completing a JSON-RPC handshake.
+//
+// Two transports are advertised:
+//   - Hub at /api/mcp exposes list_my_games (cross-instance).
+//   - Per-instance at /instance/{instance_id}/mcp (alias: /instance/{instance_id})
+//     exposes the play-the-game tools. One OAuth token covers both.
 export const GET = () => {
   const iss = issuer()
-  const mcpUrl = `${iss}/api/mcp`
+  const hubUrl = `${iss}/api/mcp`
+  const perInstanceTemplate = `${iss}/instance/{instance_id}/mcp`
+  const oauth = {
+    type: 'oauth2',
+    authorization_server: `${iss}/.well-known/oauth-authorization-server`,
+    protected_resource: `${iss}/.well-known/oauth-protected-resource`,
+    scopes: [SCOPE],
+  }
   return NextResponse.json(
     {
       $schema: 'https://modelcontextprotocol.io/schemas/server-card/v1.0',
@@ -25,19 +37,34 @@ export const GET = () => {
       },
       transport: {
         type: 'streamable-http',
-        url: mcpUrl,
+        url: hubUrl,
       },
       endpoints: [
         {
-          url: mcpUrl,
+          url: hubUrl,
           transport: 'streamable-http',
           capabilities: ['tools'],
-          auth: {
-            type: 'oauth2',
-            authorization_server: `${iss}/.well-known/oauth-authorization-server`,
-            protected_resource: `${iss}/.well-known/oauth-protected-resource`,
-            scopes: [SCOPE],
-          },
+          auth: oauth,
+          description:
+            'Cross-instance hub. Exposes list_my_games. Use this to find a game, then connect to its per-instance endpoint to play.',
+          tools: ['list_my_games'],
+        },
+        {
+          url_template: perInstanceTemplate,
+          transport: 'streamable-http',
+          capabilities: ['tools'],
+          auth: oauth,
+          description:
+            'Per-game endpoint. The /mcp suffix is optional — POST/JSON requests to https://kennerspiel.com/instance/<uuid> are routed here. Exposes the play-the-game tools.',
+          tools: [
+            'get_game',
+            'join_game',
+            'get_legal_moves',
+            'make_move',
+            'undo_move',
+            'wait_for_my_turn',
+            'get_strategy_guide',
+          ],
         },
       ],
       capabilities: {
@@ -45,48 +72,51 @@ export const GET = () => {
         resources: false,
         prompts: false,
       },
-      auth: {
-        type: 'oauth2',
-        authorization_server: `${iss}/.well-known/oauth-authorization-server`,
-        protected_resource: `${iss}/.well-known/oauth-protected-resource`,
-        scopes: [SCOPE],
-      },
+      auth: oauth,
       tools: [
         {
           name: 'list_my_games',
+          endpoint: 'hub',
           description:
             'List the Ora et Labora games this agent is seated in. Filter to games waiting on your move with only_my_turn.',
         },
         {
           name: 'get_game',
+          endpoint: 'per-instance',
           description:
-            'Read the current board state of one game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves.',
+            'Read the current board state of this game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves.',
         },
         {
           name: 'get_legal_moves',
+          endpoint: 'per-instance',
           description:
             'Enumerate legal next tokens of a move command. Interactive drill-down from an empty partial to a complete command.',
         },
         {
           name: 'join_game',
-          description: 'Claim a seat in an Ora et Labora lobby that has not yet started, by game UUID or URL.',
+          endpoint: 'per-instance',
+          description: 'Claim a seat in the lobby of this game (only while the lobby is still open).',
         },
         {
           name: 'make_move',
+          endpoint: 'per-instance',
           description:
-            'Play one complete move command in a game where it is your turn (e.g. USE LR2, BUILD G07 3 2, COMMIT).',
+            'Play one complete move command in this game when it is your turn (e.g. USE LR2, BUILD G07 3 2, COMMIT).',
         },
         {
           name: 'undo_move',
+          endpoint: 'per-instance',
           description: 'Retract the most recent command. Only the active player can undo, one command at a time.',
         },
         {
-          name: 'get_strategy_guide',
-          description: 'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p).',
+          name: 'wait_for_my_turn',
+          endpoint: 'per-instance',
+          description: 'Long-poll until it becomes your turn in this game, the game ends, or the timeout elapses.',
         },
         {
-          name: 'wait_for_my_turn',
-          description: 'Long-poll until it becomes your turn in the given game, the game ends, or the timeout elapses.',
+          name: 'get_strategy_guide',
+          endpoint: 'per-instance',
+          description: 'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p).',
         },
       ],
     },

--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -3,16 +3,13 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
 import { track } from '@vercel/analytics/server'
 import { z } from 'zod'
 import { listMyGames } from '@/mcp/tools/listMyGames'
-import { getGame } from '@/mcp/tools/getGame'
-import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
-import { makeMove } from '@/mcp/tools/makeMove'
-import { undoMove } from '@/mcp/tools/undoMove'
-import { joinGame } from '@/mcp/tools/joinGame'
-import { waitForMyTurn } from '@/mcp/tools/waitForMyTurn'
-import { getStrategyGuide } from '@/mcp/tools/getStrategyGuide'
 import { errorResult } from '@/mcp/content'
 import { resolveAccessToken } from '@/oauth/store'
 
+// Cross-instance hub. Per-game tools (get_game, join_game, get_legal_moves,
+// make_move, undo_move, wait_for_my_turn, get_strategy_guide) live on the
+// per-instance endpoint at /instance/<id>/mcp — one token from the OAuth flow
+// covers both endpoints, so users only authorize the connector once.
 const userIdFrom = (extra: { authInfo?: AuthInfo }): string | undefined =>
   (extra.authInfo?.extra as { userId?: string } | undefined)?.userId
 
@@ -26,128 +23,13 @@ const handler = createMcpHandler(
   (server) => {
     server.tool(
       'list_my_games',
-      'List the Ora et Labora games this agent is seated in. Call this first to find a game, or with only_my_turn to check whether any game is waiting on you.',
+      'List the Ora et Labora games this agent is seated in. Each returned game has an instance_id; the per-game MCP endpoint lives at https://kennerspiel.com/instance/<instance_id>/mcp (or just https://kennerspiel.com/instance/<instance_id>) and exposes get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, and get_strategy_guide.',
       { only_my_turn: z.boolean().optional().describe('Only return games where it is currently your turn') },
       async ({ only_my_turn }, extra) => {
         const userId = userIdFrom(extra)
         trackToolCall('list_my_games', userId)
         if (!userId) return unauthenticated()
         return listMyGames({ userId, onlyMyTurn: only_my_turn ?? false })
-      }
-    )
-    server.tool(
-      'get_game',
-      'Read the current board state of one game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves. Call this before deciding on a move.',
-      {
-        instance_id: z.string().uuid().describe('The game instance id, from list_my_games'),
-        detail: z
-          .enum(['summary', 'full'])
-          .optional()
-          .describe('summary (default) is a curated rendering; full is the raw engine state for debugging'),
-      },
-      async ({ instance_id, detail }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('get_game', userId)
-        if (!userId) return unauthenticated()
-        return getGame({ userId, instanceId: instance_id, detail: detail ?? 'summary' })
-      }
-    )
-    server.tool(
-      'get_legal_moves',
-      'List the legal next tokens of a move command. Call with an empty partial to see available verbs (USE, BUILD, COMMIT, ...), then append tokens and call again to drill down until a complete command is formed.',
-      {
-        instance_id: z.string().uuid().describe('The game instance id'),
-        partial: z
-          .array(z.string())
-          .optional()
-          .describe('The tokens chosen so far, e.g. [] then ["BUILD"] then ["BUILD","G07"]'),
-      },
-      async ({ instance_id, partial }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('get_legal_moves', userId)
-        if (!userId) return unauthenticated()
-        return getLegalMoves({ userId, instanceId: instance_id, partial: partial ?? [] })
-      }
-    )
-    server.tool(
-      'join_game',
-      'Claim a seat in an Ora et Labora lobby that has not yet started. Pass either the game instance id or its URL (e.g. https://kennerspiel.com/instance/<uuid>) along with the color you want to play. If you already have a seat in that game, your color is updated. Wait for the human to choose the variant and press START on the website before calling get_game.',
-      {
-        instance: z
-          .string()
-          .min(1)
-          .describe(
-            'Either the game instance UUID or a URL containing it, e.g. https://kennerspiel.com/instance/<uuid>'
-          ),
-        color: z.enum(['red', 'green', 'blue', 'white']).describe('Which seat color to claim'),
-      },
-      async ({ instance, color }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('join_game', userId)
-        if (!userId) return unauthenticated()
-        return joinGame({ userId, instanceRef: instance, color })
-      }
-    )
-    server.tool(
-      'make_move',
-      'Play one complete move command in a game where it is your turn, e.g. "USE LR2" or "BUILD G07 3 2" or "COMMIT". The command must be legal per get_legal_moves. Note most turns are several commands ending with COMMIT.',
-      {
-        instance_id: z.string().uuid().describe('The game instance id'),
-        command: z.string().min(1).describe('A complete space-separated command'),
-      },
-      async ({ instance_id, command }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('make_move', userId)
-        if (!userId) return unauthenticated()
-        return makeMove({ userId, instanceId: instance_id, command })
-      }
-    )
-    server.tool(
-      'undo_move',
-      'Undo your most recently played command in a game. This is not part of normal play — only use it when the human asks you to, e.g. to retract a sub-optimal move so they can teach a better one. Removes one command at a time (call repeatedly to roll back a multi-command turn). Only the most recent command can be undone, and only if it was your own (active when it was played). Returns the resulting state.',
-      {
-        instance_id: z.string().uuid().describe('The game instance id'),
-      },
-      async ({ instance_id }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('undo_move', userId)
-        if (!userId) return unauthenticated()
-        return undoMove({ userId, instanceId: instance_id })
-      }
-    )
-    server.tool(
-      'get_strategy_guide',
-      'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p). Covers action economy, clergy hierarchy, settlement evaluation, converter priorities, building identity reference, engine quirks, endgame protocols, and opening book. Call this at the start of a session or when planning a non-trivial move.',
-      {},
-      (_args, extra) => {
-        trackToolCall('get_strategy_guide', userIdFrom(extra))
-        return getStrategyGuide()
-      }
-    )
-    server.tool(
-      'wait_for_my_turn',
-      'Block until it becomes your turn in the given game, the game ends, or the timeout elapses. Use this instead of repeatedly polling get_game/list_my_games while waiting on other players. Pass color to wait for one specific seat (useful when this agent holds multiple seats in the same game and a sibling agent is playing the other color). Returns the same shape as list_my_games plus a timed_out flag.',
-      {
-        instance_id: z.string().uuid().describe('The game instance id'),
-        color: z
-          .enum(['red', 'green', 'blue', 'white'])
-          .optional()
-          .describe(
-            'Wait until this specific seat becomes active. Must be a color you are seated as. Omit to wait for any of your seats.'
-          ),
-        timeout_sec: z
-          .number()
-          .int()
-          .min(1)
-          .max(55)
-          .optional()
-          .describe('How long to wait before returning, in seconds (default 50, max 55 — request maxDuration is 60s)'),
-      },
-      async ({ instance_id, color, timeout_sec }, extra) => {
-        const userId = userIdFrom(extra)
-        trackToolCall('wait_for_my_turn', userId)
-        if (!userId) return unauthenticated()
-        return waitForMyTurn({ userId, instanceId: instance_id, color, timeoutSec: timeout_sec ?? 50 })
       }
     )
   },

--- a/web/src/app/authorize/actions.ts
+++ b/web/src/app/authorize/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
-import { resourceIdentifier, SCOPE } from '@/oauth/config'
+import { isAllowedResource, SCOPE } from '@/oauth/config'
 import { findClient, issueAuthorizationCode } from '@/oauth/store'
 
 const fail = (redirectUri: string | null, state: string | null, error: string, description: string): never => {
@@ -32,7 +32,7 @@ export const approve = async (formData: FormData) => {
   if (!codeChallenge) fail(redirectUri, state, 'invalid_request', 'PKCE code_challenge is required')
   if (codeChallengeMethod !== 'S256')
     fail(redirectUri, state, 'invalid_request', 'Only code_challenge_method=S256 is supported')
-  if (resource && resource.replace(/\/$/, '') !== resourceIdentifier())
+  if (resource && !isAllowedResource(resource))
     fail(redirectUri, state, 'invalid_target', 'resource does not match this server')
 
   const supabase = await createClient()

--- a/web/src/app/authorize/page.tsx
+++ b/web/src/app/authorize/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
-import { resourceIdentifier } from '@/oauth/config'
+import { isAllowedResource } from '@/oauth/config'
 import { findClient } from '@/oauth/store'
 import { approve } from './actions'
 
@@ -34,7 +34,7 @@ const Authorize = async ({ searchParams }: { searchParams: Promise<AuthorizePara
   if (!params.code_challenge) return renderError('Missing PKCE code_challenge (S256 required).')
   if (params.code_challenge_method && params.code_challenge_method !== 'S256')
     return renderError('Only code_challenge_method=S256 is supported.')
-  if (params.resource && params.resource.replace(/\/$/, '') !== resourceIdentifier())
+  if (params.resource && !isAllowedResource(params.resource))
     return renderError('resource indicator does not match this server.')
 
   const supabase = await createClient()

--- a/web/src/app/instance/[slug]/mcp/route.ts
+++ b/web/src/app/instance/[slug]/mcp/route.ts
@@ -1,0 +1,165 @@
+import { createMcpHandler, withMcpAuth } from 'mcp-handler'
+import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
+import { track } from '@vercel/analytics/server'
+import { z } from 'zod'
+import { getGame } from '@/mcp/tools/getGame'
+import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
+import { makeMove } from '@/mcp/tools/makeMove'
+import { undoMove } from '@/mcp/tools/undoMove'
+import { joinGame } from '@/mcp/tools/joinGame'
+import { waitForMyTurn } from '@/mcp/tools/waitForMyTurn'
+import { getStrategyGuide } from '@/mcp/tools/getStrategyGuide'
+import { errorResult } from '@/mcp/content'
+import { resolveAccessToken } from '@/oauth/store'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const userIdFrom = (extra: { authInfo?: AuthInfo }): string | undefined =>
+  (extra.authInfo?.extra as { userId?: string } | undefined)?.userId
+
+const unauthenticated = () => errorResult('Unauthenticated: no user is bound to this MCP session.')
+
+const trackToolCall = (tool: string, userId: string | undefined, instanceId: string): void => {
+  track('mcp_tool_call', { tool, userId: userId ?? 'anonymous', instanceId }).catch(() => {})
+}
+
+const verifyToken = async (_req: Request, bearerToken?: string): Promise<AuthInfo | undefined> => {
+  if (!bearerToken) return undefined
+  const resolved = await resolveAccessToken(bearerToken)
+  if (!resolved) return undefined
+  return {
+    token: bearerToken,
+    clientId: resolved.clientId,
+    scopes: resolved.scopes,
+    expiresAt: resolved.expiresAt,
+    extra: { userId: resolved.userId },
+  }
+}
+
+// The MCP server is rebuilt per-request so each tool closure captures the
+// instance_id parsed from the URL. instance_id never appears in tool schemas:
+// the URL is the only source of truth, which is what lets an agent join a game
+// just by being given the instance URL.
+const buildHandler = (instanceId: string) =>
+  createMcpHandler(
+    (server) => {
+      server.tool(
+        'get_game',
+        'Read the current board state of this game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves. Call this before deciding on a move.',
+        {
+          detail: z
+            .enum(['summary', 'full'])
+            .optional()
+            .describe('summary (default) is a curated rendering; full is the raw engine state for debugging'),
+        },
+        async ({ detail }, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('get_game', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return getGame({ userId, instanceId, detail: detail ?? 'summary' })
+        }
+      )
+      server.tool(
+        'get_legal_moves',
+        'List the legal next tokens of a move command. Call with an empty partial to see available verbs (USE, BUILD, COMMIT, ...), then append tokens and call again to drill down until a complete command is formed.',
+        {
+          partial: z
+            .array(z.string())
+            .optional()
+            .describe('The tokens chosen so far, e.g. [] then ["BUILD"] then ["BUILD","G07"]'),
+        },
+        async ({ partial }, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('get_legal_moves', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return getLegalMoves({ userId, instanceId, partial: partial ?? [] })
+        }
+      )
+      server.tool(
+        'join_game',
+        'Claim a seat in this game (only works while the lobby is still open). If you already hold the chosen color in this game, your seat is refreshed. Wait for the human to choose the variant and press START on the website before calling get_game.',
+        {
+          color: z.enum(['red', 'green', 'blue', 'white']).describe('Which seat color to claim'),
+        },
+        async ({ color }, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('join_game', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return joinGame({ userId, instanceRef: instanceId, color })
+        }
+      )
+      server.tool(
+        'make_move',
+        'Play one complete move command in this game when it is your turn, e.g. "USE LR2" or "BUILD G07 3 2" or "COMMIT". The command must be legal per get_legal_moves. Note most turns are several commands ending with COMMIT.',
+        {
+          command: z.string().min(1).describe('A complete space-separated command'),
+        },
+        async ({ command }, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('make_move', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return makeMove({ userId, instanceId, command })
+        }
+      )
+      server.tool(
+        'undo_move',
+        'Undo your most recently played command in this game. This is not part of normal play — only use it when the human asks you to, e.g. to retract a sub-optimal move so they can teach a better one. Removes one command at a time (call repeatedly to roll back a multi-command turn). Only the most recent command can be undone, and only if it was your own (active when it was played). Returns the resulting state.',
+        {},
+        async (_args, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('undo_move', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return undoMove({ userId, instanceId })
+        }
+      )
+      server.tool(
+        'wait_for_my_turn',
+        'Block until it becomes your turn in this game, the game ends, or the timeout elapses. Use this instead of repeatedly polling get_game while waiting on other players. Pass color to wait for one specific seat (useful when this agent holds multiple seats in the same game and a sibling agent is playing the other color). Returns the same shape as list_my_games plus a timed_out flag.',
+        {
+          color: z
+            .enum(['red', 'green', 'blue', 'white'])
+            .optional()
+            .describe(
+              'Wait until this specific seat becomes active. Must be a color you are seated as. Omit to wait for any of your seats.'
+            ),
+          timeout_sec: z
+            .number()
+            .int()
+            .min(1)
+            .max(55)
+            .optional()
+            .describe(
+              'How long to wait before returning, in seconds (default 50, max 55 — request maxDuration is 60s)'
+            ),
+        },
+        async ({ color, timeout_sec }, extra) => {
+          const userId = userIdFrom(extra)
+          trackToolCall('wait_for_my_turn', userId, instanceId)
+          if (!userId) return unauthenticated()
+          return waitForMyTurn({ userId, instanceId, color, timeoutSec: timeout_sec ?? 50 })
+        }
+      )
+      server.tool(
+        'get_strategy_guide',
+        'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p). Covers action economy, clergy hierarchy, settlement evaluation, converter priorities, building identity reference, engine quirks, endgame protocols, and opening book. Call this at the start of a session or when planning a non-trivial move.',
+        {},
+        (_args, extra) => {
+          trackToolCall('get_strategy_guide', userIdFrom(extra), instanceId)
+          return getStrategyGuide()
+        }
+      )
+    },
+    {},
+    { basePath: `/instance/${instanceId}` }
+  )
+
+const dispatch = async (req: Request, { params }: { params: Promise<{ slug: string }> }) => {
+  const { slug } = await params
+  if (!UUID_RE.test(slug)) return new Response('Not Found', { status: 404 })
+  const handler = buildHandler(slug)
+  const auth = withMcpAuth(handler, verifyToken, { required: true })
+  return auth(req)
+}
+
+export { dispatch as GET, dispatch as POST, dispatch as DELETE }
+export const maxDuration = 60

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -8,20 +8,30 @@ export const GET = () => {
 
 > Digital tabletop for Uwe Rosenberg's Ora et Labora. Humans play in a browser; AI agents play through a hosted MCP server using the same accounts as humans.
 
-Kennerspiel exposes an MCP server at \`${iss}/api/mcp\`. Any MCP-compatible client can connect, authenticate the user via OAuth 2.1 + PKCE (with RFC 7591 dynamic client registration), and play as that account. The full strategy guide is loaded by the \`get_strategy_guide\` tool; prefer calling that over scraping pages.
+Kennerspiel exposes two MCP transports on the same OAuth credentials:
+
+- The cross-instance hub at \`${iss}/api/mcp\` exposes \`list_my_games\` for discovering your seats.
+- Each game has its own endpoint at \`${iss}/instance/{instance_id}/mcp\` — the \`/mcp\` suffix is optional, so pasting just \`${iss}/instance/{instance_id}\` into Claude or ChatGPT works too. This endpoint exposes the play-the-game tools (\`get_game\`, \`join_game\`, \`get_legal_moves\`, \`make_move\`, \`undo_move\`, \`wait_for_my_turn\`, \`get_strategy_guide\`).
+
+One OAuth 2.1 + PKCE token (with RFC 7591 dynamic client registration) covers both the hub and every per-instance endpoint, so the user authorizes the connector only once.
 
 ## Machine-readable surface
 
-- [MCP server card](${iss}/.well-known/mcp.json): Discovery document — transport, auth, tool catalog.
-- [OpenAPI 3.1 spec](${iss}/openapi.json): HTTP surface (MCP transport + OAuth endpoints).
+- [MCP server card](${iss}/.well-known/mcp.json): Discovery document — transports, auth, tool catalog.
+- [OpenAPI 3.1 spec](${iss}/openapi.json): HTTP surface (hub + per-instance MCP + OAuth endpoints).
 - [agents.json](${iss}/.well-known/agents.json): agents-txt.com capability surface.
 - [OAuth authorization-server metadata](${iss}/.well-known/oauth-authorization-server): RFC 8414.
 - [OAuth protected-resource metadata](${iss}/.well-known/oauth-protected-resource): RFC 9728.
 
 ## MCP tools
 
+Hub at \`/api/mcp\`:
+
 - \`list_my_games\`: Find all games you're seated in; filter to games waiting on your move.
-- \`join_game\`: Claim a seat in an open lobby (pass the game URL or UUID).
+
+Per-instance at \`/instance/{instance_id}/mcp\`:
+
+- \`join_game\`: Claim a seat in this game's lobby.
 - \`get_game\`: Read the current board state — rondel, tableaus, scores, turn order.
 - \`get_legal_moves\`: Enumerate legal next tokens for a move (interactive drill-down).
 - \`make_move\`: Play one command (e.g. \`USE LR2\`, \`BUILD G07 3 2\`, \`COMMIT\`).

--- a/web/src/app/openapi.json/route.ts
+++ b/web/src/app/openapi.json/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server'
 import { issuer, SCOPE } from '@/oauth/config'
 
 // OpenAPI 3.1 description of the HTTP surface exposed by kennerspiel.com:
-// the MCP transport endpoint plus the OAuth 2.1 authorization-server endpoints
-// that gate access to it. Linked from page <head> via rel="service-desc".
+// the MCP transports (hub at /api/mcp and per-instance at /instance/{id}/mcp)
+// plus the OAuth 2.1 authorization-server endpoints. Linked from page <head>
+// via rel="service-desc".
 export const GET = () => {
   const iss = issuer()
   return NextResponse.json(
@@ -11,10 +12,10 @@ export const GET = () => {
       openapi: '3.1.0',
       info: {
         title: 'Kennerspiel',
-        version: '1.0.0',
-        summary: 'Kennerspiel MCP server and OAuth 2.1 endpoints.',
+        version: '1.1.0',
+        summary: 'Kennerspiel MCP server (hub + per-instance) and OAuth 2.1 endpoints.',
         description:
-          'HTTP surface for kennerspiel.com — the MCP transport at /api/mcp plus the OAuth 2.1 + PKCE authorization-server endpoints (RFC 7591 dynamic registration, RFC 8414 metadata, RFC 9728 protected-resource metadata) that gate it.',
+          'HTTP surface for kennerspiel.com — the cross-instance MCP hub at /api/mcp, per-game MCP endpoints at /instance/{instance_id}/mcp (also reachable as /instance/{instance_id}), and the OAuth 2.1 + PKCE authorization-server endpoints (RFC 7591 dynamic registration, RFC 8414 metadata, RFC 9728 protected-resource metadata) that gate them. One token covers every MCP endpoint on this origin.',
         license: { name: 'GPL-3.0', identifier: 'GPL-3.0' },
         contact: { name: 'philihp', url: 'https://github.com/philihp/kennerspiel' },
       },
@@ -23,7 +24,8 @@ export const GET = () => {
         securitySchemes: {
           oauth2: {
             type: 'oauth2',
-            description: 'OAuth 2.1 authorization code with PKCE. Tokens have a 30-day TTL.',
+            description:
+              'OAuth 2.1 authorization code with PKCE. Tokens have a 30-day TTL and cover every MCP endpoint on this origin.',
             flows: {
               authorizationCode: {
                 authorizationUrl: `${iss}/authorize`,
@@ -33,14 +35,23 @@ export const GET = () => {
             },
           },
         },
+        parameters: {
+          InstanceId: {
+            name: 'instance_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', format: 'uuid' },
+            description: 'The game instance UUID.',
+          },
+        },
       },
       paths: {
         '/api/mcp': {
           post: {
-            operationId: 'mcpRpc',
-            summary: 'Model Context Protocol transport.',
+            operationId: 'mcpHubRpc',
+            summary: 'Cross-instance MCP hub.',
             description:
-              'Streamable-HTTP MCP transport. Send JSON-RPC requests for tools/list, tools/call, etc. Tools: list_my_games, get_game, get_legal_moves, join_game, make_move, undo_move, get_strategy_guide, wait_for_my_turn.',
+              'Streamable-HTTP MCP transport. Tools: list_my_games. Use this to find a game, then switch to its per-instance endpoint to play.',
             security: [{ oauth2: [SCOPE] }],
             requestBody: {
               required: true,
@@ -52,6 +63,59 @@ export const GET = () => {
                 content: { 'application/json': { schema: { type: 'object' } } },
               },
               401: { description: 'Missing or invalid bearer token.' },
+            },
+          },
+        },
+        '/instance/{instance_id}/mcp': {
+          post: {
+            operationId: 'mcpInstanceRpc',
+            summary: 'Per-game MCP endpoint.',
+            description:
+              'Streamable-HTTP MCP transport scoped to one game. Tools: get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. The instance_id never appears in tool arguments — it comes from the URL.',
+            security: [{ oauth2: [SCOPE] }],
+            parameters: [{ $ref: '#/components/parameters/InstanceId' }],
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: {
+              200: {
+                description: 'JSON-RPC response.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              401: { description: 'Missing or invalid bearer token.' },
+              404: { description: 'instance_id is not a UUID.' },
+            },
+          },
+        },
+        '/instance/{instance_id}': {
+          post: {
+            operationId: 'mcpInstanceAlias',
+            summary: 'Per-game MCP endpoint (alias — /mcp suffix optional).',
+            description:
+              'Same handler as /instance/{instance_id}/mcp. Requests with a Bearer token, JSON-RPC body, or SSE Accept header are routed to the MCP handler so users can paste plain instance URLs into Claude or ChatGPT.',
+            security: [{ oauth2: [SCOPE] }],
+            parameters: [{ $ref: '#/components/parameters/InstanceId' }],
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: {
+              200: {
+                description: 'JSON-RPC response.',
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              401: { description: 'Missing or invalid bearer token.' },
+            },
+          },
+          get: {
+            operationId: 'instanceHtml',
+            summary: 'Per-game HTML view (browser).',
+            description:
+              'Returns the HTML game page for browsers. MCP clients (Bearer token, SSE Accept) are rewritten to the /mcp handler before reaching this page.',
+            parameters: [{ $ref: '#/components/parameters/InstanceId' }],
+            responses: {
+              200: { description: 'HTML page.', content: { 'text/html': {} } },
             },
           },
         },
@@ -88,7 +152,14 @@ export const GET = () => {
               },
               { name: 'scope', in: 'query', required: false, schema: { type: 'string', default: SCOPE } },
               { name: 'state', in: 'query', required: false, schema: { type: 'string' } },
-              { name: 'resource', in: 'query', required: false, schema: { type: 'string', format: 'uri' } },
+              {
+                name: 'resource',
+                in: 'query',
+                required: false,
+                schema: { type: 'string', format: 'uri' },
+                description:
+                  'RFC 8707 resource indicator. Any URL whose origin matches this issuer is accepted (e.g. the origin itself, /api/mcp, or /instance/<uuid>/mcp).',
+              },
             ],
             responses: {
               302: { description: 'Redirect back to the client with code and state.' },

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -15,11 +15,23 @@ const Home = () => {
       </p>
       <h2>Play with an AI</h2>
       <p>
-        Kennerspiel has an <Link href="https://modelcontextprotocol.io/">MCP</Link> server at{' '}
-        <code>https://kennerspiel.com/api/mcp</code>. Any MCP-compatible AI can take a seat at your table — it will
-        read the board, consult a built-in strategy guide, and play moves on your behalf. Useful for solo learning,
-        AI-vs-AI matches, or just having a patient opponent at 2am.
+        Kennerspiel has an <Link href="https://modelcontextprotocol.io/">MCP</Link> server. Any MCP-compatible AI can
+        take a seat at your table — it will read the board, consult a built-in strategy guide, and play moves on your
+        behalf. Useful for solo learning, AI-vs-AI matches, or just having a patient opponent at 2am.
       </p>
+      <p>Two endpoints share a single OAuth session:</p>
+      <ul>
+        <li>
+          <strong>Hub</strong>: <code>https://kennerspiel.com/api/mcp</code> — exposes <code>list_my_games</code> so the
+          agent can find your seats.
+        </li>
+        <li>
+          <strong>Per-game</strong>: the URL of any game is also its MCP endpoint. Drop{' '}
+          <code>https://kennerspiel.com/instance/&lt;uuid&gt;</code> into a chat and say &ldquo;join as white&rdquo; —
+          the agent gets <code>get_game</code>, <code>make_move</code>, the strategy guide, and everything else scoped
+          to that one game.
+        </li>
+      </ul>
       <h3>Claude (claude.ai)</h3>
       <ol>
         <li>
@@ -31,15 +43,19 @@ const Home = () => {
         <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
       </ol>
       <p>
-        No client IDs, no secrets, no copy-pasting. Ask Claude something like &ldquo;list my Ora et Labora
-        games&rdquo; and it&apos;ll find the tools automatically.
+        Once authorized, the same token also covers any per-game URL — no re-auth when you switch games. Ask Claude
+        something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the tools automatically.
       </p>
       <h3>Claude Code</h3>
-      <p>Run this once in your terminal:</p>
+      <p>Add the hub once:</p>
       <pre>
         <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
       </pre>
-      <p>Claude Code will open a browser for the OAuth flow and redirect back automatically.</p>
+      <p>Or wire up one specific game directly:</p>
+      <pre>
+        <code>claude mcp add --transport http my-game https://kennerspiel.com/instance/&lt;uuid&gt;</code>
+      </pre>
+      <p>Claude Code opens a browser for the OAuth flow and redirects back automatically.</p>
       <h3>ChatGPT</h3>
       <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
       <ol>
@@ -60,4 +76,3 @@ const Home = () => {
 }
 
 export default Home
-

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,7 +1,38 @@
-import { type NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const INSTANCE_PATH_RE = /^\/instance\/([^/]+)\/?$/
+
+// MCP clients negotiate the streamable-http transport using one of: a Bearer
+// token in Authorization, a JSON-RPC POST body, or an SSE-flavored Accept
+// header. None of those shapes match an ordinary browser visit to the HTML
+// instance page, so we rewrite the request to the /mcp sub-route. That lets a
+// user paste plain https://kennerspiel.com/instance/<uuid> into Claude / GPT
+// and have it discovered as an MCP endpoint without a /mcp suffix.
+const isMcpShapedRequest = (request: NextRequest): boolean => {
+  const authz = request.headers.get('authorization')
+  if (authz && authz.toLowerCase().startsWith('bearer ')) return true
+  const accept = request.headers.get('accept') ?? ''
+  if (accept.includes('text/event-stream')) return true
+  if (request.method === 'POST') {
+    const ct = request.headers.get('content-type') ?? ''
+    if (ct.includes('application/json')) return true
+  }
+  if (request.method === 'OPTIONS') {
+    const acrh = request.headers.get('access-control-request-headers') ?? ''
+    if (acrh.toLowerCase().includes('authorization')) return true
+  }
+  return false
+}
+
 export async function middleware(request: NextRequest) {
+  const match = request.nextUrl.pathname.match(INSTANCE_PATH_RE)
+  if (match && UUID_RE.test(match[1]) && isMcpShapedRequest(request)) {
+    const url = request.nextUrl.clone()
+    url.pathname = `/instance/${match[1]}/mcp`
+    return NextResponse.rewrite(url)
+  }
   return await updateSession(request)
 }
 
@@ -13,9 +44,9 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - api/mcp (MCP requests carry a bearer token, not Supabase auth cookies)
+     * - instance/<uuid>/mcp (per-instance MCP endpoint, same reason)
      * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
-     * Feel free to modify this pattern to include more paths.
      */
-    '/((?!_next/static|_next/image|favicon.ico|api/mcp|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api/mcp|instance/[^/]+/mcp|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }

--- a/web/src/oauth/config.ts
+++ b/web/src/oauth/config.ts
@@ -17,4 +17,19 @@ export const issuer = (): string => {
   throw new Error('OAUTH_ISSUER (or NEXT_PUBLIC_SITE_URL) is not configured')
 }
 
-export const resourceIdentifier = (): string => `${issuer()}/api/mcp`
+// The protected resource identifier is the origin: tokens minted for
+// kennerspiel.com cover every MCP endpoint we serve (the cross-instance hub at
+// /api/mcp and every per-instance endpoint at /instance/<id>/mcp), so users
+// only authorize the connector once.
+export const resourceIdentifier = (): string => issuer()
+
+// RFC 8707: clients may pass a `resource` indicator targeting any URL under
+// our origin. Accept anything whose origin matches the issuer; reject foreign
+// origins so a confused-deputy can't redirect tokens elsewhere.
+export const isAllowedResource = (resource: string): boolean => {
+  try {
+    return new URL(resource).origin === new URL(issuer()).origin
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

Split the MCP server into a cross-instance hub and per-game endpoints, so a user can hand Claude a plain instance URL and have it joined as a seat without any extra setup.

### Endpoints

| URL | Tools |
|---|---|
| `/api/mcp` (hub) | `list_my_games` |
| `/instance/<uuid>/mcp` (per-game) | `get_game`, `join_game`, `get_legal_moves`, `make_move`, `undo_move`, `wait_for_my_turn`, `get_strategy_guide` |
| `/instance/<uuid>` (alias) | same as `/instance/<uuid>/mcp` for MCP-shaped requests; HTML page for browsers |

Per-instance tools drop `instance_id` from their schemas — the URL is the only source of truth.

### One token, both endpoints

OAuth resource indicator broadens from `${issuer}/api/mcp` to the issuer origin. Resource validation in `authorize/actions.ts` and `authorize/page.tsx` switches to an origin match. A single token covers the hub and every per-instance endpoint, so users authorize the connector only once.

### Content negotiation on `/instance/<uuid>`

`middleware.ts` rewrites MCP-shaped requests — Bearer token, JSON-RPC body, or `text/event-stream` `Accept` — to `/instance/<uuid>/mcp` before the page route runs. Browsers (no Bearer, no JSON-RPC, no SSE) still get the HTML game page. The matcher now also bypasses Supabase auth on `instance/<uuid>/mcp`.

### Discovery surface updated

`mcp.json`, `openapi.json`, `agents.json`, `agents.txt`, and `llms.txt` all describe both endpoints (with a `url_template` for the per-instance pattern in `mcp.json`). Home page + README explain the URL-paste flow.

## Test plan

- [ ] `pnpm dev` → connect Claude Code to `https://localhost:3000/api/mcp`, complete OAuth.
- [ ] In the same Claude Code session, add a second MCP server pointed at `http://localhost:3000/instance/<uuid>/mcp` — confirm no re-auth prompt (token reused, origin-scoped resource).
- [ ] In a new Claude Code session, add `http://localhost:3000/instance/<uuid>` (no `/mcp` suffix) — confirm the middleware rewrite kicks in and the OAuth flow completes against the same origin.
- [ ] Browser visit to `/instance/<uuid>` still renders the HTML game page (no JSON-RPC contamination).
- [ ] `curl /api/mcp` with no Authorization returns 401 + `WWW-Authenticate: Bearer resource_metadata="https://kennerspiel.com/.well-known/oauth-protected-resource"`.
- [ ] `curl /instance/<uuid>/mcp` with no Authorization returns the same shape.
- [ ] `tools/list` on the hub returns exactly `list_my_games`. `tools/list` on a per-instance endpoint returns the other seven.
- [ ] `make_move` on the per-instance endpoint succeeds when it's your turn; no `instance_id` argument required.
- [ ] `curl /.well-known/mcp.json | jq '.endpoints'` shows two endpoints (hub + `url_template`).
- [ ] Existing tokens issued against `${issuer}/api/mcp` continue to work against both endpoints (origin-match validation accepts them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY

---
_Generated by [Claude Code](https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY)_