### PR TITLE
fix(mcp): restore full toolset on the /api/mcp hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This is an implementation of Uwe Rosenberg's game [Ora et Labora](https://amzn.t
 
 ## Playing with AI
 
-Kennerspiel exposes an [MCP](https://modelcontextprotocol.io/) server with two endpoints:
+Kennerspiel exposes an [MCP](https://modelcontextprotocol.io/) server with two endpoints, both backed by the same OAuth session:
 
-- **Hub**: `https://kennerspiel.com/api/mcp` — exposes `list_my_games`. Use it to discover your seats.
-- **Per-game**: `https://kennerspiel.com/instance/<uuid>/mcp` — exposes `get_game`, `join_game`, `get_legal_moves`, `make_move`, `undo_move`, `wait_for_my_turn`, and `get_strategy_guide`. The `/mcp` suffix is optional: pasting plain `https://kennerspiel.com/instance/<uuid>` into Claude or ChatGPT works too (POST/JSON requests are routed to the MCP handler; browsers still get the HTML game page).
+- **Hub**: `https://kennerspiel.com/api/mcp` — exposes every tool (`list_my_games`, `get_game`, `join_game`, `get_legal_moves`, `make_move`, `undo_move`, `wait_for_my_turn`, `get_strategy_guide`). Per-game tools take an `instance_id` argument. This is the recommended endpoint for account-level integrations like claude.ai and ChatGPT: add it once and you can play any game from any conversation.
+- **Per-game**: `https://kennerspiel.com/instance/<uuid>/mcp` — same play-the-game tools as the hub, but `instance_id` is baked into the URL. The `/mcp` suffix is optional: pasting plain `https://kennerspiel.com/instance/<uuid>` into Claude or ChatGPT works too (POST/JSON requests are routed to the MCP handler; browsers still get the HTML game page). Best for Claude Code projects pinned to one game.
 
 Authentication uses standard OAuth 2.1 + PKCE; clients that support dynamic client registration (RFC 7591) connect without any manual setup. A single access token covers both the hub and every per-game endpoint, so the user only authorizes once.
 

--- a/web/src/app/.well-known/agents.json/route.ts
+++ b/web/src/app/.well-known/agents.json/route.ts
@@ -17,7 +17,8 @@ export const GET = () => {
       capabilities: [
         {
           id: 'play-ora-et-labora-hub',
-          description: 'Cross-instance MCP hub. Exposes list_my_games.',
+          description:
+            'MCP hub. Exposes every tool — list_my_games, get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. Per-game tools take instance_id as an argument.',
           endpoint: `${iss}/api/mcp`,
           method: 'POST',
           protocol: 'MCP',
@@ -29,7 +30,7 @@ export const GET = () => {
         {
           id: 'play-ora-et-labora-instance',
           description:
-            'Per-game MCP endpoint. Exposes get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. The /mcp suffix is optional — POST/JSON requests to /instance/<uuid> are routed here.',
+            'Per-game MCP endpoint. Same play-the-game tools as the hub (get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide) but instance_id is baked into the URL. The /mcp suffix is optional — POST/JSON requests to /instance/<uuid> are routed here.',
           endpoint_template: `${iss}/instance/{instance_id}/mcp`,
           method: 'POST',
           protocol: 'MCP',

--- a/web/src/app/.well-known/agents.txt/route.ts
+++ b/web/src/app/.well-known/agents.txt/route.ts
@@ -17,7 +17,7 @@ Capability: play-ora-et-labora-hub
   Auth-Endpoint: ${iss}/authorize
   Auth-Docs: ${iss}/.well-known/oauth-authorization-server
   Scopes: play
-  Description: Cross-instance hub. Exposes list_my_games.
+  Description: MCP hub. Exposes every tool: list_my_games, get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. Per-game tools take instance_id as an argument.
 
 Capability: play-ora-et-labora-instance
   Endpoint-Template: ${iss}/instance/{instance_id}/mcp
@@ -27,7 +27,7 @@ Capability: play-ora-et-labora-instance
   Auth-Endpoint: ${iss}/authorize
   Auth-Docs: ${iss}/.well-known/oauth-authorization-server
   Scopes: play
-  Description: Per-game endpoint. The /mcp suffix is optional. Tools: get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide.
+  Description: Per-game endpoint. Same play-the-game tools as the hub, instance_id baked into the URL. The /mcp suffix is optional.
 
 Capability: mcp-discovery
   Endpoint: ${iss}/.well-known/mcp.json

--- a/web/src/app/.well-known/mcp.json/route.ts
+++ b/web/src/app/.well-known/mcp.json/route.ts
@@ -7,9 +7,13 @@ import { issuer, SCOPE } from '@/oauth/config'
 // catalog without first completing a JSON-RPC handshake.
 //
 // Two transports are advertised:
-//   - Hub at /api/mcp exposes list_my_games (cross-instance).
+//   - Hub at /api/mcp exposes every tool (per-game tools take instance_id as
+//     an argument). This is the "connect once" endpoint for claude.ai / ChatGPT
+//     integrations that are configured at the account level.
 //   - Per-instance at /instance/{instance_id}/mcp (alias: /instance/{instance_id})
-//     exposes the play-the-game tools. One OAuth token covers both.
+//     exposes the play-the-game tools with instance_id baked into the URL, for
+//     users who'd rather drop a per-game URL into a chat or Claude Code.
+// One OAuth token covers both.
 export const GET = () => {
   const iss = issuer()
   const hubUrl = `${iss}/api/mcp`
@@ -20,6 +24,25 @@ export const GET = () => {
     protected_resource: `${iss}/.well-known/oauth-protected-resource`,
     scopes: [SCOPE],
   }
+  const hubTools = [
+    'list_my_games',
+    'get_game',
+    'join_game',
+    'get_legal_moves',
+    'make_move',
+    'undo_move',
+    'wait_for_my_turn',
+    'get_strategy_guide',
+  ]
+  const perInstanceTools = [
+    'get_game',
+    'join_game',
+    'get_legal_moves',
+    'make_move',
+    'undo_move',
+    'wait_for_my_turn',
+    'get_strategy_guide',
+  ]
   return NextResponse.json(
     {
       $schema: 'https://modelcontextprotocol.io/schemas/server-card/v1.0',
@@ -46,8 +69,8 @@ export const GET = () => {
           capabilities: ['tools'],
           auth: oauth,
           description:
-            'Cross-instance hub. Exposes list_my_games. Use this to find a game, then connect to its per-instance endpoint to play.',
-          tools: ['list_my_games'],
+            'Hub. Exposes every tool — per-game tools take an instance_id argument. This is the recommended endpoint for account-level integrations (claude.ai, ChatGPT) so the user connects once and can play any game.',
+          tools: hubTools,
         },
         {
           url_template: perInstanceTemplate,
@@ -55,16 +78,8 @@ export const GET = () => {
           capabilities: ['tools'],
           auth: oauth,
           description:
-            'Per-game endpoint. The /mcp suffix is optional — POST/JSON requests to https://kennerspiel.com/instance/<uuid> are routed here. Exposes the play-the-game tools.',
-          tools: [
-            'get_game',
-            'join_game',
-            'get_legal_moves',
-            'make_move',
-            'undo_move',
-            'wait_for_my_turn',
-            'get_strategy_guide',
-          ],
+            'Per-game endpoint. The /mcp suffix is optional — POST/JSON requests to https://kennerspiel.com/instance/<uuid> are routed here. Same play-the-game tools as the hub, but the instance_id is baked into the URL.',
+          tools: perInstanceTools,
         },
       ],
       capabilities: {
@@ -82,40 +97,40 @@ export const GET = () => {
         },
         {
           name: 'get_game',
-          endpoint: 'per-instance',
+          endpoint: 'hub-or-per-instance',
           description:
-            'Read the current board state of this game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves.',
+            'Read the current board state of a game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves.',
         },
         {
           name: 'get_legal_moves',
-          endpoint: 'per-instance',
+          endpoint: 'hub-or-per-instance',
           description:
             'Enumerate legal next tokens of a move command. Interactive drill-down from an empty partial to a complete command.',
         },
         {
           name: 'join_game',
-          endpoint: 'per-instance',
-          description: 'Claim a seat in the lobby of this game (only while the lobby is still open).',
+          endpoint: 'hub-or-per-instance',
+          description: 'Claim a seat in the lobby of a game (only while the lobby is still open).',
         },
         {
           name: 'make_move',
-          endpoint: 'per-instance',
+          endpoint: 'hub-or-per-instance',
           description:
-            'Play one complete move command in this game when it is your turn (e.g. USE LR2, BUILD G07 3 2, COMMIT).',
+            'Play one complete move command in a game when it is your turn (e.g. USE LR2, BUILD G07 3 2, COMMIT).',
         },
         {
           name: 'undo_move',
-          endpoint: 'per-instance',
+          endpoint: 'hub-or-per-instance',
           description: 'Retract the most recent command. Only the active player can undo, one command at a time.',
         },
         {
           name: 'wait_for_my_turn',
-          endpoint: 'per-instance',
-          description: 'Long-poll until it becomes your turn in this game, the game ends, or the timeout elapses.',
+          endpoint: 'hub-or-per-instance',
+          description: 'Long-poll until it becomes your turn, the game ends, or the timeout elapses.',
         },
         {
           name: 'get_strategy_guide',
-          endpoint: 'per-instance',
+          endpoint: 'hub-or-per-instance',
           description: 'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p).',
         },
       ],

--- a/web/src/app/api/[transport]/route.ts
+++ b/web/src/app/api/[transport]/route.ts
@@ -3,13 +3,20 @@ import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
 import { track } from '@vercel/analytics/server'
 import { z } from 'zod'
 import { listMyGames } from '@/mcp/tools/listMyGames'
+import { getGame } from '@/mcp/tools/getGame'
+import { getLegalMoves } from '@/mcp/tools/getLegalMoves'
+import { makeMove } from '@/mcp/tools/makeMove'
+import { undoMove } from '@/mcp/tools/undoMove'
+import { joinGame } from '@/mcp/tools/joinGame'
+import { waitForMyTurn } from '@/mcp/tools/waitForMyTurn'
+import { getStrategyGuide } from '@/mcp/tools/getStrategyGuide'
 import { errorResult } from '@/mcp/content'
 import { resolveAccessToken } from '@/oauth/store'
 
-// Cross-instance hub. Per-game tools (get_game, join_game, get_legal_moves,
-// make_move, undo_move, wait_for_my_turn, get_strategy_guide) live on the
-// per-instance endpoint at /instance/<id>/mcp — one token from the OAuth flow
-// covers both endpoints, so users only authorize the connector once.
+// Hub MCP server. Exposes every tool so a user who adds the connector once in
+// Claude / ChatGPT can play any of their games from any conversation. The
+// per-instance endpoint at /instance/<id>/mcp mirrors the play-the-game tools
+// without an instance_id parameter, for users who'd rather drop a per-game URL.
 const userIdFrom = (extra: { authInfo?: AuthInfo }): string | undefined =>
   (extra.authInfo?.extra as { userId?: string } | undefined)?.userId
 
@@ -23,13 +30,128 @@ const handler = createMcpHandler(
   (server) => {
     server.tool(
       'list_my_games',
-      'List the Ora et Labora games this agent is seated in. Each returned game has an instance_id; the per-game MCP endpoint lives at https://kennerspiel.com/instance/<instance_id>/mcp (or just https://kennerspiel.com/instance/<instance_id>) and exposes get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, and get_strategy_guide.',
+      'List the Ora et Labora games this agent is seated in. Call this first to find a game, or with only_my_turn to check whether any game is waiting on you.',
       { only_my_turn: z.boolean().optional().describe('Only return games where it is currently your turn') },
       async ({ only_my_turn }, extra) => {
         const userId = userIdFrom(extra)
         trackToolCall('list_my_games', userId)
         if (!userId) return unauthenticated()
         return listMyGames({ userId, onlyMyTurn: only_my_turn ?? false })
+      }
+    )
+    server.tool(
+      'get_game',
+      'Read the current board state of one game: rondel, player tableaus and landscapes, scores, whose turn it is, and recent moves. Call this before deciding on a move.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id, from list_my_games'),
+        detail: z
+          .enum(['summary', 'full'])
+          .optional()
+          .describe('summary (default) is a curated rendering; full is the raw engine state for debugging'),
+      },
+      async ({ instance_id, detail }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('get_game', userId)
+        if (!userId) return unauthenticated()
+        return getGame({ userId, instanceId: instance_id, detail: detail ?? 'summary' })
+      }
+    )
+    server.tool(
+      'get_legal_moves',
+      'List the legal next tokens of a move command. Call with an empty partial to see available verbs (USE, BUILD, COMMIT, ...), then append tokens and call again to drill down until a complete command is formed.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id'),
+        partial: z
+          .array(z.string())
+          .optional()
+          .describe('The tokens chosen so far, e.g. [] then ["BUILD"] then ["BUILD","G07"]'),
+      },
+      async ({ instance_id, partial }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('get_legal_moves', userId)
+        if (!userId) return unauthenticated()
+        return getLegalMoves({ userId, instanceId: instance_id, partial: partial ?? [] })
+      }
+    )
+    server.tool(
+      'join_game',
+      'Claim a seat in an Ora et Labora lobby that has not yet started. Pass either the game instance id or its URL (e.g. https://kennerspiel.com/instance/<uuid>) along with the color you want to play. If you already have a seat in that game, your color is updated. Wait for the human to choose the variant and press START on the website before calling get_game.',
+      {
+        instance: z
+          .string()
+          .min(1)
+          .describe(
+            'Either the game instance UUID or a URL containing it, e.g. https://kennerspiel.com/instance/<uuid>'
+          ),
+        color: z.enum(['red', 'green', 'blue', 'white']).describe('Which seat color to claim'),
+      },
+      async ({ instance, color }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('join_game', userId)
+        if (!userId) return unauthenticated()
+        return joinGame({ userId, instanceRef: instance, color })
+      }
+    )
+    server.tool(
+      'make_move',
+      'Play one complete move command in a game where it is your turn, e.g. "USE LR2" or "BUILD G07 3 2" or "COMMIT". The command must be legal per get_legal_moves. Note most turns are several commands ending with COMMIT.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id'),
+        command: z.string().min(1).describe('A complete space-separated command'),
+      },
+      async ({ instance_id, command }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('make_move', userId)
+        if (!userId) return unauthenticated()
+        return makeMove({ userId, instanceId: instance_id, command })
+      }
+    )
+    server.tool(
+      'undo_move',
+      'Undo your most recently played command in a game. This is not part of normal play — only use it when the human asks you to, e.g. to retract a sub-optimal move so they can teach a better one. Removes one command at a time (call repeatedly to roll back a multi-command turn). Only the most recent command can be undone, and only if it was your own (active when it was played). Returns the resulting state.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id'),
+      },
+      async ({ instance_id }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('undo_move', userId)
+        if (!userId) return unauthenticated()
+        return undoMove({ userId, instanceId: instance_id })
+      }
+    )
+    server.tool(
+      'wait_for_my_turn',
+      'Block until it becomes your turn in the given game, the game ends, or the timeout elapses. Use this instead of repeatedly polling get_game/list_my_games while waiting on other players. Pass color to wait for one specific seat (useful when this agent holds multiple seats in the same game and a sibling agent is playing the other color). Returns the same shape as list_my_games plus a timed_out flag.',
+      {
+        instance_id: z.string().uuid().describe('The game instance id'),
+        color: z
+          .enum(['red', 'green', 'blue', 'white'])
+          .optional()
+          .describe(
+            'Wait until this specific seat becomes active. Must be a color you are seated as. Omit to wait for any of your seats.'
+          ),
+        timeout_sec: z
+          .number()
+          .int()
+          .min(1)
+          .max(55)
+          .optional()
+          .describe('How long to wait before returning, in seconds (default 50, max 55 — request maxDuration is 60s)'),
+      },
+      async ({ instance_id, color, timeout_sec }, extra) => {
+        const userId = userIdFrom(extra)
+        trackToolCall('wait_for_my_turn', userId)
+        if (!userId) return unauthenticated()
+        return waitForMyTurn({ userId, instanceId: instance_id, color, timeoutSec: timeout_sec ?? 50 })
+      }
+    )
+    server.tool(
+      'get_strategy_guide',
+      'Return the full strategic coaching guide for Ora et Labora (France variant, long 2p). Covers action economy, clergy hierarchy, settlement evaluation, converter priorities, building identity reference, engine quirks, endgame protocols, and opening book. Call this at the start of a session or when planning a non-trivial move.',
+      {},
+      (_args, extra) => {
+        trackToolCall('get_strategy_guide', userIdFrom(extra))
+        return getStrategyGuide()
       }
     )
   },

--- a/web/src/app/llms.txt/route.ts
+++ b/web/src/app/llms.txt/route.ts
@@ -10,8 +10,8 @@ export const GET = () => {
 
 Kennerspiel exposes two MCP transports on the same OAuth credentials:
 
-- The cross-instance hub at \`${iss}/api/mcp\` exposes \`list_my_games\` for discovering your seats.
-- Each game has its own endpoint at \`${iss}/instance/{instance_id}/mcp\` — the \`/mcp\` suffix is optional, so pasting just \`${iss}/instance/{instance_id}\` into Claude or ChatGPT works too. This endpoint exposes the play-the-game tools (\`get_game\`, \`join_game\`, \`get_legal_moves\`, \`make_move\`, \`undo_move\`, \`wait_for_my_turn\`, \`get_strategy_guide\`).
+- The hub at \`${iss}/api/mcp\` exposes every tool. Per-game tools take \`instance_id\` as an argument. This is the recommended endpoint for account-level integrations (claude.ai, ChatGPT): the user adds the connector once and can play any game from any conversation.
+- Each game also has its own endpoint at \`${iss}/instance/{instance_id}/mcp\` — the \`/mcp\` suffix is optional, so pasting just \`${iss}/instance/{instance_id}\` into Claude Code or a one-off chat works too. Same play-the-game tools as the hub but instance_id is baked into the URL.
 
 One OAuth 2.1 + PKCE token (with RFC 7591 dynamic client registration) covers both the hub and every per-instance endpoint, so the user authorizes the connector only once.
 
@@ -25,13 +25,10 @@ One OAuth 2.1 + PKCE token (with RFC 7591 dynamic client registration) covers bo
 
 ## MCP tools
 
-Hub at \`/api/mcp\`:
+The hub at \`/api/mcp\` exposes every tool. Per-instance endpoints at \`/instance/{instance_id}/mcp\` expose the same play-the-game tools without an instance_id argument.
 
-- \`list_my_games\`: Find all games you're seated in; filter to games waiting on your move.
-
-Per-instance at \`/instance/{instance_id}/mcp\`:
-
-- \`join_game\`: Claim a seat in this game's lobby.
+- \`list_my_games\` (hub only): Find all games you're seated in; filter to games waiting on your move.
+- \`join_game\`: Claim a seat in a game's lobby.
 - \`get_game\`: Read the current board state — rondel, tableaus, scores, turn order.
 - \`get_legal_moves\`: Enumerate legal next tokens for a move (interactive drill-down).
 - \`make_move\`: Play one command (e.g. \`USE LR2\`, \`BUILD G07 3 2\`, \`COMMIT\`).

--- a/web/src/app/openapi.json/route.ts
+++ b/web/src/app/openapi.json/route.ts
@@ -15,7 +15,7 @@ export const GET = () => {
         version: '1.1.0',
         summary: 'Kennerspiel MCP server (hub + per-instance) and OAuth 2.1 endpoints.',
         description:
-          'HTTP surface for kennerspiel.com — the cross-instance MCP hub at /api/mcp, per-game MCP endpoints at /instance/{instance_id}/mcp (also reachable as /instance/{instance_id}), and the OAuth 2.1 + PKCE authorization-server endpoints (RFC 7591 dynamic registration, RFC 8414 metadata, RFC 9728 protected-resource metadata) that gate them. One token covers every MCP endpoint on this origin.',
+          'HTTP surface for kennerspiel.com — the MCP hub at /api/mcp (every tool, with instance_id as an argument), per-game MCP endpoints at /instance/{instance_id}/mcp (also reachable as /instance/{instance_id}, instance_id baked into the URL), and the OAuth 2.1 + PKCE authorization-server endpoints (RFC 7591 dynamic registration, RFC 8414 metadata, RFC 9728 protected-resource metadata) that gate them. One token covers every MCP endpoint on this origin.',
         license: { name: 'GPL-3.0', identifier: 'GPL-3.0' },
         contact: { name: 'philihp', url: 'https://github.com/philihp/kennerspiel' },
       },
@@ -49,9 +49,9 @@ export const GET = () => {
         '/api/mcp': {
           post: {
             operationId: 'mcpHubRpc',
-            summary: 'Cross-instance MCP hub.',
+            summary: 'MCP hub (full toolset).',
             description:
-              'Streamable-HTTP MCP transport. Tools: list_my_games. Use this to find a game, then switch to its per-instance endpoint to play.',
+              'Streamable-HTTP MCP transport. Exposes every tool: list_my_games, get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. Per-game tools take an instance_id argument. This is the recommended endpoint for account-level integrations (claude.ai, ChatGPT) — connect once and play any game.',
             security: [{ oauth2: [SCOPE] }],
             requestBody: {
               required: true,
@@ -71,7 +71,7 @@ export const GET = () => {
             operationId: 'mcpInstanceRpc',
             summary: 'Per-game MCP endpoint.',
             description:
-              'Streamable-HTTP MCP transport scoped to one game. Tools: get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide. The instance_id never appears in tool arguments — it comes from the URL.',
+              'Streamable-HTTP MCP transport scoped to one game. Same play-the-game tools as the hub (get_game, join_game, get_legal_moves, make_move, undo_move, wait_for_my_turn, get_strategy_guide), but instance_id is baked into the URL instead of appearing as a tool argument.',
             security: [{ oauth2: [SCOPE] }],
             parameters: [{ $ref: '#/components/parameters/InstanceId' }],
             requestBody: {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -19,17 +19,18 @@ const Home = () => {
         take a seat at your table — it will read the board, consult a built-in strategy guide, and play moves on your
         behalf. Useful for solo learning, AI-vs-AI matches, or just having a patient opponent at 2am.
       </p>
-      <p>Two endpoints share a single OAuth session:</p>
+      <p>Two ways to connect, both backed by the same OAuth session:</p>
       <ul>
         <li>
-          <strong>Hub</strong>: <code>https://kennerspiel.com/api/mcp</code> — exposes <code>list_my_games</code> so the
-          agent can find your seats.
+          <strong>Hub</strong>: <code>https://kennerspiel.com/api/mcp</code> — exposes every tool. This is the one to
+          use for claude.ai or ChatGPT integrations: add the connector once at the account level and you&apos;ll be able
+          to play any game from any conversation.
         </li>
         <li>
           <strong>Per-game</strong>: the URL of any game is also its MCP endpoint. Drop{' '}
           <code>https://kennerspiel.com/instance/&lt;uuid&gt;</code> into a chat and say &ldquo;join as white&rdquo; —
-          the agent gets <code>get_game</code>, <code>make_move</code>, the strategy guide, and everything else scoped
-          to that one game.
+          the agent gets the play-the-game tools scoped to that one game (no <code>instance_id</code> argument needed
+          because the URL already names it). Handy for Claude Code projects or one-off chats.
         </li>
       </ul>
       <h3>Claude (claude.ai)</h3>


### PR DESCRIPTION
## Summary

#1813 moved every play-the-game tool off `/api/mcp` and onto the per-instance endpoint. That broke the flow that account-level integrations (claude.ai, ChatGPT) rely on: those connectors are configured once per account, not per game, so stripping the per-game tools off the hub meant a connected user could find their games with `list_my_games` but couldn't actually play them — they'd have to set up a separate per-game connector for every match.

Put them back. The hub now exposes the full toolset (per-game tools take `instance_id` as an argument, like before #1813). The per-instance endpoint at `/instance/<id>/mcp` stays as a power-user path for URL-paste flows where `instance_id` is implicit — useful for Claude Code projects pinned to one game.

One OAuth token continues to cover both endpoints, so users still only authorize once.

### Tool surface after this PR

| Tool | Hub `/api/mcp` | Per-instance `/instance/<id>/mcp` |
|---|---|---|
| `list_my_games` | ✓ | — |
| `get_game` | ✓ (takes `instance_id`) | ✓ |
| `join_game` | ✓ (takes `instance` URL or UUID) | ✓ |
| `get_legal_moves` | ✓ (takes `instance_id`) | ✓ |
| `make_move` | ✓ (takes `instance_id`) | ✓ |
| `undo_move` | ✓ (takes `instance_id`) | ✓ |
| `wait_for_my_turn` | ✓ (takes `instance_id`) | ✓ |
| `get_strategy_guide` | ✓ | ✓ |

Refreshed `mcp.json`, `openapi.json`, `agents.json/txt`, `llms.txt`, the home page, and the README to describe the "hub has everything, per-instance is the bonus path" split.

## Test plan

- [ ] Reconnect claude.ai's existing Kennerspiel integration (pointed at `/api/mcp`) — `tools/list` should return all 8 tools again.
- [ ] Ask Claude "list my games and make a move on the one waiting on me" — should work end-to-end through the hub.
- [ ] `/instance/<uuid>/mcp` still returns the 7 instance-scoped tools (no `instance_id` arg).
- [ ] Pasting `https://kennerspiel.com/instance/<uuid>` into Claude Code still rewrites to `/mcp` and works.
- [ ] `curl /.well-known/mcp.json | jq '.endpoints[0].tools | length'` returns `8`; `.endpoints[1].tools | length` returns `7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY

---
_Generated by [Claude Code](https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY)_