### PR TITLE
fix(mcp): reject incomplete commands in make_move

### DIFF
--- a/web/src/mcp/tools/makeMove.ts
+++ b/web/src/mcp/tools/makeMove.ts
@@ -1,3 +1,4 @@
+import { control } from 'hathora-et-labora-game'
 import { GameStatusEnum } from 'hathora-et-labora-game/dist/types'
 import { activePlayerColor, applyCommand, asPlaying, engineColorToEntrantColor, replay, tokenize } from '../engine'
 import { renderSummary } from '../render'
@@ -34,12 +35,24 @@ export const makeMove = async ({
     return errorResult(`It is not your turn: you are ${mine}, and ${activeColor} is the active player.`)
   }
 
-  // 4. legality check
+  // 4. legality check — must satisfy both:
+  //   a) the reducer accepts the tokens (catches bad syntax / unknown verbs), and
+  //   b) `control()` lists "" as a completion of the tokens (catches partial
+  //      multi-token commands like `BUILD G07` without the position — the reducer
+  //      would happily apply that and park the game in a sub-step, but it isn't a
+  //      complete legal command per get_legal_moves).
   const tokens = tokenize(command)
+  if (tokens.length === 0) return errorResult('Empty command. Use get_legal_moves to find a legal command.')
   const nextState = applyCommand(playing, tokens)
   if (nextState === undefined) {
     return errorResult(
       `Illegal move: "${tokens.join(' ')}" was rejected by the game engine. Use get_legal_moves to find a legal command.`
+    )
+  }
+  const completions = control(playing, tokens).completion ?? []
+  if (!completions.includes('')) {
+    return errorResult(
+      `Incomplete move: "${tokens.join(' ')}" is a valid prefix but not a complete command. Use get_legal_moves with partial=${JSON.stringify(tokens)} to see the next tokens you still need to append.`
     )
   }
 


### PR DESCRIPTION
## Summary

`make_move` only used `applyCommand` (the reducer) to validate legality, which is permissive about partial multi-token commands. Submitting `BUILD G07` (without the position) would pass the check: the reducer applies it incrementally and leaves the game in a sub-step waiting for the rest of the command. That let agents play "moves" that `get_legal_moves` would never have shown as legal, leaving games in awkward in-between states.

Add a second check that mirrors what `get_legal_moves` already surfaces: `control(state, tokens).completion` must include the empty-string sentinel `""` — the engine's signal that the partial is submittable as a complete command. Now a command has to pass both the reducer and the canonical legal-completions list.

Also short-circuits empty commands explicitly so the error message is friendlier than "rejected by the game engine".

## Test plan

- [ ] `make_move` with `command="BUILD G07"` (incomplete) on a state where BUILD G07 is mid-step → returns `Incomplete move: "BUILD G07" is a valid prefix but not a complete command. Use get_legal_moves with partial=["BUILD","G07"] to see the next tokens you still need to append.`
- [ ] `make_move` with `command="BUILD G07 3 2"` (complete) when legal → still succeeds.
- [ ] `make_move` with `command=""` → returns the empty-command error.
- [ ] `make_move` with `command="FOO BAR"` (unknown verb) → still returns the existing "rejected by the game engine" error.
- [ ] `make_move` with `command="COMMIT"` when COMMIT is legal → still succeeds (COMMIT is a one-token complete command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY

---
_Generated by [Claude Code](https://claude.ai/code/session_0193axY6xUe7E7bsHY2SbTYY)_