### PR TITLE
fix(web): correct Inn coin preview when wine is consumed

### DIFF
--- a/game/src/buildings/__tests__/inn.test.ts
+++ b/game/src/buildings/__tests__/inn.test.ts
@@ -134,6 +134,93 @@ describe('buildings/inn', () => {
         nickel: 0,
       })
     })
+
+    const withSheep = (sheep: number): GameState => ({
+      ...s0,
+      players: [{ ...s0.players![0], sheep }, ...s0.players!.slice(1)],
+    })
+
+    it('pays out 6 for 3 sheep', () => {
+      const s1 = inn('ShShSh')(withSheep(3))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        wine: 10,
+        penny: 6,
+        nickel: 0,
+      })
+    })
+
+    it('pays out 12 for 3 sheep + 1 wine', () => {
+      const s1 = inn('WnShShSh')(withSheep(3))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        wine: 9,
+        penny: 7,
+        nickel: 1,
+      })
+    })
+
+    it('pays out 7 for 3 sheep + 1 grain', () => {
+      const s1 = inn('ShShShGn')(withSheep(3))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        grain: 9,
+        wine: 10,
+        penny: 7,
+        nickel: 0,
+      })
+    })
+
+    it('pays out 13 for 3 sheep + 1 grain + 1 wine', () => {
+      const s1 = inn('WnShShShGn')(withSheep(3))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        grain: 9,
+        wine: 9,
+        penny: 8,
+        nickel: 1,
+      })
+    })
+
+    it('pays out 7 for 4 sheep (food cap, 1 sheep worth wasted)', () => {
+      const s1 = inn('ShShShSh')(withSheep(4))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        wine: 10,
+        penny: 7,
+        nickel: 0,
+      })
+    })
+
+    it('pays out 13 for 4 sheep + 1 wine', () => {
+      const s1 = inn('WnShShShSh')(withSheep(4))!
+      expect(s1.players![0]).toMatchObject({
+        sheep: 0,
+        wine: 9,
+        penny: 8,
+        nickel: 1,
+      })
+    })
+
+    it('pays out 7 for 2 meat (food cap, 3 food wasted)', () => {
+      const s1 = inn('MtMt')(s0)!
+      expect(s1.players![0]).toMatchObject({
+        meat: 8,
+        wine: 10,
+        penny: 7,
+        nickel: 0,
+      })
+    })
+
+    it('pays out 13 for 2 meat + 1 wine', () => {
+      const s1 = inn('WnMtMt')(s0)!
+      expect(s1.players![0]).toMatchObject({
+        meat: 8,
+        wine: 9,
+        penny: 8,
+        nickel: 1,
+      })
+    })
   })
 
   describe('complete', () => {

--- a/web/src/components/erection/inn.tsx
+++ b/web/src/components/erection/inn.tsx
@@ -49,7 +49,7 @@ export const Inn = () => {
     2 * whiskeyUsed +
     1 * wineUsed
 
-  const coinsMade = 1 * min(foodUsed - max(wineUsed - 1, 0), MAX_FOOD) + COINS_FOR_WINE * min(1, wineUsed)
+  const coinsMade = 1 * min(foodUsed - min(wineUsed, 1), MAX_FOOD) + COINS_FOR_WINE * min(1, wineUsed)
 
   const substrings = [
     join('', repeat(ResourceEnum.Grain, grainUsed)),


### PR DESCRIPTION
## Summary

The Inn UI previewed 1 wine as 7 coins (1 nickel + 2 pennies), but the backend (`game/src/buildings/inn.ts`) correctly pays only 6 coins (1 nickel + 1 penny). The preview formula at `web/src/components/erection/inn.tsx:52` counted the wine going to the +6¢ bonus as 1 food **in addition to** the bonus.

The expression `max(wineUsed - 1, 0)` returns 0 for `wineUsed = 1`, leaving the wine in the food pool. Switched to `min(wineUsed, 1)` so exactly one wine is removed from the food pool when there is a wine for the bonus — matching the rules: up to 7 food @ 1¢ each, plus +1 wine @ 6¢.

Affected cases (preview → actual backend payout):
- 1 wine: was 7 → now 6 ✓
- 1 wine + 1 grain: was 8 → now 7 ✓
- 1 wine + 6 grain: was 13 → now 12 ✓
- 1 wine + 7 grain (max): unchanged at 13 ✓ (food cap already kicked in)

## Test plan

- [ ] Open the Inn USE modal in the web UI
- [ ] Input 1 wine alone → preview shows 1 nickel + 1 penny (6¢)
- [ ] Input 2 wine → preview shows 1 nickel + 2 pennies (7¢)
- [ ] Input 1 wine + 7 grain → preview shows 1 nickel + 8 pennies (13¢)
- [ ] Confirm the trade and verify the preview matches the actual payout

---
_Generated by [Claude Code](https://claude.ai/code/session_019mASHFKHg8V4NmgtRZsszm)_