### PR TITLE
chore(web): bump hathora-et-labora-game to 0.21.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "dotenv": "17.4.2",
     "flags": "4.2.0",
     "form-urlencoded": "6.1.7",
-    "hathora-et-labora-game": "0.21.0",
+    "hathora-et-labora-game": "0.21.1",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.1.0",
     "mcp-handler": "1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 6.1.7
         version: 6.1.7
       hathora-et-labora-game:
-        specifier: 0.21.0
-        version: 0.21.0
+        specifier: 0.21.1
+        version: 0.21.1
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -1971,8 +1971,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hathora-et-labora-game@0.21.0:
-    resolution: {integrity: sha512-hqs5f5B0480+s7zB28j2oZHxYXsc4DUUKNXkie65bbkVx4zyt/Ix8p17MQ7esX1x+nGsAN7oa0ejgrKYt68TuA==}
+  hathora-et-labora-game@0.21.1:
+    resolution: {integrity: sha512-Nedt/ir76ZuAHu2hIUWUKmRnqatvrOyTedzeSmhxOTPV2Ej3I+uCgDv0PtgslYM5ID82nMO1AvHDWlo/tieyaQ==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -5101,7 +5101,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hathora-et-labora-game@0.21.0:
+  hathora-et-labora-game@0.21.1:
     dependencies:
       fast-shuffle: 6.2.0
       pcg: 3.0.0


### PR DESCRIPTION
## Summary

- Bumps `hathora-et-labora-game` from 0.21.0 → 0.21.1 in the web app
- Picks up the House of the Brotherhood reward-combination fix from #1846, so the in-game completion offers `Book + Ornament + Reliquary` (and other previously pruned combinations) at higher cloister counts

## Test plan

- [ ] Open the House of the Brotherhood in a game with 14 points entitlement and confirm `Book + Ornament + Reliquary` is selectable
- [ ] CI green on the web build/tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173PPu3ahzsL2vXRszCghVz

---
_Generated by [Claude Code](https://claude.ai/code/session_0173PPu3ahzsL2vXRszCghVz)_