### PR TITLE
Focus AI integration docs on Chat users

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,7 +16,7 @@ const Home = () => {
         Create an <Link href="/instance/">instance</Link> and share the URL with friends.
       </p>
 
-      <h3>Connect to an AI</h3>
+      <h3>Connect your AI to Kennerspiel</h3>
       <ul>
         <li>
           <strong>(Claude)</strong> Customize → Connectors → Add Custom Connector.
@@ -28,6 +28,19 @@ const Home = () => {
       </ul>
       <p>
         Add <code>https://kennerspiel.com/api/mcp</code>, your agent will attempt to OAuth to this site
+      </p>
+
+      <h3>Play a game with AI</h3>
+      <p>
+        Create an <Link href="/instance/">instance</Link>, and during setup give your AI the instance ID. You can say
+        something like
+      </p>
+      <blockquote>
+        Please join https://kennerspiel.com/instance/ff801bac-4070-4870-93d2-b80190be9000 and play as green and white
+      </blockquote>
+      <p>
+        Your AI can play as multiple players, and will download an internally developed{' '}
+        <Link href="https://github.com/philihp/kennerspiel/blob/main/docs/ora-et-labora-strategy-SKILL.md">skill</Link>
       </p>
 
       <p>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -19,21 +19,11 @@ const Home = () => {
         take a seat at your table — it will read the board, consult a built-in strategy guide, and play moves on your
         behalf. Useful for solo learning, AI-vs-AI matches, or just having a patient opponent at 2am.
       </p>
-      <p>Two ways to connect, both backed by the same OAuth session:</p>
-      <ul>
-        <li>
-          <strong>Hub</strong>: <code>https://kennerspiel.com/api/mcp</code> — exposes every tool. This is the one to
-          use for claude.ai or ChatGPT integrations: add the connector once at the account level and you&apos;ll be able
-          to play any game from any conversation.
-        </li>
-        <li>
-          <strong>Per-game</strong>: the URL of any game is also its MCP endpoint. Drop{' '}
-          <code>https://kennerspiel.com/instance/&lt;uuid&gt;</code> into a chat and say &ldquo;join as white&rdquo; —
-          the agent gets the play-the-game tools scoped to that one game (no <code>instance_id</code> argument needed
-          because the URL already names it). Handy for Claude Code projects or one-off chats.
-        </li>
-      </ul>
-      <h3>Claude (claude.ai)</h3>
+      <p>
+        Both Claude.ai and ChatGPT can connect via the <code>https://kennerspiel.com/api/mcp</code> connector. Add it
+        once at the account level and you&apos;ll be able to play any game from any conversation.
+      </p>
+      <h3>Claude.ai</h3>
       <ol>
         <li>
           Open <strong>Settings → Integrations → Add integration</strong>.
@@ -44,19 +34,9 @@ const Home = () => {
         <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
       </ol>
       <p>
-        Once authorized, the same token also covers any per-game URL — no re-auth when you switch games. Ask Claude
-        something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the tools automatically.
+        Once authorized, ask Claude something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the
+        tools automatically.
       </p>
-      <h3>Claude Code</h3>
-      <p>Add the hub once:</p>
-      <pre>
-        <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
-      </pre>
-      <p>Or wire up one specific game directly:</p>
-      <pre>
-        <code>claude mcp add --transport http my-game https://kennerspiel.com/instance/&lt;uuid&gt;</code>
-      </pre>
-      <p>Claude Code opens a browser for the OAuth flow and redirects back automatically.</p>
       <h3>ChatGPT</h3>
       <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
       <ol>
@@ -68,6 +48,12 @@ const Home = () => {
         </li>
         <li>ChatGPT discovers the OAuth endpoints automatically and redirects you here to authorize.</li>
       </ol>
+      <p>
+        Alternatively, if you prefer the command line, you can add the connector with:
+      </p>
+      <pre>
+        <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
+      </pre>
       <p>
         Source code is available at{' '}
         <Link href="https://github.com/philihp/kennerspiel">github.com/philihp/kennerspiel</Link>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,56 +3,33 @@ import Link from 'next/link'
 const Home = () => {
   return (
     <main>
-      <h1>Kennerspiel</h1>
+      <h2>Kennerspiel</h2>
       <p>
-        Hi! This is a place to play turn-based board games on virtual tables with minimal client overhead. It&apos;s not
-        much too look at right now, but I coded all of this by hand without any AI assistance, so please give me that
-        much.
+        Hi! This is a place to play turn-based open-information and deterministic board games on virtual tables with
+        minimal client overhead. I started out with Uwe Rosenberg&apos;s game{' '}
+        <Link href="https://amzn.to/3P1UYDe">Ora et Labora</Link>, and I&apos;ve been having fun teaching Claude how
+        to play it with me. It&apos;s a work in progress, but playable right now.
       </p>
+
+      <h3>Quickstart</h3>
       <p>
-        You&apos;ll probably want to start out by creating an <Link href="/instance/">instance</Link>, and either play a
-        solo game or invite some friends.
+        Create an <Link href="/instance/">instance</Link> and share the URL with friends.
       </p>
-      <h2>Play with an AI</h2>
-      <p>
-        Kennerspiel has an <Link href="https://modelcontextprotocol.io/">MCP</Link> server. Any MCP-compatible AI can
-        take a seat at your table — it will read the board, consult a built-in strategy guide, and play moves on your
-        behalf. Useful for solo learning, AI-vs-AI matches, or just having a patient opponent at 2am.
-      </p>
-      <p>
-        Both Claude.ai and ChatGPT can connect via the <code>https://kennerspiel.com/api/mcp</code> connector. Add it
-        once at the account level and you&apos;ll be able to play any game from any conversation.
-      </p>
-      <h3>Claude.ai</h3>
-      <ol>
+
+      <h3>Connect to an AI</h3>
+      <ul>
         <li>
-          Open <strong>Settings → Integrations → Add integration</strong>.
+          <strong>(Claude)</strong> Customize → Connectors → Add Custom Connector.
         </li>
         <li>
-          Paste this URL: <code>https://kennerspiel.com/api/mcp</code>
+          <strong>(ChatGPT)</strong> Settings → Apps (or Apps & connectors) → Enable Developer mode if prompted. →
+          Click Create App (or Add custom connector on some accounts).
         </li>
-        <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
-      </ol>
+      </ul>
       <p>
-        Once authorized, just share a game URL and ask &ldquo;please play as white in https://kennerspiel.com/instance/&lt;uuid&gt;&rdquo;.
+        Add <code>https://kennerspiel.com/api/mcp</code>, your agent will attempt to OAuth to this site
       </p>
-      <h3>ChatGPT</h3>
-      <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
-      <ol>
-        <li>
-          Open <strong>Settings → Connectors → Create</strong>.
-        </li>
-        <li>
-          Paste this URL: <code>https://kennerspiel.com/api/mcp</code>
-        </li>
-        <li>ChatGPT discovers the OAuth endpoints automatically and redirects you here to authorize.</li>
-      </ol>
-      <p>
-        Alternatively, if you prefer the command line, you can add the connector with:
-      </p>
-      <pre>
-        <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
-      </pre>
+
       <p>
         Source code is available at{' '}
         <Link href="https://github.com/philihp/kennerspiel">github.com/philihp/kennerspiel</Link>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -34,9 +34,17 @@ const Home = () => {
         <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
       </ol>
       <p>
-        Once authorized, ask Claude something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the
-        tools automatically.
+        Once authorized, you can play in two ways:
       </p>
+      <ul>
+        <li>
+          List your games: ask Claude something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the
+          tools automatically.
+        </li>
+        <li>
+          Quick play: just share a game URL and ask &ldquo;please play as white in https://kennerspiel.com/instance/&lt;uuid&gt;&rdquo;.
+        </li>
+      </ul>
       <h3>ChatGPT</h3>
       <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
       <ol>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -34,17 +34,8 @@ const Home = () => {
         <li>Sign in to Kennerspiel when Claude opens the authorization page, then click Authorize.</li>
       </ol>
       <p>
-        Once authorized, you can play in two ways:
+        Once authorized, just share a game URL and ask &ldquo;please play as white in https://kennerspiel.com/instance/&lt;uuid&gt;&rdquo;.
       </p>
-      <ul>
-        <li>
-          List your games: ask Claude something like &ldquo;list my Ora et Labora games&rdquo; and it&apos;ll find the
-          tools automatically.
-        </li>
-        <li>
-          Quick play: just share a game URL and ask &ldquo;please play as white in https://kennerspiel.com/instance/&lt;uuid&gt;&rdquo;.
-        </li>
-      </ul>
       <h3>ChatGPT</h3>
       <p>Requires a Plus, Pro, Business, or Enterprise account with Developer mode enabled.</p>
       <ol>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,28 +7,24 @@ const Home = () => {
       <p>
         Hi! This is a place to play turn-based open-information and deterministic board games on virtual tables with
         minimal client overhead. I started out with Uwe Rosenberg&apos;s game{' '}
-        <Link href="https://amzn.to/3P1UYDe">Ora et Labora</Link>, and I&apos;ve been having fun teaching Claude how
-        to play it with me. It&apos;s a work in progress, but playable right now.
+        <Link href="https://amzn.to/3P1UYDe">Ora et Labora</Link>, and I&apos;ve been having fun teaching Claude how to
+        play it with me. It&apos;s a work in progress, but playable right now.
       </p>
 
-      <h3>Quickstart</h3>
-      <p>
-        Create an <Link href="/instance/">instance</Link> and share the URL with friends.
-      </p>
-
-      <h3>Connect your AI to Kennerspiel</h3>
+      <h3>Connect AI to Kennerspiel</h3>
       <ul>
         <li>
           <strong>(Claude)</strong> Customize → Connectors → Add Custom Connector.
         </li>
         <li>
-          <strong>(ChatGPT)</strong> Settings → Apps (or Apps & connectors) → Enable Developer mode if prompted. →
-          Click Create App (or Add custom connector on some accounts).
+          <strong>(ChatGPT)</strong> Settings → Apps (or Apps & connectors) → Enable Developer mode if prompted. → Click
+          Create App (or Add custom connector on some accounts).
+        </li>
+        <li>
+          <strong>(Claude CLI)</strong>{' '}
+          <code>claude mcp add --transport http kennerspiel https://kennerspiel.com/api/mcp</code>
         </li>
       </ul>
-      <p>
-        Add <code>https://kennerspiel.com/api/mcp</code>, your agent will attempt to OAuth to this site
-      </p>
 
       <h3>Play a game with AI</h3>
       <p>
@@ -39,8 +35,9 @@ const Home = () => {
         Please join https://kennerspiel.com/instance/ff801bac-4070-4870-93d2-b80190be9000 and play as green and white
       </blockquote>
       <p>
-        Your AI can play as multiple players, and will download an internally developed{' '}
-        <Link href="https://github.com/philihp/kennerspiel/blob/main/docs/ora-et-labora-strategy-SKILL.md">skill</Link>
+        Your AI can play as multiple players, and should play according to an internally developed{' '}
+        <Link href="https://github.com/philihp/kennerspiel/blob/main/docs/ora-et-labora-strategy-SKILL.md">skill</Link>,
+        which your AI can access through the connector.
       </p>
 
       <p>


### PR DESCRIPTION
## Summary

Streamlined the homepage AI integration instructions to focus on Chat users (Claude.ai and ChatGPT) instead of promoting multiple integration methods.

## Changes

- Removed the "Two ways to connect" section that explained Hub vs Per-game endpoints
- Removed all Claude Code references
- Simplified messaging to emphasize the single `https://kennerspiel.com/api/mcp` connector that works for both Claude.ai and ChatGPT
- Added CLI option at the end for users preferring command-line setup via `claude mcp add`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNSEGCVPvteFHEct4MRpX3)_