### PR TITLE
feat: allow COMMIT without using the main action (a pass)

### DIFF
--- a/game/src/commands/__tests__/commit.test.ts
+++ b/game/src/commands/__tests__/commit.test.ts
@@ -16,10 +16,11 @@ describe('commands/commit', () => {
   })
 
   describe('complete', () => {
-    it('does not allow commit if main action not used', () => {
-      // this was a bit of a judgement call. the rules say each player "gets to carry out an action", but
-      // i can't figure out a single instance where a player would want to pass on this, so i'm going to say
-      // no commits without doing a thing
+    it('allows commit even if main action not used (a pass)', () => {
+      // The rules say each player "gets to carry out one action" — an
+      // entitlement, not an obligation — so a player may pass (end their turn
+      // without using the main action). This also avoids softlocking end-game
+      // states where no legal action remains.
       const s1 = {
         ...s0,
         frame: {
@@ -28,7 +29,7 @@ describe('commands/commit', () => {
         },
       }
       const c0 = complete(s1)([])
-      expect(c0).toStrictEqual([])
+      expect(c0).toStrictEqual(['COMMIT'])
     })
     describe('neutral building phase', () => {
       it('does not allow commit if still buildings', () => {

--- a/game/src/commands/commit.ts
+++ b/game/src/commands/commit.ts
@@ -5,13 +5,17 @@ import { GameCommandEnum, GameState, StateReducer } from '../types'
 
 const checkCanCommit: StateReducer = (state) => {
   if (state === undefined) return state
+  // A work-contract responder (active != current) is mid-interrupt: they must
+  // place a clergyman in response, not end the whole turn.
   if (state.frame!.currentPlayerIndex !== state.frame!.activePlayerIndex) return undefined
-  if (state.frame!.neutralBuildingPhase) {
-    if (state.buildings!.length !== 0) return undefined
-    return state
-  }
-  if (state.frame!.mainActionUsed) return state
-  return undefined
+  // The solo neutral building phase must place all neutral buildings first.
+  if (state.frame!.neutralBuildingPhase && state.buildings!.length !== 0) return undefined
+  // Otherwise a player may always end their turn. The rules say each player
+  // "gets to carry out one action" — an entitlement, not an obligation (the
+  // designer reserves "must" for real obligations), so passing (COMMIT without
+  // using the main action) is legal. Requiring mainActionUsed also softlocked
+  // end-game states where no legal action remained.
+  return state
 }
 
 export const commit: StateReducer = pipe(


### PR DESCRIPTION
## What

Lets a player end their turn (COMMIT) without using their main action — i.e. **pass**.

## Why

The rules say each player *"gets to carry out one action"* — an entitlement, not an obligation. Rosenberg reserves *"must"* for genuine obligations (take your clergymen back, pay the work-contract coin, place a bought landscape immediately, …) and never applies it to the action itself. So passing is legal by the rules. (The old `commit.ts` even carried a comment acknowledging this was a judgment call.)

It also fixes a concrete **end-game softlock**: states where no legal action remained could never reach `gameEnd`, because COMMIT required `mainActionUsed`. With this change, random-vs-random self-play finishes **100%** of games (previously 0% — they stalled at round 28 / settlement D).

## Change (`game/` only)

`commit.ts` — `checkCanCommit` no longer requires `mainActionUsed`. The two guards that must remain are kept:
- a work-contract responder (`activePlayerIndex != currentPlayerIndex`) is mid-interrupt and must place a clergyman, not end the turn;
- the solo neutral building phase must finish placing buildings first.

Updated the unit test to assert COMMIT is offered with no action used.

## No web change

The web Commit button already does the right thing — it's enabled from `control().completion` (so a pass becomes available once this ships) and `actionCommit.tsx`'s existing `maybeDont` only styles it **primary** when `mainActionUsed` is true (and no other action remains). Left exactly as-is.

## Shipping note

`web` consumes the **published** `hathora-et-labora-game`, so this reaches the live site after the game package is republished and `web` bumps its dependency.

## Verification

- All **1371** game tests pass.
- Random-vs-random arena: `finished: 100%` (was 0%), avg steps 2182 → 785.
- Rebased onto current `main`; game `tests` ✅ and Vercel green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27