### PR TITLE
chore(workspace): disable pnpm minimumReleaseAge gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,10 @@ packages:
 # (moved here from game/pnpm-workspace.yaml)
 allowBuilds:
   esbuild: true
-minimumReleaseAgeExclude:
-  - '@types/ramda@0.32.0'
+# Supply-chain age gate disabled. pnpm 11 defaults minimumReleaseAge to 24h,
+# which fails CI whenever a dependency bump (e.g. a Renovate eslint/prettier
+# update) lands within that window. 0 turns it off; the exclude list is then
+# moot and removed.
+minimumReleaseAge: 0
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## What

Sets `minimumReleaseAge: 0` in the root `pnpm-workspace.yaml` (and drops the now-moot `minimumReleaseAgeExclude`).

## Why

pnpm 11 defaults `minimumReleaseAge` to 24h. The root workspace's `tests` workflow runs `pnpm install --no-frozen-lockfile` under pnpm 11.8 (from `game`'s `packageManager`), so it **re-resolves** dependencies and then **rejects any version published within the last 24h**:

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
  eslint@10.6.0 ... within the minimumReleaseAge cutoff
  prettier@3.8.5 ... within the minimumReleaseAge cutoff
```

Those came from the Renovate bumps (#1855 / #1854). The net effect is that **`main` and every `game`-touching PR's `tests` check goes red for ~24h after any dependency update** — not a useful gate for this repo. Turning it off removes that recurring breakage.

## Notes

- `web` is its own workspace and isn't affected (its Vercel build uses a frozen lockfile and didn't enforce this).
- This PR doesn't touch `game/**` or the workflow file, so the `tests` check won't run on the PR itself (path filter). It's validated by the **push-to-`main`** run on merge, after which `main`'s CI goes green and PRs blocked on this clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27)_