### PR TITLE
chore(renovate): modernize config and make it pnpm-aware

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "schedule": ["every weekend"],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Independency Dashboard",
   "semanticCommits": "enabled",
-  "transitiveRemediation": true,
+  "postUpdateOptions": ["pnpmDedupe"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["every weekend"]
+  },
   "packageRules": [
     {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "depTypeList": ["devDependencies"],
+      "matchDepTypes": ["devDependencies"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Why

We've hit the same failure three times this week — Renovate bumps a dependency in `package.json` but the pnpm lockfile isn't updated, so `pnpm install --frozen-lockfile` (Vercel) or `--no-frozen-lockfile` (the `tests` workflow) then fails (eslint/prettier → #1857, supabase → #1865). The Renovate config was also using deprecated syntax.

## Changes (`.github/renovate.json`)

**pnpm lockfile hygiene (the actual fix):**
- `postUpdateOptions: ["pnpmDedupe"]` — after each update Renovate regenerates/dedupes the pnpm lockfile, so it stays in sync with `package.json`.
- `lockFileMaintenance` (enabled, automerge, weekend) — periodic full lockfile refresh as a safety net for any drift that still slips through.

**Modernization (the old config was partly inert):**
- `extends`: `config:base` → `config:recommended` (`config:base` is deprecated).
- `packageRules`: `updateTypes` → `matchUpdateTypes`, `depTypeList` → `matchDepTypes`. The old keys are unknown to current Renovate and were **silently ignored**, so the intended automerge rules weren't actually applying.
- dropped deprecated `transitiveRemediation`.

Validated locally with `renovate-config-validator` (✓ validated successfully).

## Note

Pairs with #1864 (disabling pnpm's `minimumReleaseAge` gate), which was also blocking Renovate's lockfile-update install from resolving freshly-published versions. Together these should end the recurring drift. The `tests` check won't run on this PR (no `game/**` changes); any Vercel red here is the inherited supabase drift that #1865 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27)_