### PR TITLE
docs(trainer): project-based plan for the offline AlphaZero trainer

### DIFF
--- a/docs/mcts-self-play-plan.md
+++ b/docs/mcts-self-play-plan.md
@@ -1,5 +1,10 @@
 # MCTS Self-Play & Position-Evaluation Plan
 
+> **Superseded** by [`docs/trainer/README.md`](trainer/README.md) — the
+> full-AlphaZero (policy + value) trainer plan. Phases 1–3 below shipped and
+> correspond to projects 01–06 there; this document is kept for its
+> measurements and historical record.
+
 Plan for building a Monte Carlo Tree Search (MCTS) agent that plays Ora et
 Labora against itself, learns a position evaluator (value network) from that
 self-play, and is ultimately served for real-time human-vs-computer play.

--- a/docs/trainer/01-state-encoder.md
+++ b/docs/trainer/01-state-encoder.md
@@ -1,0 +1,49 @@
+# 01 — State encoder (egocentric tensor)
+
+| | |
+| --- | --- |
+| Status | ✅ done (`game/src/encode.ts`) |
+| Package | `game/` |
+| Depends on | — |
+
+## Goal
+
+Encode a `GameState` as a fixed-length `Float32Array` suitable as neural-net
+input, so any position can be turned into training/inference features without
+bespoke feature engineering per consumer.
+
+## Design
+
+- **Egocentric perspective**: the encoding rotates seats so the requested
+  perspective is always slot 0. The net never spends capacity learning that
+  seats are interchangeable, and every absolute position yields N training
+  samples.
+- **Layout**: `MAX_PLAYERS(4) × PLAYER_BLOCK + FRAME + SHARED`, where a player
+  block is a 38×9 landscape grid × 10 channels (6 land one-hots, 1 categorical
+  erection-id channel, 3 clergy flags) plus per-player scalars (22 resources,
+  wonders, clergy buckets, settlement hand). `FEATURE_LEN ≈ 14.7k` floats
+  (~57 KB dense f32, ~29 KB f16).
+- **Categorical erection channel**: buildings/settlements are a single id
+  (embedding-friendly) rather than one-hots; vocab capacity is reserved at 256
+  so adding buildings never changes `FEATURE_LEN`. Enum orderings are
+  **append-only** — trained weights are keyed by id.
+- **`featureSpec` export**: machine-readable offsets, grid geometry, vocab
+  lists, and versions, so downstream code (exporter, PyTorch model) is built
+  data-driven rather than hard-coding shapes.
+- Implementation is an imperative preallocated `Writer` (no per-call
+  allocation churn beyond the output buffer).
+
+## Inputs
+
+- A `GameState` (any status) and a perspective index.
+
+## Outputs
+
+- `encode(state, perspective?) → Float32Array(FEATURE_LEN)`
+- `featureSpec`, `FEATURE_LEN` exported from `hathora-et-labora-game`.
+
+## How it runs / verification
+
+- Library code — consumed by the exporter (16) and evaluators (12, 21).
+- `pnpm --dir game test` — encoder unit tests pin offsets, vocab stability,
+  and perspective rotation.

--- a/docs/trainer/01-state-encoder.md
+++ b/docs/trainer/01-state-encoder.md
@@ -10,32 +10,156 @@
 
 Encode a `GameState` as a fixed-length `Float32Array` suitable as neural-net
 input, so any position can be turned into training/inference features without
-bespoke feature engineering per consumer.
+bespoke feature engineering per consumer. The layout is published as data
+(`featureSpec`) so the exporter ([16](16-shard-exporter.md)) and the PyTorch
+model ([18](18-model.md)) never hard-code offsets.
 
 ## Design
 
-- **Egocentric perspective**: the encoding rotates seats so the requested
-  perspective is always slot 0. The net never spends capacity learning that
-  seats are interchangeable, and every absolute position yields N training
-  samples.
-- **Layout**: `MAX_PLAYERS(4) × PLAYER_BLOCK + FRAME + SHARED`, where a player
-  block is a 38×9 landscape grid × 10 channels (6 land one-hots, 1 categorical
-  erection-id channel, 3 clergy flags) plus per-player scalars (22 resources,
-  wonders, clergy buckets, settlement hand). `FEATURE_LEN ≈ 14.7k` floats
-  (~57 KB dense f32, ~29 KB f16).
-- **Categorical erection channel**: buildings/settlements are a single id
-  (embedding-friendly) rather than one-hots; vocab capacity is reserved at 256
-  so adding buildings never changes `FEATURE_LEN`. Enum orderings are
-  **append-only** — trained weights are keyed by id.
-- **`featureSpec` export**: machine-readable offsets, grid geometry, vocab
-  lists, and versions, so downstream code (exporter, PyTorch model) is built
-  data-driven rather than hard-coding shapes.
-- Implementation is an imperative preallocated `Writer` (no per-call
-  allocation churn beyond the output buffer).
+### Exported surface
+
+```ts
+export const FEATURE_LEN: number   // 14,670 with the current vocab
+export const encode: (state: GameState, perspective?: number) => Float32Array
+export const featureSpec: FeatureSpec
+```
+
+`encode` allocates one zero-initialized `Float32Array(FEATURE_LEN)` and fills
+it in a single left-to-right pass. `perspective` defaults to
+`frame.currentPlayerIndex` — note this is **not** `activePlayerIndex`, so
+callers encoding "the player to move" during a `WORK_CONTRACT` interrupt must
+pass the perspective explicitly (see [02](02-engine-adapter.md)'s
+`playerToMove`). A `SETUP`-status state returns the all-zero vector rather
+than throwing.
+
+### Layout
+
+`FEATURE_LEN = MAX_PLAYERS(4) × PLAYER_BLOCK(3,455) + FRAME(549) + SHARED(301)
+= 14,670` floats (~57 KB dense f32, ~29 KB f16).
+
+| Block | Size | Contents |
+| --- | --- | --- |
+| Player scalars | 35 | 22 resource counts, wonders, 4 clergy buckets `[lb_unplaced, lb_placed, prior_unplaced, prior_placed]`, 8-bit in-hand settlement-type mask |
+| Player grid | 38×9×10 = 3,420 | per tile: 6 land one-hots, 1 categorical erection-id channel, 3 clergy flags `[laybrother, prior, opponent-owned]` |
+| Frame | 549 | round (raw), settlementRound one-hot (7), current/active player one-hots over *rotated slots* (4+4), 4 booleans, bonusActions command bitmask (14), nextUse one-hot (3), usable + unusable building masks (256+256) |
+| Shared | 301 | rondel deltas (9) and yields (9), still-available buildings mask (256), plot + district prices (9+9, zero-padded), wonders remaining, config one-hots: players (4), length (2), country (2) |
+
+Empty player slots (games with <4 players) are zero blocks.
+
+### Egocentric rotation
+
+`rotateOrder(numPlayers, perspective)` maps output slot `s` to absolute seat
+`(perspective + s) % numPlayers`, so slot 0 is always "me" and relative turn
+order is preserved. The frame's `currentPlayerIndex`/`activePlayerIndex`
+one-hots are emitted in rotated slot space, not absolute seats.
+
+### Erection vocabulary (categorical, color-collapsed)
+
+A tile's building/settlement is a single integer id in a **categorical
+channel** (0 = empty, 1..80 today), not a one-hot; the model embeds it.
+Colored variants collapse to one generic key — `L[RGBW][123]` →
+`ClayMound`/`FarmYard`/`CloisterOffice`, `S[RGBW][1-8]` → `Settlement1..8` —
+because a colored tile only ever sits on its owner's board and slot identity
+already carries ownership. Country variants (e.g. `F03` GrainStorage vs `I03`
+Granary) stay distinct: different buildings, not colors. The unified vocab is
+72 generic buildings followed by 8 settlement types; settlement ids start at
+`buildings.length + 1`. All vocab-shaped features (the three 256-wide masks)
+reserve `VOCAB_CAPACITY = 256` slots so adding expansion buildings never
+changes `FEATURE_LEN`. Enum orderings are **append-only** — trained weights
+are keyed by slot/id position and silently misalign if anything is reordered.
+
+### Grid anchoring
+
+The landscape grows in both directions (`landscapeOffset` tracks rows bought
+above row 0). Output row `r` reads logical row `r + landscapeOffset − ANCHOR`
+with `ANCHOR = 18`, `H = 38`, `W = 9`, so a player's logical row 0 always
+lands at the same output row regardless of purchases; two states differing
+only in `landscapeOffset` bookkeeping encode identically (pinned by test).
+Cells outside the window are clipped; `undefined` tiles write zeros.
+
+### Normalization
+
+Rondel features are normalized: delta = `((slot − pointingBefore) mod 13)/13`,
+yield = `take(pointingBefore, slot, config)/10` (0 for tokens not yet on the
+rondel). Everything else — resource counts, round, prices, wonders, clergy
+buckets — is a raw count; the net owns scaling.
+
+### Writer
+
+An imperative preallocated `Writer` (`put`/`hot`/`bits`/`skip`) writes
+straight into the output buffer; `hot` and `bits` silently drop out-of-range
+indices (this is what makes the 256-wide masks forward-compatible). One pass,
+O(FEATURE_LEN), no intermediate feature arrays; the only per-call allocations
+are the output buffer and small per-tableau helpers. `erectionId` still does
+an `indexOf` over the 80-entry vocab per occupied tile — a known micro-cost
+that [07](07-engine-fast-paths.md) replaces with a precomputed `Map`, along
+with an `encodeInto(state, perspective, out, offset)` variant so hot callers
+reuse one scratch buffer.
+
+### featureSpec
+
+Machine-readable layout: `featureLen`, grid geometry (`height`, `width`,
+`gridAnchor`), `tileChannels`, `vocabCapacity`, per-tile channel offsets, a
+`categorical` list telling the model which channels to embed (currently just
+`erection` with capacity 256 and its vocab), block offsets
+(`players[4]`, `frame`, `shared`, and intra-player-block offsets), and every
+vocab list (erections, buildings, settlements, lands, commands, resources,
+rondel keys, settlement rounds, next-uses, lengths, countries).
+
+### Edge cases
+
+Handled: SETUP states (zero vector), <4 players (zero blocks), missing rondel
+tokens, prices shorter than 9 slots, tiles/rows outside the 38×9 window,
+unknown mask indices (dropped). Not handled: perspectives ≥ `players.length`
+(caller contract), and no symmetry augmentation — the board has no useful
+symmetries to exploit.
+
+## Design notes & tradeoffs
+
+- **Egocentric rotation vs absolute seats.** Chosen: rotate so perspective is
+  slot 0. The net never spends capacity learning seat interchangeability, and
+  each position yields N training samples (one per perspective). Alternative:
+  absolute seats plus a "my seat" indicator — simpler, but forces the net to
+  learn the same value function four times. Cost: consumers must be careful
+  that player-index features (frame one-hots) are in rotated space.
+- **Categorical erection id vs one-hot.** Chosen: one float channel holding an
+  integer id, embedded by the model. One-hot at capacity 256 would cost
+  38×9×256 ≈ 87k floats per player; categorical keeps the grid at 10 channels
+  and makes new buildings a pure embedding-table growth. Cost: the model must
+  special-case this channel (hence `featureSpec.categorical`), and the raw id
+  is meaningless as a continuous float.
+- **Fixed 256 vocab capacity.** Chosen: reserve 256 slots wherever the
+  building vocabulary appears. Adding expansion buildings never changes
+  `FEATURE_LEN`, so old shards and old checkpoints stay shape-compatible.
+  Cost: ~3×176 permanently-zero floats today. Alternative — exact-size masks —
+  saves ~0.5 KB but breaks every artifact on each vocab change.
+- **Append-only enum ordering.** Trained weights are keyed by id; reordering
+  is a silent corruption, not an error. The rule is enforced socially (header
+  comment + tests pinning specific ids) rather than by a checksum; a vocab
+  hash in shard metadata is a cheap later hardening ([16](16-shard-exporter.md)).
+- **Color collapse.** Chosen: collapse colored duplicates, keep country
+  variants. Halves the vocab-ish (100 raw enums → 80 ids) and removes a
+  spurious feature dimension. Cost: relies on the invariant that colored tiles
+  only appear on their owner's board — true in this game, an assumption to
+  re-verify for future games.
+- **Anchored grid vs offset-as-feature.** Chosen: shift rows so logical row 0
+  is fixed at output row 18, making features translation-stable for a future
+  conv/attention model. Alternative: raw rows + a `landscapeOffset` scalar —
+  smaller (H could be ~15) but every purchase shifts all learned spatial
+  features. Cost: 38 rows of mostly-zero padding.
+- **Zero vector for SETUP instead of throwing.** Encoding is total over all
+  game statuses, so pipelines never need status guards; the cost is that a
+  zero vector is a valid-looking input that means "nothing", which consumers
+  must not train on.
+- **Fresh buffer per call.** Simple ownership semantics; ~57 KB per call is
+  fine for training-data export but not for per-simulation use. Deliberately
+  deferred to [07](07-engine-fast-paths.md) (`encodeInto`) rather than
+  complicating the v1 API.
 
 ## Inputs
 
-- A `GameState` (any status) and a perspective index.
+- A `GameState` (any status) and an optional perspective index (defaults to
+  `frame.currentPlayerIndex`).
 
 ## Outputs
 
@@ -44,6 +168,15 @@ bespoke feature engineering per consumer.
 
 ## How it runs / verification
 
-- Library code — consumed by the exporter (16) and evaluators (12, 21).
-- `pnpm --dir game test` — encoder unit tests pin offsets, vocab stability,
-  and perspective rotation.
+- Library code — consumed by the exporter ([16](16-shard-exporter.md)) and
+  evaluators ([12](12-evaluator-interface.md), [21](21-onnx-evaluator.md)).
+- `pnpm --dir game test` — `game/src/__tests__/encode.test.ts` pins: zero
+  vector for SETUP; output length = `FEATURE_LEN` (and < 20k, guarding against
+  regressing to the old dense one-hot layout); `vocabCapacity` = 256 with
+  headroom; resource offsets via `featureSpec`; perspective rotation (wood
+  counts land in rotated slots); tile land/erection/clergy channels;
+  color-collapse (`ClayMoundR` ≡ `ClayMoundG`) and country distinctness
+  (F03 ≠ I03); opponent-clergy flag; settlement ids after buildings;
+  anchor invariance under `landscapeOffset`; clergy buckets; bonusActions
+  bitmask position; rondel yield/delta values incl. missing tokens; the
+  available-buildings mask.

--- a/docs/trainer/01-state-encoder.md
+++ b/docs/trainer/01-state-encoder.md
@@ -138,7 +138,7 @@ symmetries to exploit.
   comment + tests pinning specific ids) rather than by a checksum; a vocab
   hash in shard metadata is a cheap later hardening ([16](16-shard-exporter.md)).
 - **Color collapse.** Chosen: collapse colored duplicates, keep country
-  variants. Halves the vocab-ish (100 raw enums → 80 ids) and removes a
+  variants. Shrinks the vocab (113 raw enum values → 80 ids) and removes a
   spurious feature dimension. Cost: relies on the invariant that colored tiles
   only appear on their owner's board — true in this game, an assumption to
   re-verify for future games.

--- a/docs/trainer/02-engine-adapter.md
+++ b/docs/trainer/02-engine-adapter.md
@@ -1,0 +1,50 @@
+# 02 — Engine adapter
+
+| | |
+| --- | --- |
+| Status | ✅ done (`agent/src/engine.ts`, `agent/src/rng.ts`) |
+| Package | `agent/` |
+| Depends on | — |
+
+## Goal
+
+A thin, typed seam between the published game engine and everything the
+trainer builds, so search/self-play code never touches raw engine calls and
+error handling lives in one place.
+
+## Design
+
+- `Move = string[]` — one complete command, e.g. `['BUILD','G07','3','2']`.
+- Wrap `reducer` so illegal/unparseable moves return `undefined` instead of
+  throwing.
+- `outcome(state)` maps final (or cutoff) scores to a per-player rank-based
+  vector in `[0,1]`: `(beaten + 0.5·tied) / opponents`. This generalizes to
+  3–4 players and doubles as the score-margin rollout cutoff value.
+- `rng.ts`: mulberry32 — deterministic, seedable, cheap. Everything downstream
+  takes an `Rng`, never `Math.random`.
+
+## Inputs
+
+- The `hathora-et-labora-game` package: `reducer`, `control`, `initialState`.
+
+## Outputs
+
+Exported functions:
+
+```ts
+apply(state, move): GameState | undefined
+replay(commands): GameState | undefined
+isPlaying(state): boolean
+isTerminal(state): boolean
+playerToMove(state): number        // frame.activePlayerIndex, handles interrupts
+numPlayers(state): number
+scores(state): Score[]
+outcome(state): number[]           // per-player [0,1]
+```
+
+## How it runs / verification
+
+- Library code — consumed by 03–06 and later folded behind the `GameAdapter`
+  (09).
+- `pnpm --dir agent test` — `__tests__/engine.test.ts` covers replay
+  determinism (same seed ⇒ identical state) and outcome ranking.

--- a/docs/trainer/02-engine-adapter.md
+++ b/docs/trainer/02-engine-adapter.md
@@ -52,9 +52,13 @@ outcome(state): number[]                    // per-player value in [0, 1]
 - **`outcome`** maps score totals to a per-player rank vector:
   `(#opponents beaten + 0.5 · #ties) / #opponents`, i.e. 2p → win 1 /
   draw 0.5 / loss 0. Solo (`n === 1`) returns the raw score total, since
-  there is no opponent to rank against. Because it ranks *current* totals, it
-  is meaningful on non-terminal states too — [05](05-uct-search.md) uses this
-  as its rollout score-margin cutoff.
+  there is no opponent to rank against — **a known contract violation**: the
+  raw score (hundreds of points) breaks the `[0,1]` scale that UCT's
+  exploration constant and the sigmoid value head assume. The adapter
+  ([09](09-game-adapter.md)) remaps solo to `σ((score − 500)/100)`, anchored
+  on the solo success criterion (score > 500 ⇒ value > 0.5). Because it
+  ranks *current* totals, `outcome` is meaningful on non-terminal states
+  too — [05](05-uct-search.md) uses this as its rollout score-margin cutoff.
 
 ### RNG (`agent/src/rng.ts`)
 

--- a/docs/trainer/02-engine-adapter.md
+++ b/docs/trainer/02-engine-adapter.md
@@ -10,41 +10,126 @@
 
 A thin, typed seam between the published game engine and everything the
 trainer builds, so search/self-play code never touches raw engine calls and
-error handling lives in one place.
+error handling lives in one place. Later folded behind the game-agnostic
+`GameAdapter` ([09](09-game-adapter.md)) without changing callers' semantics.
 
 ## Design
 
-- `Move = string[]` — one complete command, e.g. `['BUILD','G07','3','2']`.
-- Wrap `reducer` so illegal/unparseable moves return `undefined` instead of
-  throwing.
-- `outcome(state)` maps final (or cutoff) scores to a per-player rank-based
-  vector in `[0,1]`: `(beaten + 0.5·tied) / opponents`. This generalizes to
-  3–4 players and doubles as the score-margin rollout cutoff value.
-- `rng.ts`: mulberry32 — deterministic, seedable, cheap. Everything downstream
-  takes an `Rng`, never `Math.random`.
+### Exported surface (`agent/src/engine.ts`)
+
+```ts
+export type Move = string[]                 // one complete command
+export { initialState }                     // re-exported from the engine
+
+apply(state: GameState, move: Move): GameState | undefined
+replay(commands: Move[]): GameState | undefined
+isPlaying(state): boolean                   // status === PLAYING
+isTerminal(state): boolean                  // status === FINISHED
+playerToMove(state): number                 // frame.activePlayerIndex
+numPlayers(state): number                   // config.players
+scores(state): Score[]                      // control(state, []).score
+outcome(state): number[]                    // per-player value in [0, 1]
+```
+
+- **`Move = string[]`** is one complete command exactly as the reducer takes
+  it, e.g. `['USE','LR2']`, `['BUILD','G07','3','2']`, `['COMMIT']`.
+- **`apply`** wraps `reducer` in try/catch: unparseable commands (the reducer
+  throws) and ordinary illegal moves both normalize to `undefined`. No other
+  code in `agent/` calls `reducer` directly.
+- **`replay`** left-folds `apply` from `initialState`; any failing command
+  makes the whole replay `undefined` (it does not identify *which* command
+  failed — cheap and sufficient for search/self-play, where a failure is a
+  bug upstream).
+- **`playerToMove`** is `frame.activePlayerIndex`, which differs from
+  `currentPlayerIndex` only during interrupts (e.g. `WORK_CONTRACT`, where an
+  opponent must answer mid-turn). Search keys nodes off this.
+- **`numPlayers`** reads `config.players` rather than `players.length`
+  because the tableau array can include a neutral player (solo variant).
+- **`scores`** delegates to `control(state, [])` and reads `.score` — valid
+  mid-game and at terminal. This also pays for `control`'s `computeFlow`
+  frame-walk, which enumeration/search never read; that overhead is exactly
+  what [07](07-engine-fast-paths.md) removes.
+- **`outcome`** maps score totals to a per-player rank vector:
+  `(#opponents beaten + 0.5 · #ties) / #opponents`, i.e. 2p → win 1 /
+  draw 0.5 / loss 0. Solo (`n === 1`) returns the raw score total, since
+  there is no opponent to rank against. Because it ranks *current* totals, it
+  is meaningful on non-terminal states too — [05](05-uct-search.md) uses this
+  as its rollout score-margin cutoff.
+
+### RNG (`agent/src/rng.ts`)
+
+```ts
+export type Rng = () => number              // float in [0, 1)
+mulberry32(seed: number): Rng
+randInt(rng, n): number
+choice<T>(rng, xs: readonly T[]): T
+```
+
+mulberry32 is a 32-bit state PRNG: one add, two `Math.imul` mixes, a few
+shifts per draw. Everything downstream (rollouts, arena scheduling, self-play)
+takes an `Rng` parameter and never touches `Math.random`, so a seed fully
+determines a game.
+
+### Edge cases
+
+Handled: throwing reducer, illegal moves, interrupts, neutral player, solo
+outcome, ties. Not handled: `playerToMove`/`numPlayers`/`scores` assume a
+post-`START` state (`frame!`/`config!` non-null assertions) — calling them on
+a SETUP state is a caller bug; `replay` gives no diagnostics on failure.
+
+## Design notes & tradeoffs
+
+- **`Move` as `string[]` vs structured objects.** Chosen: the engine's own
+  token format. Zero translation layers, trivially JSON-serializable for the
+  self-play logs, and `control()`'s completion tokens concatenate directly
+  into moves ([03](03-move-enumeration.md)). Cost: no type safety over move
+  contents and no cheap structural equality — string-keyed canonicalization
+  is deferred to [10](10-move-canonicalization.md), and typed encoding to
+  [11](11-action-encoder.md).
+- **Returning `undefined` vs throwing.** Chosen: `undefined` for both
+  unparseable and illegal moves. Search probes moves speculatively thousands
+  of times per decision; exceptions as control flow would be slow and force
+  try/catch into every hot loop. Cost: the two failure kinds are
+  indistinguishable and silent — tests compensate by asserting enumerated
+  moves always apply.
+- **Rank-based `[0,1]` outcome vs raw score margin vs zero-sum ±1.** Chosen:
+  rank-based. It generalizes unchanged to 3–4 players (a per-player vector,
+  not a scalar), keeps UCT's exploration term on a known value scale, and is
+  robust to the game's large, config-dependent score ranges. Raw margin would
+  reward point-piling long after the win is decided and needs
+  per-config normalization; strict zero-sum ±1 doesn't extend to multiplayer.
+  Cost: throws away margin information (a 1-point win equals a 40-point win),
+  which weakens the rollout-cutoff signal in lopsided positions — accepted,
+  and revisited only if value targets prove noisy.
+- **mulberry32 vs PCG (or xoshiro).** Chosen: mulberry32. ~5 integer ops per
+  draw, 32-bit state, trivially embeddable, and statistically far better than
+  needed for move sampling; the engine itself already uses PCG internally for
+  game setup, where stream quality matters more. Cost: small state/period and
+  no stream splitting — mitigated by deriving independent seeds per game
+  (`seed * 7919 + k` in the arena/self-play CLIs).
+- **Wrapping the engine at all vs calling it directly.** One place to
+  normalize errors and semantics (`activePlayerIndex`, `config.players`) and
+  a surface small enough that [09](09-game-adapter.md) can later swap the
+  engine without touching search. Cost: a one-file indirection.
 
 ## Inputs
 
-- The `hathora-et-labora-game` package: `reducer`, `control`, `initialState`.
+- The `hathora-et-labora-game` package: `reducer`, `control`, `initialState`,
+  `GameStatusEnum`.
 
 ## Outputs
 
-Exported functions:
-
-```ts
-apply(state, move): GameState | undefined
-replay(commands): GameState | undefined
-isPlaying(state): boolean
-isTerminal(state): boolean
-playerToMove(state): number        // frame.activePlayerIndex, handles interrupts
-numPlayers(state): number
-scores(state): Score[]
-outcome(state): number[]           // per-player [0,1]
-```
+- The exported functions above, consumed by [03](03-move-enumeration.md)–
+  [06](06-selfplay-v1.md).
 
 ## How it runs / verification
 
 - Library code — consumed by 03–06 and later folded behind the `GameAdapter`
   (09).
-- `pnpm --dir agent test` — `__tests__/engine.test.ts` covers replay
-  determinism (same seed ⇒ identical state) and outcome ranking.
+- `pnpm --dir agent test` — `__tests__/engine.test.ts` covers: `apply`
+  advancing a CONFIG command; `undefined` (not a throw) for a nonsense
+  command; replaying an opening into a PLAYING 2-player state;
+  `playerToMove ≡ frame.activePlayerIndex`; `scores` returning one numeric
+  breakdown per non-neutral player; `outcome` shape, `[0,1]` bounds, and the
+  2-player components summing to 1. Determinism (same seed ⇒ same game) is
+  exercised end-to-end by the moves/MCTS tests rather than here.

--- a/docs/trainer/03-move-enumeration.md
+++ b/docs/trainer/03-move-enumeration.md
@@ -1,0 +1,45 @@
+# 03 — Move enumeration & sampling
+
+| | |
+| --- | --- |
+| Status | ✅ done (`agent/src/moves.ts`) |
+| Package | `agent/` |
+| Depends on | [02](02-engine-adapter.md) |
+
+## Goal
+
+Turn the engine's token-by-token legal-move oracle into (a) a curated list of
+complete legal moves for search expansion, and (b) a cheap random complete
+move for rollouts.
+
+## Design
+
+The engine builds moves interactively: `control(state, partial).completion`
+returns legal next tokens, `''` marking a complete command. Legal *full moves*
+are therefore a DFS over the completion tree.
+
+- `enumerateMoves(state, { maxPerLevel?, maxMoves? })` — DFS with curation
+  caps. Branching is median 18 but p99 1,114 / max ~1,675 (SETTLE/USE
+  resource-payment combinatorics), so caps are load-bearing: `maxPerLevel`
+  bounds tokens explored per tree level (random subset), `maxMoves` hard-caps
+  the result. Defaults for search: `{ maxPerLevel: 24, maxMoves: 128 }`.
+- `sampleMove(state, rng, maxDepth?)` — random walk down the completion tree,
+  no enumeration; retries on dead ends, falls back to capped enumeration.
+  This is the rollout workhorse.
+
+## Inputs
+
+- A `GameState`; `control()` from the engine (later the `completions()` fast
+  path from [07](07-engine-fast-paths.md)); an `Rng`; curation caps.
+
+## Outputs
+
+- `enumerateMoves(state, opts): Move[]` — legal complete commands, curated.
+- `sampleMove(state, rng, maxDepth?): Move | undefined`.
+
+## How it runs / verification
+
+- Library code — consumed by 05, 10, and the adapter (09).
+- `pnpm --dir agent test` — `__tests__/moves.test.ts`: every enumerated move
+  applies cleanly via `reducer`; sampling is deterministic under a seeded Rng;
+  caps are respected on fat-tail states.

--- a/docs/trainer/03-move-enumeration.md
+++ b/docs/trainer/03-move-enumeration.md
@@ -10,36 +10,133 @@
 
 Turn the engine's token-by-token legal-move oracle into (a) a curated list of
 complete legal moves for search expansion, and (b) a cheap random complete
-move for rollouts.
+move for rollouts — the two access patterns everything above this layer needs.
 
 ## Design
 
-The engine builds moves interactively: `control(state, partial).completion`
-returns legal next tokens, `''` marking a complete command. Legal *full moves*
-are therefore a DFS over the completion tree.
+### The completion tree
 
-- `enumerateMoves(state, { maxPerLevel?, maxMoves? })` — DFS with curation
-  caps. Branching is median 18 but p99 1,114 / max ~1,675 (SETTLE/USE
-  resource-payment combinatorics), so caps are load-bearing: `maxPerLevel`
-  bounds tokens explored per tree level (random subset), `maxMoves` hard-caps
-  the result. Defaults for search: `{ maxPerLevel: 24, maxMoves: 128 }`.
-- `sampleMove(state, rng, maxDepth?)` — random walk down the completion tree,
-  no enumeration; retries on dead ends, falls back to capped enumeration.
-  This is the rollout workhorse.
+The engine builds commands interactively: `control(state, partial).completion`
+returns the legal *next tokens* after a partial command, with the empty-string
+token `''` marking that `partial` is itself complete and submittable
+(`game/src/control.ts` dispatches on the head token to the per-command
+`complete*` functions). A full legal move is therefore a root-to-`''`-leaf
+path, and legal-move generation is a tree walk. Note each `control()` call
+also computes flow and scores that enumeration never reads — the dominant
+cost here until [07](07-engine-fast-paths.md)'s `completions()` fast path.
+
+### Exported surface
+
+```ts
+export type EnumerateOpts = { maxPerLevel?: number; maxMoves?: number }
+export type EnumerateResult = { moves: Move[]; truncated: boolean }
+
+enumerateMovesInfo(state, opts?): EnumerateResult
+enumerateMoves(state, opts?): Move[]        // .moves of the above
+sampleMove(state, rng, maxDepth = 16): Move | undefined
+```
+
+### `enumerateMovesInfo` — capped DFS
+
+Depth-first over the completion tree from `[]`:
+
+1. If `completion` includes `''`, push `partial` onto the output.
+2. Recurse into the non-`''` tokens, **truncated to the first `maxPerLevel`**
+   (`nexts.slice(0, maxPerLevel)`) — a deterministic prefix in the engine's
+   completion order, not a random subset.
+3. Stop globally once `out.length >= maxMoves`.
+4. `truncated` is set whenever either cap actually bit, so callers can tell a
+   complete action set from a curated one.
+
+Both caps default to `Infinity` — **enumeration itself is uncapped**; callers
+choose curation. In practice: MCTS expansion uses `{maxPerLevel: 24,
+maxMoves: 128}` ([05](05-uct-search.md)), greedy uses `{maxPerLevel: 12,
+maxMoves: 64}` ([04](04-baselines-arena.md)), the sampler fallback uses
+`{maxPerLevel: 64, maxMoves: 512}`. Caps are load-bearing: branching is
+median ~18 but p99 ~1,114 / max ~1,675 complete moves (SETTLE/USE
+resource-payment combinatorics), and each visited tree node costs one
+`control()` call.
+
+### `sampleMove` — random walk, retry, fallback
+
+Up to 8 attempts, each a random walk from `[]`: draw a uniform token from
+`completion` (via `choice(rng, …)`), stop on `''`, give up on an empty
+completion or after `maxDepth` (16) tokens. An attempt only counts if the
+result actually applies — the engine occasionally offers `''` on a
+not-yet-valid partial, so the candidate is verified with `apply()` before
+being returned. If all 8 attempts fail, fall back to a capped enumeration
+(`{maxPerLevel: 64, maxMoves: 512}`) and pick uniformly from it; return
+`undefined` only if even that is empty (a genuinely stuck state). Cost per
+call: typically one walk of ≤ a handful of `control()` calls — no
+enumeration, which is what makes rollouts affordable.
+
+### Edge cases
+
+Handled: `''` offered on invalid partials (apply-verified), dead-end walks
+(retry), pathological branching (caps), states with no legal move
+(`undefined`). Not handled: dedup of semantically identical moves that differ
+only in token order or joker/plain-token choice — that is
+[10](10-move-canonicalization.md); and the walk's per-*token* uniformity means
+`sampleMove` is not uniform over complete *moves* (see notes).
+
+## Design notes & tradeoffs
+
+- **DFS over `control()` vs a native full-move generator in the engine.**
+  Chosen: drive the same completion oracle the UI uses. Zero new engine
+  surface, and legality is by construction identical to what a human could
+  submit. Cost: one `control()` call per tree node with flow/score overhead —
+  measured as the top search cost, and the motivation for
+  [07](07-engine-fast-paths.md)'s `completions()`, a drop-in for the
+  `control(...).completion` calls here.
+- **Prefix-slice `maxPerLevel` vs a random subset.** Chosen: keep the first
+  `maxPerLevel` tokens in engine order. It keeps enumeration a pure function
+  of `(state, opts)` — no `Rng` parameter, stable across calls, cacheable, and
+  reproducible in tests. Cost: a *systematic* bias toward whatever the engine
+  lists first (e.g. low-numbered coordinates and early resource combos);
+  tokens past the cap are never even candidates, at every level. A random
+  subset would spread the bias but make node expansion nondeterministic
+  independent of the search seed. Accepted for v1 because rollouts
+  (`sampleMove`) don't go through the caps at all; canonicalization (10)
+  shrinks the fat tails at the source, and [14](14-selfplay-v2.md) records
+  `truncated` provenance with the candidates.
+- **`maxMoves` as a hard global cap.** A last-resort bound so no state can
+  produce an unbounded expansion list; combined with `maxPerLevel` it bounds
+  work, not just output size (the DFS aborts early once full).
+- **`sampleMove` retry + verify + fallback vs trusting the tree.** Chosen:
+  verify with `apply()` and retry, then fall back to enumeration. The `''`
+  token is occasionally offered on partials the reducer rejects, and a walk
+  can dead-end; silently returning an inapplicable move would corrupt
+  rollouts. The fallback guarantees a legal move whenever one exists, so
+  `undefined` reliably means "stuck/terminal". Cost: an extra `apply()` per
+  sample, and the rare worst case pays for a capped enumeration.
+- **Per-token uniform sampling vs uniform-over-moves.** Chosen: per-token.
+  Uniform over complete moves would require enumerating them — the very cost
+  being avoided. The induced distribution over moves is skewed toward shallow
+  commands (e.g. `COMMIT` at depth 1 vs a 5-token SETTLE payment), which is
+  acceptable — arguably even helpful — for rollout speed; it is *not* a
+  calibrated policy prior and is never used as one.
+- **`maxDepth = 16`.** Comfortably above the longest real command (multi-token
+  USE/SETTLE payments) while bounding a hypothetical runaway completion chain;
+  hitting it just burns one retry.
 
 ## Inputs
 
 - A `GameState`; `control()` from the engine (later the `completions()` fast
-  path from [07](07-engine-fast-paths.md)); an `Rng`; curation caps.
+  path from [07](07-engine-fast-paths.md)); an `Rng` (sampling only);
+  curation caps.
 
 ## Outputs
 
-- `enumerateMoves(state, opts): Move[]` — legal complete commands, curated.
+- `enumerateMovesInfo(state, opts): { moves, truncated }` /
+  `enumerateMoves(state, opts): Move[]` — legal complete commands, curated.
 - `sampleMove(state, rng, maxDepth?): Move | undefined`.
 
 ## How it runs / verification
 
-- Library code — consumed by 05, 10, and the adapter (09).
+- Library code — consumed by 04, 05, 10, and the adapter (09).
 - `pnpm --dir agent test` — `__tests__/moves.test.ts`: every enumerated move
-  applies cleanly via `reducer`; sampling is deterministic under a seeded Rng;
-  caps are respected on fat-tail states.
+  at the opening applies cleanly via the reducer; the move-head set is
+  non-empty (no dead opening); caps are respected (`maxMoves: 30` honored,
+  capped moves still legal, `truncated` reported); `sampleMove` is legal and
+  deterministic under a fixed seed (same seed ⇒ same move); and `sampleMove`
+  alone drives a long game forward for >50 steps without getting stuck.

--- a/docs/trainer/04-baselines-arena.md
+++ b/docs/trainer/04-baselines-arena.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| Status | ✅ done (`agent/src/policies/`, `agent/src/arena.ts`, `agent/src/cli/arena.ts`) |
+| Status | ✅ done (`agent/src/policy.ts`, `agent/src/policies/`, `agent/src/arena.ts`, `agent/src/cli/arena.ts`) |
 | Package | `agent/` |
 | Depends on | [02](02-engine-adapter.md), [03](03-move-enumeration.md) |
 
@@ -10,22 +10,119 @@
 
 Fixed-strength reference opponents and a reproducible head-to-head harness,
 so every later improvement (UCT, PUCT, each net generation) is measured, not
-assumed.
+assumed. The same `runMatch` result object later drives gating
+([22](22-arena-gating.md)).
 
 ## Design
 
-- **Policies** (`Policy = { name, pick(state, rng): Move | undefined }`):
-  - `randomPolicy()` — `sampleMove`, no enumeration.
-  - `greedyPolicy()` — enumerate (capped), apply each, pick the move
-    maximizing own `control().score.total`; ties broken randomly.
-- **Arena**:
-  - `playGame(policies[], cfg, seed, rng, maxSteps)` — seat each policy, play
-    from a seeded opening (`['CONFIG',…], ['START', seed,…]`) to terminal.
-  - `runMatch(A, B, { games, cfg, baseSeed })` — alternates seats each game
-    (first-mover advantage cancels), tallies W/D/L, reports an Elo delta.
-- **CLI**: `pnpm arena [games] [short|long] [specA] [specB]` with specs
-  `random`, `greedy`, `mcts[:sims]` — later extended with `nn:` by
-  [22](22-arena-gating.md).
+### Policy interface (`agent/src/policy.ts`)
+
+```ts
+export type Policy = {
+  name: string
+  pick: (state: GameState, rng: Rng) => Move | undefined
+}
+```
+
+`pick` returns `undefined` only when there is no legal move (stuck/terminal).
+Policies are stateless closures; all randomness flows through the passed
+`Rng`.
+
+### Baselines (`agent/src/policies/`)
+
+- `randomPolicy()` — one `sampleMove` per decision; no enumeration, so it is
+  cheap enough to also serve as the rollout distribution's sanity mirror.
+- `greedyPolicy(opts = { maxPerLevel: 12, maxMoves: 64 })` — 1-ply lookahead:
+  enumerate (curated), `apply` each candidate, score the child with
+  `scores(next)[me].total` where `me = playerToMove(state)` at the decision
+  point, and play a uniformly random choice among the argmax set. Failed
+  applies score `-Infinity`. Weak but non-trivial: it grabs immediate points
+  before COMMITting and reliably beats random.
+
+### Arena (`agent/src/arena.ts`)
+
+```ts
+export type GameConfig = { players; country; length; colors }
+export const CONFIG_2P_LONG / CONFIG_2P_SHORT   // 2p france, colors R/G
+opening(cfg, seed): Move[]     // [['CONFIG',…], ['START', seed, …colors]]
+
+playGame(policies: Policy[], cfg, seed, rng, maxSteps = 8000): GameResult
+runMatch(a: Policy, b: Policy, opts: MatchOptions): MatchResult
+```
+
+- **`playGame`** replays the seeded opening, then loops: seat =
+  `playerToMove(state)`, policy = `policies[seat % policies.length]`, apply
+  its pick. It stops at terminal, when a policy returns `undefined`, when an
+  `apply` fails (defensive — a policy returned an illegal move), or at
+  `maxSteps`. Result: `{ totals, outcome, steps, finished, commands }` — the
+  full command list makes any game replayable/debuggable. Both seats draw
+  from the *same* `rng` stream, so a game is a pure function of
+  `(policies, cfg, seed, rng seed)`.
+- **`runMatch`** plays `opts.games` games (default cfg `CONFIG_2P_LONG`,
+  default `baseSeed = 1`). Game `g` uses board seed `baseSeed + g` and policy
+  rng `mulberry32(seed * 7919 + 1)`; odd games swap which policy takes seat 0
+  so first-mover/turn-order advantage cancels over an even count. Winners are
+  decided by comparing `outcome` components (rank-based, from
+  [02](02-engine-adapter.md)) — equal outcomes count as a draw. Result:
+  `{ a, b, games, aWins, bWins, draws, aWinRate, eloDiff, avgSteps,
+  finishedRate }`, where `aWinRate = (aWins + 0.5·draws)/games` and
+  `eloDiff = −400·log10(1/p − 1)` rounded, clamped to ±800 at p ∈ {0, 1}.
+
+### CLI (`agent/src/cli/arena.ts`)
+
+`pnpm --dir agent arena [games] [short|long] [specA] [specB]` — defaults
+`10 short mcts:64 random`; any third arg other than `long` means short.
+Specs: `random` | `greedy` | `mcts[:sims]` (default 64); unknown specs throw.
+Prints one summary: per-policy wins and draws, A's win-rate and Elo estimate,
+average steps/game, finished-rate, wall-clock seconds. Extended with `nn:`
+specs by [22](22-arena-gating.md).
+
+### Edge cases
+
+Handled: unfinished games (maxSteps cutoff still scores via mid-game
+`outcome`; `finishedRate` reports how often that happened), stuck policies,
+illegal picks, odd game counts (one extra game as A-first — a slight residual
+seat imbalance), 0%/100% win rates (Elo clamp). Not handled: >2 policies per
+match (`playGame` seats N policies, but `runMatch`/CLI are head-to-head
+2-player only), confidence intervals on the win rate.
+
+## Design notes & tradeoffs
+
+- **Greedy as a 1-ply lookahead vs a hand-written heuristic.** Chosen:
+  enumerate-apply-score. Zero game knowledge to maintain and it strengthens
+  automatically if scoring improves. Cost: ~`maxMoves` reducer applies *plus*
+  one `control()`-based `scores()` per candidate per decision — by far the
+  most expensive baseline; the tight default caps (12/64) exist to keep it
+  usable, at the price of inheriting enumeration's prefix-order bias
+  ([03](03-move-enumeration.md)).
+- **Seat alternation in `runMatch` vs random seating.** Chosen: strict
+  alternation with the board seed fixed per game index. Cancels first-mover
+  advantage exactly over even N (random seating only in expectation), and
+  paired seeds mean A and B face comparable board streams. Cost: not a full
+  paired design — the two policies see the *same* rng stream interleaved, so
+  a game is not "the same game with seats swapped"; true seed-paired swaps
+  are a possible upgrade for gating (22).
+- **Elo estimate at small N.** `eloFromWinRate` is a point estimate of the
+  logistic inverse with no error bars: at 20 games, ±1 game swings ~±35 Elo
+  around parity, and 0/20 collapses to the arbitrary −800 clamp. It is
+  reported as a readability aid, not a decision statistic; gating (22) must
+  use game counts large enough (or a significance test) that the point
+  estimate is meaningful.
+- **Winner from `outcome` vs raw totals.** Comparing rank-based outcome
+  components is identical to comparing totals in 2p, but keeps `runMatch`
+  correct if a >2p mode is ever tallied, and reuses the one blessed
+  score-comparison path.
+- **`maxSteps = 8000` safety valve.** Long games run several hundred
+  commands; 8000 is an order of magnitude above that, so hitting it signals a
+  livelock (e.g. a policy that never COMMITs) rather than a long game. Scoring
+  cutoff games by current rank instead of discarding them keeps weak policies
+  from hiding behind timeouts, at the cost of slightly noisy labels —
+  `finishedRate` makes this visible.
+- **Shared `Rng` per game vs per-policy streams.** One stream is simpler and
+  fully reproducible; the cost is that changing one policy's consumption
+  pattern perturbs the other's draws, so cross-version comparisons rely on
+  seeds, not identical opponents' randomness. Accepted: matches are compared
+  statistically, never game-by-game.
 
 ## Inputs
 
@@ -33,7 +130,8 @@ assumed.
 
 ## Outputs
 
-- Per-match summary to stdout: wins/draws/losses per seat, Elo estimate.
+- Per-match summary to stdout: per-policy wins, draws, win-rate, Elo
+  estimate, avg steps, finished-rate, elapsed time.
 - `runMatch` result object (consumed programmatically by gating, 22).
 
 ## How it runs / verification
@@ -42,5 +140,8 @@ assumed.
 pnpm --dir agent arena 20 long greedy random   # greedy should dominate
 ```
 
-- `pnpm --dir agent test` — `__tests__/arena.test.ts`: seat alternation,
-  determinism under fixed seeds, terminal accounting.
+- `pnpm --dir agent test` — `__tests__/arena.test.ts`: a full
+  random-vs-random short game returns 2-entry totals/outcome and real
+  progress (steps > 10); greedy achieves ≥ 0.5 win-rate over 4 deterministic
+  seeded short games vs random (non-flaky by fixed seeds); wins + draws +
+  losses account for every game across alternated seats.

--- a/docs/trainer/04-baselines-arena.md
+++ b/docs/trainer/04-baselines-arena.md
@@ -1,0 +1,46 @@
+# 04 — Baseline policies & arena
+
+| | |
+| --- | --- |
+| Status | ✅ done (`agent/src/policies/`, `agent/src/arena.ts`, `agent/src/cli/arena.ts`) |
+| Package | `agent/` |
+| Depends on | [02](02-engine-adapter.md), [03](03-move-enumeration.md) |
+
+## Goal
+
+Fixed-strength reference opponents and a reproducible head-to-head harness,
+so every later improvement (UCT, PUCT, each net generation) is measured, not
+assumed.
+
+## Design
+
+- **Policies** (`Policy = { name, pick(state, rng): Move | undefined }`):
+  - `randomPolicy()` — `sampleMove`, no enumeration.
+  - `greedyPolicy()` — enumerate (capped), apply each, pick the move
+    maximizing own `control().score.total`; ties broken randomly.
+- **Arena**:
+  - `playGame(policies[], cfg, seed, rng, maxSteps)` — seat each policy, play
+    from a seeded opening (`['CONFIG',…], ['START', seed,…]`) to terminal.
+  - `runMatch(A, B, { games, cfg, baseSeed })` — alternates seats each game
+    (first-mover advantage cancels), tallies W/D/L, reports an Elo delta.
+- **CLI**: `pnpm arena [games] [short|long] [specA] [specB]` with specs
+  `random`, `greedy`, `mcts[:sims]` — later extended with `nn:` by
+  [22](22-arena-gating.md).
+
+## Inputs
+
+- Two policy specs, a game config (players/length/country), a base seed.
+
+## Outputs
+
+- Per-match summary to stdout: wins/draws/losses per seat, Elo estimate.
+- `runMatch` result object (consumed programmatically by gating, 22).
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent arena 20 long greedy random   # greedy should dominate
+```
+
+- `pnpm --dir agent test` — `__tests__/arena.test.ts`: seat alternation,
+  determinism under fixed seeds, terminal accounting.

--- a/docs/trainer/05-uct-search.md
+++ b/docs/trainer/05-uct-search.md
@@ -1,0 +1,48 @@
+# 05 — Pure UCT search
+
+| | |
+| --- | --- |
+| Status | ✅ done (`agent/src/mcts/search.ts`, `agent/src/policies/mcts.ts`) |
+| Package | `agent/` |
+| Depends on | [02](02-engine-adapter.md), [03](03-move-enumeration.md) |
+
+## Goal
+
+A working net-free MCTS: strong enough to generate meaningful gen-0 training
+data and to serve forever as the fixed-strength arena yardstick.
+
+## Design
+
+- Classic UCT: SELECT (UCB1 over fully-expanded nodes) → EXPAND (pop one
+  untried move) → SIMULATE (rollout) → BACKUP.
+- **Per-player value vectors**: the game is multiplayer and not strictly
+  zero-sum. Every edge backs up a `number[]` of per-player values; selection
+  maximizes the component of the *mover at that node*. This is correct for
+  runs of same-player nodes (a turn is several commands ending in `COMMIT`)
+  and for `WORK_CONTRACT` interrupts.
+- **Rollouts**: `sampleMove` (no enumeration), depth-capped (~30 commands),
+  then `outcome()` on the reached state — which ranks by current score totals,
+  acting as a score-margin cutoff so rollouts stay shallow.
+- Hot loops are deliberately imperative (sims × depth iterations).
+- `mctsPolicy({ sims, c?, rolloutDepth?, curation? })` wraps search as a
+  `Policy` for the arena.
+
+## Inputs
+
+- Root `GameState`, seeded `Rng`, `MctsOptions` (`sims`, `c=1.4`,
+  `rolloutDepth=30`, curation caps).
+
+## Outputs
+
+- `search(state, rng, opts) → { root, best, visits: [{move, n, q}] }` — the
+  visit distribution is the future policy target (made complete in
+  [13](13-puct-search.md)).
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent arena 10 short mcts:64 random   # mcts should win convincingly
+```
+
+- `pnpm --dir agent test` — `__tests__/mcts.test.ts`: best move is legal,
+  search is deterministic under a fixed seed, more sims ⇒ ≥ strength.

--- a/docs/trainer/05-uct-search.md
+++ b/docs/trainer/05-uct-search.md
@@ -9,34 +9,148 @@
 ## Goal
 
 A working net-free MCTS: strong enough to generate meaningful gen-0 training
-data and to serve forever as the fixed-strength arena yardstick.
+data ([06](06-selfplay-v1.md)) and to serve forever as the fixed-strength
+arena yardstick (`mcts:400` in the master plan). PUCT with learned priors
+replaces the selection/rollout internals later ([13](13-puct-search.md));
+the result shape is designed to survive that swap.
 
 ## Design
 
-- Classic UCT: SELECT (UCB1 over fully-expanded nodes) → EXPAND (pop one
-  untried move) → SIMULATE (rollout) → BACKUP.
-- **Per-player value vectors**: the game is multiplayer and not strictly
-  zero-sum. Every edge backs up a `number[]` of per-player values; selection
-  maximizes the component of the *mover at that node*. This is correct for
-  runs of same-player nodes (a turn is several commands ending in `COMMIT`)
-  and for `WORK_CONTRACT` interrupts.
-- **Rollouts**: `sampleMove` (no enumeration), depth-capped (~30 commands),
-  then `outcome()` on the reached state — which ranks by current score totals,
-  acting as a score-margin cutoff so rollouts stay shallow.
-- Hot loops are deliberately imperative (sims × depth iterations).
-- `mctsPolicy({ sims, c?, rolloutDepth?, curation? })` wraps search as a
-  `Policy` for the arena.
+### Exported surface
+
+```ts
+export type MctsOptions = {
+  sims: number             // simulations per move
+  c?: number               // UCT exploration constant (default 1.4)
+  rolloutDepth?: number    // max rollout commands (default 30)
+  curation?: EnumerateOpts // per-node enumeration caps (default {24, 128})
+}
+export type SearchResult = {
+  root: Node
+  best: Move | undefined
+  visits: { move: Move; n: number; q: number }[]  // sorted by n desc
+}
+search(state, rng, options): SearchResult
+
+// policies/mcts.ts
+mctsPolicy(options: MctsOptions): Policy   // name `mcts(${sims})`, pick → best
+```
+
+### Data structures
+
+- `Node { state, mover, terminal, untried: Move[], edges: Edge[], n }` —
+  `mover = playerToMove(state)` (−1 at terminal); `untried` is the curated
+  `enumerateMoves` list, consumed from the back by `pop()`.
+- `Edge { move, child, n, w: number[] }` — `w` is a **per-player value-sum
+  vector** of length `numPlayers`; `q` for a player is `w[p]/n`.
+
+### The four phases, per simulation
+
+1. **SELECT** — while the node is non-terminal, fully expanded
+   (`untried.length === 0`), and has edges: pick
+   `argmax_edges( w[node.mover]/n + c·√(ln N / n) )` where `N = node.n`.
+   The value term is the *mover at that node's* component, which is what
+   makes multi-command turns and interrupts correct (see notes).
+2. **EXPAND** — pop one untried move, `apply` it, wrap the child in a new
+   `Node` (one `enumerateMoves` call), attach a fresh edge with `w = zeros`.
+   If `apply` unexpectedly fails (enumerated moves should be legal), the
+   child defensively reuses the parent's state rather than crashing.
+3. **SIMULATE** — terminal leaf: `outcome(state)` directly. Otherwise a
+   rollout: up to `rolloutDepth` (30) commands of `sampleMove` + `apply`
+   (breaking early on terminal, no-move, or failed apply), then `outcome()`
+   on the reached state. On a non-terminal state `outcome()` ranks *current*
+   score totals — a built-in score-margin cutoff that lets rollouts stay
+   shallow instead of playing out a 300-command game.
+4. **BACKUP** — increment `n` on every node on the path (root included) and,
+   on every edge, `n` plus the whole per-player value vector into `w`. No
+   negamax sign-flip: each selection reads its own mover's component.
+
+After `sims` iterations, `visits` reports every *expanded* root edge as
+`{ move, n, q }` with `q = w[root.mover]/n`, sorted by visit count;
+`best` is the most-visited move (standard robust-child rule).
+
+### Complexity / perf
+
+Per simulation: one `enumerateMoves` on the newly expanded node (the
+dominant cost — a capped DFS of `control()` calls,
+[03](03-move-enumeration.md)) plus ≤ `rolloutDepth` sampleMove/apply pairs
+and an O(depth · players) backup. The select/rollout/backup loops are
+deliberately imperative — they run sims × depth times per decision, where a
+functional style's per-call allocations would dominate; cold paths elsewhere
+keep the ramda style. At `sims=64` on the opening, a decision is on the
+order of a second; the `completions()` fast path
+([07](07-engine-fast-paths.md)) and benchmarks ([08](08-benchmarks.md))
+target exactly this.
+
+### Edge cases
+
+Handled: terminal root (no untried, no edges ⇒ `best === undefined`),
+mid-rollout dead ends, failed applies, interrupt turns (per-node `mover`),
+2–4 players (vector values throughout). Not handled: transpositions (the
+tree is a tree — identical states reached by different orders are searched
+separately), progressive widening past the curation caps (moves the caps
+drop are invisible to search), and no virtual loss (single-threaded only).
+
+## Design notes & tradeoffs
+
+- **Per-player value vectors vs negamax scalars.** Chosen: back up a
+  `number[]` and select on the node-mover's component. Negamax assumes
+  strictly-alternating zero-sum play; here a turn is a *run* of same-player
+  nodes ending in `COMMIT`, `WORK_CONTRACT` interrupts splice the opponent
+  mid-turn, and 3–4-player configs aren't two-sided at all. Keying off each
+  node's own `activePlayerIndex` handles all of these with one rule. Cost:
+  `players ×` memory/adds per edge — trivial — and "max my component" is
+  maxⁿ (paranoid opponents are not modeled), the standard multiplayer-MCTS
+  compromise.
+- **UCB1 with `c = 1.4`.** `√2 ≈ 1.414` is the textbook constant for rewards
+  in `[0,1]`, which the rank-based `outcome()` guarantees by construction —
+  the constant and the value scale were chosen together. Not tuned further:
+  this searcher's job is to be a *stable* yardstick; PUCT (13) is where
+  exploration tuning effort goes.
+- **Rollout depth 30 + score-margin cutoff.** Chosen: truncate and rank
+  current totals rather than play to terminal (hundreds of commands) or
+  bolt on a value heuristic. This is the single biggest speed lever in v1 and
+  what makes `sims=64` playable. Cost: a real evaluation *bias* — current
+  score ignores position (resources, engine-building) and early game rollouts
+  barely differentiate; and rank (not margin) discards how far ahead a line
+  is. Accepted deliberately: the whole point of the trainer is that a learned
+  value head (12/13) replaces rollouts entirely.
+- **Expansion order = `untried.pop()`.** Untried moves come off the *end* of
+  the enumeration list — cheap O(1), deterministic, but it means expansion
+  order inherits (reversed) engine completion order rather than being
+  randomized. With enough sims UCB1 washes this out; at very low sims the
+  first-expanded moves get a head start. Same determinism-over-debiasing call
+  as the curation caps in [03](03-move-enumeration.md).
+- **Curation caps `{maxPerLevel: 24, maxMoves: 128}` as search defaults.**
+  Bounds per-node expansion cost and tree width on the fat-tail SETTLE/USE
+  states. Cost: capped-away moves are *unsearchable*, and the visit
+  distribution silently lacks them — tolerable for playing strength, but a
+  data-quality problem for policy targets that [14](14-selfplay-v2.md) must
+  record explicitly.
+- **Robust child (max visits) vs max Q.** Visits are the standard, lower-
+  variance action pick and double as the future policy target; Q of a
+  1-visit edge is noise. `q` is still reported per edge for diagnostics and
+  for the future targets.
+- **No transposition table.** Ora et Labora states are large and hashing
+  them per node would cost more than the (rare, order-dependent) transposition
+  hits are worth at these sim counts; revisit only if profiling (08) says
+  otherwise.
+- **Fresh tree per decision (no reuse between moves).** Simpler lifetime
+  semantics and correct under opponent moves outside the tree; costs
+  re-expanding the root each turn. Tree reuse is an optimization PUCT-era
+  work can pick up if throughput demands it.
 
 ## Inputs
 
 - Root `GameState`, seeded `Rng`, `MctsOptions` (`sims`, `c=1.4`,
-  `rolloutDepth=30`, curation caps).
+  `rolloutDepth=30`, curation caps `{24, 128}`).
 
 ## Outputs
 
 - `search(state, rng, opts) → { root, best, visits: [{move, n, q}] }` — the
   visit distribution is the future policy target (made complete in
-  [13](13-puct-search.md)).
+  [13](13-puct-search.md)/[14](14-selfplay-v2.md)).
+- `mctsPolicy(opts)` — the search wrapped as an arena `Policy`.
 
 ## How it runs / verification
 
@@ -44,5 +158,9 @@ data and to serve forever as the fixed-strength arena yardstick.
 pnpm --dir agent arena 10 short mcts:64 random   # mcts should win convincingly
 ```
 
-- `pnpm --dir agent test` — `__tests__/mcts.test.ts`: best move is legal,
-  search is deterministic under a fixed seed, more sims ⇒ ≥ strength.
+- `pnpm --dir agent test` — `__tests__/mcts.test.ts`: `best` is a legal move;
+  root visits sum to > 0 and ≤ `sims`; every reported `q` lies in `[0,1]`;
+  the search is deterministic under a fixed seed (same seed ⇒ same best
+  move); `mctsPolicy` returns a legal move. "More sims ⇒ stronger" is *not*
+  a unit test — it is observed via arena runs (`mcts:64` vs `random`, and
+  later `mcts:N` ladders in [08](08-benchmarks.md)).

--- a/docs/trainer/06-selfplay-v1.md
+++ b/docs/trainer/06-selfplay-v1.md
@@ -10,34 +10,129 @@
 
 Generate labeled games by having UCT play every seat, recording per-decision
 search statistics (future policy targets) and the final outcome (value
-target), in a compact replayable format.
+target), in a compact replayable format. v1 exists to prove the loop and to
+surface the data-format problems early; [14](14-selfplay-v2.md) is the
+training-grade rewrite.
 
 ## Design
 
-- One MCTS search per decision; record `{ perspective, visits, chosen }` plus
-  enough to reconstruct the state.
-- **Store commands, not tensors**: a game is a command list (a few KB);
-  dense tensors are regenerated later by replay+encode ([16](16-shard-exporter.md)).
-- Output is JSONL, one game per line, appended so runs are resumable.
+### Exported surface (`agent/src/selfplay.ts`)
+
+```ts
+export type Decision = {
+  perspective: number               // player to move (slot to encode from)
+  commands: Move[]                  // full prefix so far → replay to rebuild the state
+  visits: { move: Move; n: number }[]  // expanded root edges, by visit count
+  chosen: Move
+}
+export type SelfPlayGame = {
+  commands: Move[]                  // the whole game, replayable
+  decisions: Decision[]
+  outcome: number[]                 // per-player [0,1] value target
+  finished: boolean
+  steps: number
+}
+selfPlayGame(cfg: GameConfig, seed: number, rng: Rng,
+             options: MctsOptions, maxSteps = 8000): SelfPlayGame
+```
+
+### Game loop
+
+1. Start from `opening(cfg, seed)` (the arena's seeded
+   `CONFIG`/`START` pair, [04](04-baselines-arena.md)) and `replay` it.
+2. While `isPlaying` and under `maxSteps`: run one `search(state, rng,
+   options)` ([05](05-uct-search.md)) for the current decision.
+3. Record a `Decision`: `perspective = playerToMove(state)` (the
+   `activePlayerIndex`, so interrupt decisions are labeled with the actual
+   decider), a **copy of the full command prefix**, the search's visit list
+   stripped to `{move, n}`, and `chosen = res.best`.
+4. Play `chosen` (argmax visits — no temperature), append it to `commands`,
+   continue. Break defensively if search returns no move or the apply fails.
+5. Label the game: `outcome(state)` (rank-based per-player values — also
+   valid at a `maxSteps` cutoff, where it ranks current totals), `finished =
+   isTerminal(state)`, `steps`.
+
+Every seat is played by the *same* searcher drawing from the *same* `rng`, so
+a game is a pure function of `(cfg, seed, rng seed, options)`.
+
+### CLI (`agent/src/cli/selfplay.ts`)
+
+`pnpm --dir agent selfplay [games] [short|long] [sims]` — defaults
+`1 short 64`. Game `g` uses board seed `1000 + g` and rng
+`mulberry32(seed * 7919 + 3)` (a different stream than the arena's `+1`).
+Each finished game is `JSON.stringify`-ed and **appended** as one line to
+`selfplay-data/games-{length}-sims{N}.jsonl` (directory auto-created), with a
+per-game progress line (steps, finished flag, outcome, seconds) on stdout.
+Append-only output means interrupted runs lose at most the in-flight game and
+re-runs accumulate into the same file — but re-running identical arguments
+also *duplicates* seeds 1000..1000+g; distinct runs should vary `sims`/length
+or the file. Single-process; the worker-pool CLI is
+[15](15-selfplay-workers.md).
 
 ## Known limitations (fixed by [14](14-selfplay-v2.md))
 
 - Each decision stores a copy of the full command prefix → O(steps²) file
-  size; v2 replaces this with a `step` index into the game's command list.
-- `visits` covers only *expanded* edges; unexpanded curated candidates are
+  size (a ~250-step game stores ~31k command copies). v2 replaces this with a
+  `step` index into the game's single command list.
+- `visits` covers only *expanded* edges; unexpanded curated candidates — and
+  everything the curation caps dropped before search even saw it — are
   silently absent, which breaks policy-target support. v2 records the full
-  candidate list, zeros included.
-- No temperature schedule or root exploration noise.
+  candidate list, zeros included, plus truncation provenance.
+- No temperature schedule or root exploration noise: `chosen` is always the
+  argmax, so games are deterministic given the seed and early-game diversity
+  comes only from the board seed. v2 adds τ-sampling and Dirichlet noise
+  (via [13](13-puct-search.md)).
+- No format/config provenance on the line (`sims` lives only in the
+  filename); v2's schema carries `v`, cfg, seed, netId, and search params.
+
+## Design notes & tradeoffs
+
+- **Store commands, not tensors.** Chosen: a game is its command list plus
+  per-decision indices — a few KB — and dense tensors are regenerated later
+  by replay + `encode` ([01](01-state-encoder.md),
+  [16](16-shard-exporter.md)). Tensors at ~57 KB × ~250 decisions ≈ 14 MB/game
+  would dwarf that, and — decisive — stored tensors freeze the encoder
+  version, while stored commands let any future encoder/action-space change
+  re-derive training data from the same games. Cost: export pays a full
+  replay per game (cheap relative to search) and the engine must stay
+  replay-compatible with old logs.
+- **O(steps²) prefixes as a deliberate v1 shortcut.** Copying the prefix per
+  decision made each `Decision` self-contained (any line fragment replays
+  without context) and kept v1 to a page of code. The quadratic blow-up was
+  understood upfront and is acceptable at v1 volumes (tens of games for
+  pipeline bring-up); it is the first thing [14](14-selfplay-v2.md) deletes.
+- **Recording only expanded edges.** v1 reuses `SearchResult.visits`
+  verbatim rather than teaching the search to report its curated candidate
+  list. Fine for *watching* the searcher; wrong for training, since a policy
+  target needs the full support with explicit zeros. Kept anyway: defining
+  the candidate-list format properly is entangled with canonical move keys
+  ([10](10-move-canonicalization.md)), so v1 punts rather than inventing a
+  throwaway string format.
+- **Argmax play (no temperature).** Strongest play per game and zero extra
+  machinery, at the cost of low state diversity across a run — mitigated
+  slightly by per-game board seeds, properly fixed by v2's τ schedule.
+  For gen-0 bootstrap data, quantity × seed variety was judged sufficient.
+- **JSONL, one game per line, append-only.** Line-oriented output is
+  crash-tolerant (a partial final line is detectably broken JSON),
+  `grep`/`jq`-able, trivially mergeable across workers later, and needs no
+  database. Cost: no dedup or run manifest — the run directory layout in the
+  [README](README.md) plus v2 metadata take that over.
+- **Reusing arena plumbing.** `opening`, `GameConfig`, and the engine seam
+  are shared with [04](04-baselines-arena.md), so self-play games and arena
+  games are byte-compatible command lists — one replay/debug path for both.
 
 ## Inputs
 
-- Game config (players/length/country), base seed, `MctsOptions` (`sims`…).
+- Game config (players/length/country), base seed, `MctsOptions` (`sims`,
+  and optionally `c`/`rolloutDepth`/curation — the CLI passes `{ sims }`
+  only, taking the search defaults).
 
 ## Outputs
 
-- JSONL lines: `{ commands, decisions: [{ perspective, commands, visits,
+- JSONL lines `{ commands, decisions: [{ perspective, commands, visits,
   chosen }], outcome, finished, steps }` appended to
   `selfplay-data/games-{length}-sims{N}.jsonl`.
+- `selfPlayGame(...)` for programmatic use.
 
 ## How it runs / verification
 
@@ -45,5 +140,11 @@ target), in a compact replayable format.
 pnpm --dir agent selfplay 10 short 64   # 10 games, short config, 64 sims
 ```
 
-- `pnpm --dir agent test` — decisions replay to legal states; outcome matches
-  a fresh replay of `commands`.
+- No dedicated unit-test file: v1's correctness rides on the tested layers it
+  composes — search legality/determinism (`__tests__/mcts.test.ts`), game-loop
+  mechanics (`__tests__/arena.test.ts`), and move legality
+  (`__tests__/moves.test.ts`) — plus manual inspection of the JSONL (replay
+  `commands`, confirm `outcome`/`finished`, spot-check that each decision's
+  prefix replays to a state whose `activePlayerIndex` matches `perspective`).
+  Round-trip and size regressions become real tests in
+  [14](14-selfplay-v2.md).

--- a/docs/trainer/06-selfplay-v1.md
+++ b/docs/trainer/06-selfplay-v1.md
@@ -1,0 +1,49 @@
+# 06 — Self-play generator v1
+
+| | |
+| --- | --- |
+| Status | ✅ done (`agent/src/selfplay.ts`, `agent/src/cli/selfplay.ts`) |
+| Package | `agent/` |
+| Depends on | [04](04-baselines-arena.md), [05](05-uct-search.md) |
+
+## Goal
+
+Generate labeled games by having UCT play every seat, recording per-decision
+search statistics (future policy targets) and the final outcome (value
+target), in a compact replayable format.
+
+## Design
+
+- One MCTS search per decision; record `{ perspective, visits, chosen }` plus
+  enough to reconstruct the state.
+- **Store commands, not tensors**: a game is a command list (a few KB);
+  dense tensors are regenerated later by replay+encode ([16](16-shard-exporter.md)).
+- Output is JSONL, one game per line, appended so runs are resumable.
+
+## Known limitations (fixed by [14](14-selfplay-v2.md))
+
+- Each decision stores a copy of the full command prefix → O(steps²) file
+  size; v2 replaces this with a `step` index into the game's command list.
+- `visits` covers only *expanded* edges; unexpanded curated candidates are
+  silently absent, which breaks policy-target support. v2 records the full
+  candidate list, zeros included.
+- No temperature schedule or root exploration noise.
+
+## Inputs
+
+- Game config (players/length/country), base seed, `MctsOptions` (`sims`…).
+
+## Outputs
+
+- JSONL lines: `{ commands, decisions: [{ perspective, commands, visits,
+  chosen }], outcome, finished, steps }` appended to
+  `selfplay-data/games-{length}-sims{N}.jsonl`.
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent selfplay 10 short 64   # 10 games, short config, 64 sims
+```
+
+- `pnpm --dir agent test` — decisions replay to legal states; outcome matches
+  a fresh replay of `commands`.

--- a/docs/trainer/07-engine-fast-paths.md
+++ b/docs/trainer/07-engine-fast-paths.md
@@ -104,14 +104,27 @@ All changes in `game/`; agent call sites migrate in [08](08-benchmarks.md) /
    map.get(e) ?? 0` — identical output for every enum value including the
    unknown→0 fallback (today `indexOf` returns −1 and `+1` yields 0).
 
-6. **Exports** — from `game/src/index.ts`, additive only: `completions`,
+6. **Country capacity in the encoder** — the shared block's country one-hot
+   is currently exactly `COUNTRIES.length = 2` wide, so adding a third
+   country would change `FEATURE_LEN` and strand every trained checkpoint.
+   More countries are a stated plan, and right now zero trained weights
+   exist — this is the one moment a `FEATURE_LEN` change is free. Widen the
+   config country field to a reserved `COUNTRY_CAPACITY = 8` (same
+   append-only pattern as the 256-slot erection vocab; the country list in
+   `featureSpec.vocab.countries` stays the source of truth for live ids) and
+   bump the featureSpec version. `config.players` (max 4) and `length` (2)
+   are closed sets and stay exact-size.
+
+7. **Exports** — from `game/src/index.ts`, additive only: `completions`,
    `scores`, `encodeInto`, `erectionId`, and `parseResourceParam` (from
    `game/src/board/resource.ts`). Exporting `parseResourceParam` requires also
    exporting the `Cost` type (and `ResourceEnum`, useful for
    [11](11-action-encoder.md)); neither is exported today.
 
-7. **Version bump** — `hathora-et-labora-game` is published (currently
-   `0.21.1`); this is additive, so bump minor → `0.22.0`.
+8. **Version bump** — `hathora-et-labora-game` is published (currently
+   `0.21.1`); this is additive except the `FEATURE_LEN` change in step 6
+   (nothing ships trained weights yet, so it is safe now and never again);
+   bump minor → `0.22.0`.
 
 ## Edge cases
 
@@ -136,8 +149,10 @@ All changes in `game/`; agent call sites migrate in [08](08-benchmarks.md) /
 - New exports from `hathora-et-labora-game`: `completions`, `scores`,
   `encodeInto`, `erectionId`, `parseResourceParam` (+ `Cost`, `ResourceEnum`
   types).
+- Country one-hot widened to `COUNTRY_CAPACITY = 8` (new `FEATURE_LEN`,
+  featureSpec version bump) so future countries never change shapes again.
 - A minor version bump of the package (`0.21.1` → `0.22.0`); `control()` and
-  `encode()` behavior unchanged.
+  `encode()` behavior otherwise unchanged.
 
 ## How it runs / verification
 

--- a/docs/trainer/07-engine-fast-paths.md
+++ b/docs/trainer/07-engine-fast-paths.md
@@ -1,0 +1,53 @@
+# 07 — Engine fast paths
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `game/` |
+| Depends on | [01](01-state-encoder.md) |
+| Milestone | M1 |
+
+## Goal
+
+Remove the two known per-simulation hot-path costs in the engine's public
+API, and export the helpers the action encoder needs. This is the single
+highest-leverage search speedup available.
+
+## Design
+
+1. **`completions(state, partial): string[]`** in `game/src/control.ts`.
+   Every `control()` call currently also runs `computeFlow` (a bounded
+   200-iteration frame-walk allocating `Flower[]`) and per-player scoring —
+   neither of which move enumeration reads. `completions()` is the same
+   `ts-pattern` dispatch over `complete*` functions with flow/score skipped;
+   `control()` is reimplemented on top of it.
+2. **`encodeInto(state, perspective, out: Float32Array, offset?)`** in
+   `game/src/encode.ts`. The `Writer` already targets a buffer; `encode()`
+   becomes a two-line wrapper. Lets the exporter and evaluators reuse one
+   scratch buffer instead of allocating ~57 KB per call.
+3. **Erection-id lookup Map** — `erectionId` currently does `indexOf` over the
+   vocab per tile; precompute a `Map<ErectionEnum, number>` at module load
+   (same pattern as the existing building-mask index).
+4. **Export helpers**: `parseResourceParam` (from `game/src/board/resource.ts`)
+   and the erection-id/vocab helpers from `encode.ts`, via `game/src/index.ts`.
+   Additive, non-breaking; needed by [11](11-action-encoder.md).
+
+## Inputs
+
+- Existing `control.ts` / `encode.ts` internals; fixture games under
+  `game/src/__tests__/` for parity states.
+
+## Outputs
+
+- New exports from `hathora-et-labora-game`: `completions`, `encodeInto`,
+  `parseResourceParam`, erection-id helpers.
+- A minor version bump of the package.
+
+## How it runs / verification
+
+- `pnpm --dir game test` — new parity suite: for every state and partial
+  reached while replaying fixture games, `completions(state, partial)` deep-
+  equals `control(state, partial).completion`; `encodeInto` output equals
+  `encode` output.
+- Benchmark ([08](08-benchmarks.md)) shows `completions()` ≫ `control()`
+  (expect ~5–10× on enumeration-heavy states) and `encode` ≤ 0.5 ms.

--- a/docs/trainer/07-engine-fast-paths.md
+++ b/docs/trainer/07-engine-fast-paths.md
@@ -9,45 +9,192 @@
 
 ## Goal
 
-Remove the two known per-simulation hot-path costs in the engine's public
-API, and export the helpers the action encoder needs. This is the single
-highest-leverage search speedup available.
+Remove the known per-simulation hot-path costs in the engine's public API and
+export the helpers the action encoder needs. This is the single
+highest-leverage search speedup available, because the agent currently reaches
+everything through `control()`, which does far more work than the agent reads.
 
-## Design
+## What the code does today
 
-1. **`completions(state, partial): string[]`** in `game/src/control.ts`.
-   Every `control()` call currently also runs `computeFlow` (a bounded
-   200-iteration frame-walk allocating `Flower[]`) and per-player scoring —
-   neither of which move enumeration reads. `completions()` is the same
-   `ts-pattern` dispatch over `complete*` functions with flow/score skipped;
-   `control()` is reimplemented on top of it.
-2. **`encodeInto(state, perspective, out: Float32Array, offset?)`** in
-   `game/src/encode.ts`. The `Writer` already targets a buffer; `encode()`
-   becomes a two-line wrapper. Lets the exporter and evaluators reuse one
-   scratch buffer instead of allocating ~57 KB per call.
-3. **Erection-id lookup Map** — `erectionId` currently does `indexOf` over the
-   vocab per tile; precompute a `Map<ErectionEnum, number>` at module load
-   (same pattern as the existing building-mask index).
-4. **Export helpers**: `parseResourceParam` (from `game/src/board/resource.ts`)
-   and the erection-id/vocab helpers from `encode.ts`, via `game/src/index.ts`.
-   Additive, non-breaking; needed by [11](11-action-encoder.md).
+`control(state, partial, player?)` in `game/src/control.ts` returns
+`{ active, flow, partial, completion, score }` and computes **all** of it on
+every call:
+
+- **`completion`** — a `ts-pattern` `match(head(partial))` dispatch: for
+  `undefined` it concatenates all twelve `complete*(state)([])` calls (from
+  `game/src/commands/index.ts`, in the fixed order USE, BUILD, CUT_PEAT,
+  FELL_TREES, WORK_CONTRACT, BUY_PLOT, BUY_DISTRICT, CONVERT, SETTLE,
+  WITH_LAYBROTHER, WITH_PRIOR, COMMIT), returning `[]` when
+  `status === FINISHED`; for a known command head it calls that command's
+  `complete*(state)(partial)`; otherwise `[]`.
+- **`flow`** — `computeFlow()`, a bounded frame-walk (`limit = 200`) over
+  `pickFrameFlow(config)` that allocates a `Flower` object per upcoming frame,
+  including `introduced` building lists. Only the web UI reads this.
+- **`score`** — per real player (neutral player sliced off), `goodsPoints`
+  (whose `optimalCashPoints` brute-forces up to a 5×5 wine/whiskey grid via
+  `lift`), `allBuildingPoints`, and `allDwellingPoints` — two full landscape
+  scans plus per-settlement adjacency sums.
+
+The agent's move enumeration (`agent/src/moves.ts`) calls
+`control(state, partial).completion` **once per node of a DFS over the
+completion tree** — hundreds of calls per enumeration on branchy states — and
+throws away `flow` and `score` every time. Worse, `agent/src/engine.ts`
+`scores()` is implemented as `control(state, []).score`, so every rollout
+cutoff and terminal `outcome()` in MCTS pays for a **full top-level completion
+enumeration** just to read the score. Both directions of waste get fast paths.
+
+On the encoder side, `encode()` in `game/src/encode.ts` allocates a fresh
+`Float32Array(FEATURE_LEN)` (~57 KB) per call even though the internal
+`Writer` class already writes positionally into a caller-supplied buffer; and
+`erectionId()` does `indexOf` over `GENERIC_BUILDINGS` (72 entries) or
+`SETTLEMENT_TYPES` per occupied tile, per encode, while the sibling lookups
+(`buildingMaskIndex`, `settlementHandIndex`) already use precomputed `Map`s.
+
+## Implementation plan
+
+All changes in `game/`; agent call sites migrate in [08](08-benchmarks.md) /
+[09](09-game-adapter.md).
+
+1. **`completions()`** — in `game/src/control.ts`, extract the existing
+   `match(head(partial))` block verbatim (including the `FINISHED → []` guard
+   and the twelve-command concatenation order, which parity tests pin):
+
+   ```ts
+   export const completions = (state: GameState, partial: string[] = []): string[]
+   ```
+
+2. **`scores()`** — extract the score block from `control()` unchanged:
+
+   ```ts
+   export const scores = (state: GameState): Score[]
+   ```
+
+3. **Reimplement `control()` on top of both** with no behavior change:
+   `{ active, flow: computeFlow(state), partial, completion:
+   completions(state, partial), score: scores(state) }`. `control()` keeps its
+   exact signature and output; the web UI and MCP tools
+   (`web/src/context/InstanceContext.ts`, `web/src/mcp/tools/*.ts`) are
+   untouched.
+
+4. **`encodeInto()`** — in `game/src/encode.ts`:
+
+   ```ts
+   export const encodeInto = (
+     state: GameState,
+     perspective: number | undefined,
+     out: Float32Array,
+     offset = 0
+   ): void
+   ```
+
+   - Throw `RangeError` if `out.length < offset + FEATURE_LEN`.
+   - **`out.fill(0, offset, offset + FEATURE_LEN)` first.** The `Writer`
+     relies on zero-initialized memory (`hot`/`bits` only set 1s, `skip`
+     writes nothing), so a reused scratch buffer must be cleared or stale
+     values leak through skipped player blocks and one-hot gaps.
+   - `SETUP` status: zero-fill and return (mirrors `encode`'s early return).
+   - Start the `Writer` at `offset` (its `pos` field is already public; pass
+     it via constructor or assignment).
+   - `encode(state, perspective?)` becomes the two-line wrapper: allocate
+     `Float32Array(FEATURE_LEN)`, `encodeInto`, return.
+
+5. **Erection-id lookup Map** — replace the `indexOf` chains in `erectionId`
+   with a `Map<ErectionEnum, number>` built at module load from `BUILDINGS`
+   and `SETTLEMENTS` (same pattern as `buildingMaskIndex`). `erectionId(e) =
+   map.get(e) ?? 0` — identical output for every enum value including the
+   unknown→0 fallback (today `indexOf` returns −1 and `+1` yields 0).
+
+6. **Exports** — from `game/src/index.ts`, additive only: `completions`,
+   `scores`, `encodeInto`, `erectionId`, and `parseResourceParam` (from
+   `game/src/board/resource.ts`). Exporting `parseResourceParam` requires also
+   exporting the `Cost` type (and `ResourceEnum`, useful for
+   [11](11-action-encoder.md)); neither is exported today.
+
+7. **Version bump** — `hathora-et-labora-game` is published (currently
+   `0.21.1`); this is additive, so bump minor → `0.22.0`.
+
+## Edge cases
+
+- `completions(state, ['NOT_A_COMMAND'])` must return `[]` (the `.otherwise`
+  arm), same as `control` today.
+- `completions` with a `FINISHED` state and non-empty partial: today the
+  command-specific arms still run; preserve that (only the `undefined` head
+  short-circuits on `FINISHED`).
+- `encodeInto` at a non-zero `offset` into a buffer sized for several states
+  (the [16](16-shard-exporter.md) use case) — covered by an explicit test.
+- `scores()` on a 1-player config still slices the neutral player off
+  (`slice(0, config.players)`), exactly as inside `control()`.
 
 ## Inputs
 
 - Existing `control.ts` / `encode.ts` internals; fixture games under
-  `game/src/__tests__/` for parity states.
+  `game/src/__tests__/` (`game21872.test.ts`, `game4aedf9e5.test.ts`, …) for
+  parity states.
 
 ## Outputs
 
-- New exports from `hathora-et-labora-game`: `completions`, `encodeInto`,
-  `parseResourceParam`, erection-id helpers.
-- A minor version bump of the package.
+- New exports from `hathora-et-labora-game`: `completions`, `scores`,
+  `encodeInto`, `erectionId`, `parseResourceParam` (+ `Cost`, `ResourceEnum`
+  types).
+- A minor version bump of the package (`0.21.1` → `0.22.0`); `control()` and
+  `encode()` behavior unchanged.
 
 ## How it runs / verification
 
-- `pnpm --dir game test` — new parity suite: for every state and partial
-  reached while replaying fixture games, `completions(state, partial)` deep-
-  equals `control(state, partial).completion`; `encodeInto` output equals
-  `encode` output.
-- Benchmark ([08](08-benchmarks.md)) shows `completions()` ≫ `control()`
-  (expect ~5–10× on enumeration-heavy states) and `encode` ≤ 0.5 ms.
+- `pnpm --dir game test` — new parity suite (`game/src/__tests__/`):
+  - Replay fixture games; at every intermediate state assert
+    `completions(state, []) ≡ control(state, []).completion` and
+    `scores(state) ≡ control(state, []).score` (deep equality, order
+    included), plus the same over partials reached by a capped DFS drill-down
+    (so command-specific arms are exercised, not just the top level).
+  - `encodeInto` into a fresh buffer equals `encode` byte-for-byte for every
+    fixture state and each perspective; `encodeInto` into a NaN-poisoned
+    scratch buffer equals `encode` (proves the `fill(0)`); offset variant
+    writes exactly `[offset, offset + FEATURE_LEN)` and nothing outside it.
+  - `erectionId` over every `BuildingEnum`/`SettlementEnum` value matches the
+    old `indexOf` implementation (table test).
+- Benchmark ([08](08-benchmarks.md)) then shows `completions()` ≫
+  `control()` (expect ~5–10× on enumeration-heavy states, since flow + score
+  dominate the 0.33 ms baseline), `scores()` ≫ `control().score`, and
+  `encode`/`encodeInto` ≤ 0.5 ms.
+- Agent migration (with 08/09): `moves.ts` switches
+  `control(state, partial).completion ?? []` → `completions(state, partial)`;
+  `engine.ts` `scores()` switches to the game's `scores` export.
+
+## Design notes & tradeoffs
+
+- **Parallel `completions()` vs an options param on `control()` vs caching
+  flow.** An options bag (`control(state, partial, player, { skipFlow })`)
+  keeps one entry point but changes the published `Controls` shape
+  conditionally — every existing consumer must now handle possibly-absent
+  `flow`/`score`, and the type either lies or splits. Caching `computeFlow`
+  per state object (WeakMap) helps the web but not the agent, whose states
+  are all fresh objects from `reducer`. A parallel function is dumb, additive,
+  and lets `control()` be *defined* in terms of it, so parity is structural
+  rather than tested-for. Chosen: parallel functions.
+- **Exporting internals (`parseResourceParam`, `erectionId`, `scores`) vs
+  re-implementing in `agent/`.** Duplication would let the game package keep a
+  minimal surface, but [11](11-action-encoder.md) must agree with the engine
+  exactly (payment multisets, embedding ids shared with the state grid) — a
+  re-implementation that drifts (e.g. the `Po`/`Ho` legacy aliases in
+  `parseResourceParam`) silently corrupts training targets. Coupling to the
+  package that already owns these semantics is the safer failure mode; the
+  exports are small and stable. Chosen: export.
+- **Map vs `indexOf` for `erectionId`.** The vocab arrays are small (72 + 8),
+  so a single lookup is cheap either way; but `erectionId` runs per occupied
+  tile per encode (~hundreds of times per call at 38×9 per player), and the
+  codebase already established the Map pattern for the two mask indexes.
+  Micro-win, zero risk, consistency win. Chosen: Map.
+- **`encodeInto` argument order.** `(state, perspective, out, offset?)`
+  mirrors `encode(state, perspective)` and matches the adapter's
+  `encodeState(state, perspective, out)` ([09](09-game-adapter.md));
+  `perspective` stays explicit (pass `undefined` for the default) rather than
+  trailing-optional, so the exporter can't silently encode from the wrong
+  seat.
+- **Semver for the published package.** Everything here is additive and
+  `control()`/`encode()` outputs are bit-identical, so a minor bump (0.22.0)
+  is honest. In 0.x land some tools treat minor as breaking — acceptable; the
+  in-repo consumers (`web/`, `agent/`) use `workspace:*` anyway. What we must
+  *not* do is change `control()`'s shape or the completion-token grammar here;
+  that is why move canonicalization ([10](10-move-canonicalization.md)) lives
+  in `agent/` instead.

--- a/docs/trainer/08-benchmarks.md
+++ b/docs/trainer/08-benchmarks.md
@@ -1,0 +1,60 @@
+# 08 — Benchmark harness
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [03](03-move-enumeration.md), [07](07-engine-fast-paths.md) |
+| Milestone | M1 |
+
+## Goal
+
+A repeatable benchmark CLI so performance claims are measured, pinned in
+docs, and re-checked after every engine or search change. Self-play
+throughput is the binding constraint of the whole project; this is the
+instrument.
+
+## Design
+
+- `agent/src/cli/bench.ts`, run as `pnpm --dir agent bench`.
+- State corpus: replay fixture games (e.g. the command lists in
+  `game/src/__tests__/game21872.test.ts` and self-play JSONL when available),
+  collecting every intermediate state — realistic mid-game states, not
+  synthetic ones.
+- Metrics (median / p90 / p99 over the corpus):
+  - `reducer` apply per command
+  - `control(state, [])` vs `completions(state, [])`
+  - `enumerateMoves` at search curation caps
+  - `encode` / `encodeInto`
+  - branching factor distribution (legal complete moves per state)
+- Output: a markdown table to stdout, pasted into this doc set when numbers
+  move.
+
+## Inputs
+
+- Fixture command lists; optionally a JSONL file of self-play games
+  (`--games <path>`).
+
+## Outputs
+
+- Benchmark table on stdout; pinned numbers recorded in
+  [README](README.md) / PR descriptions.
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent bench
+pnpm --dir agent bench --games runs/r1/gen-000/selfplay/worker-0.jsonl
+```
+
+- Sanity: numbers are stable (< ~10% jitter) across two consecutive runs on
+  an idle machine.
+
+## Baseline (previously measured, to re-verify)
+
+| Op | Cost |
+| --- | --- |
+| `reducer` apply | ~0.011 ms |
+| `control(state, [])` | ~0.33 ms |
+| `encode` (pre-rewrite figure; expect far less now) | ~13.3 ms |
+| Branching | median 18 · p90 126 · p99 1,114 · max 1,675 |

--- a/docs/trainer/08-benchmarks.md
+++ b/docs/trainer/08-benchmarks.md
@@ -9,52 +9,145 @@
 
 ## Goal
 
-A repeatable benchmark CLI so performance claims are measured, pinned in
-docs, and re-checked after every engine or search change. Self-play
-throughput is the binding constraint of the whole project; this is the
-instrument.
+A repeatable benchmark CLI so performance claims are measured, pinned in docs,
+and re-checked after every engine or search change. Self-play throughput is
+the binding constraint of the whole project (see the risk section in
+[README](README.md)); this is the instrument. It is also where the
+[07](07-engine-fast-paths.md) fast paths prove their worth, and where the
+agent flips its own call sites onto them.
 
-## Design
+## Implementation plan
 
-- `agent/src/cli/bench.ts`, run as `pnpm --dir agent bench`.
-- State corpus: replay fixture games (e.g. the command lists in
-  `game/src/__tests__/game21872.test.ts` and self-play JSONL when available),
-  collecting every intermediate state — realistic mid-game states, not
-  synthetic ones.
-- Metrics (median / p90 / p99 over the corpus):
-  - `reducer` apply per command
-  - `control(state, [])` vs `completions(state, [])`
-  - `enumerateMoves` at search curation caps
-  - `encode` / `encodeInto`
-  - branching factor distribution (legal complete moves per state)
-- Output: a markdown table to stdout, pasted into this doc set when numbers
-  move.
+1. **CLI entry** — `agent/src/cli/bench.ts`, plus a script in
+   `agent/package.json` alongside the existing `arena`/`selfplay` entries:
+   `"bench": "node --import tsx/esm src/cli/bench.ts"`. Run as
+   `pnpm --dir agent bench`.
+
+2. **State corpus** — realistic replayed states, three sources, merged:
+   - **Fixture replay**: the fixture games in `game/src/__tests__/` are the
+     best real-game data we have, but they live *inside* test files —
+     `game21872.test.ts` is ~392 inline `reducer(...)` calls (4p long), while
+     `game4aedf9e5.test.ts` holds a plain `map(split(' '), [...])` command
+     list (3p long) that lifts straight out. Extract one or two command lists
+     into `agent/src/bench/fixtures/*.json` (array of space-joined command
+     strings) rather than importing across packages from test files.
+   - **Seeded generated games** (default, zero maintenance): play a handful of
+     deterministic games at bench startup with the existing `greedyPolicy` and
+     `randomPolicy` via `playGame` (`agent/src/arena.ts`) — legal, full-length
+     trajectories in a few seconds.
+   - **Self-play JSONL** (`--games <path>`) once [06](06-selfplay-v1.md)/
+     [14](14-selfplay-v2.md) output exists — the most representative corpus,
+     preferred when available.
+
+   Replaying each command list through `apply()` (`agent/src/engine.ts`) and
+   collecting **every intermediate state** yields hundreds of mid-game states
+   per game; sample down to a fixed-size corpus (e.g. 500 states, seeded
+   shuffle) so runtimes stay constant.
+
+3. **Measured operations** (each timed per state):
+   - `reducer` apply per command (timed during the replay itself)
+   - `control(state, [])` vs `completions(state, [])` — the headline 07 win
+   - `scores(state)` vs `control(state, []).score` — the rollout/`outcome()`
+     path (see [07](07-engine-fast-paths.md))
+   - `enumerateMoves` at the search curation caps
+     (`{ maxPerLevel: 24, maxMoves: 128 }`, the `DEFAULTS` in
+     `agent/src/mcts/search.ts`) and uncapped
+   - `sampleMove` (the rollout inner loop, `agent/src/moves.ts`)
+   - `encode` vs `encodeInto` into a reused scratch buffer
+   - branching factor per state: uncapped `enumerateMoves().length`, plus —
+     once [10](10-move-canonicalization.md) lands — the deduped count, so the
+     duplicate inflation is visible as its own column
+4. **Timing methodology** — small and honest, not a framework:
+   - `process.hrtime.bigint()` around each op; one warmup pass over the whole
+     corpus first (JIT/IC warmup), then N timed reps per state (N chosen per
+     op so each sample ≥ ~1 µs of work; batch ultra-cheap ops).
+   - Aggregate **across states** (not across reps of one state): report
+     median / p90 / p99 / max and the corpus size.
+   - Defeat dead-code elimination by accumulating a checksum from each result
+     (e.g. sum of completion lengths, first float of the encode buffer) and
+     printing it once.
+   - `--json` flag for machine-readable output; default is a markdown table
+     on stdout, pasted into this doc's baseline section when numbers move.
+
+5. **Flip agent call sites onto the fast paths** (same PR or immediately
+   after, so the bench measures what self-play will actually run):
+   `agent/src/moves.ts` `control(state, partial).completion ?? []` →
+   `completions(state, partial)`; `agent/src/engine.ts` `scores()` →
+   the game package's `scores` export. Both are one-line diffs guarded by the
+   07 parity suite.
 
 ## Inputs
 
-- Fixture command lists; optionally a JSONL file of self-play games
+- Fixture command lists (extracted to `agent/src/bench/fixtures/*.json`);
+  seeded policy games; optionally a JSONL file of self-play games
   (`--games <path>`).
 
 ## Outputs
 
-- Benchmark table on stdout; pinned numbers recorded in
-  [README](README.md) / PR descriptions.
+- Benchmark table on stdout; pinned numbers recorded in the baseline section
+  below and referenced from [README](README.md) / PR descriptions.
 
 ## How it runs / verification
 
 ```sh
 pnpm --dir agent bench
 pnpm --dir agent bench --games runs/r1/gen-000/selfplay/worker-0.jsonl
+pnpm --dir agent bench --json > bench.json
 ```
 
-- Sanity: numbers are stable (< ~10% jitter) across two consecutive runs on
-  an idle machine.
+- Sanity: numbers are stable (< ~10% jitter on medians) across two
+  consecutive runs on an idle machine; the printed checksum is identical
+  across runs given the same corpus seed (proves determinism of the corpus
+  and that ops weren't optimized away).
+- The M1 exit criterion reads off this table: `completions()` ≫ `control()`
+  on enumeration-heavy states, `encodeInto` ≤ 0.5 ms.
 
 ## Baseline (previously measured, to re-verify)
+
+Historical single-machine spot measurements; the first bench run replaces
+this table with percentile rows per op.
 
 | Op | Cost |
 | --- | --- |
 | `reducer` apply | ~0.011 ms |
 | `control(state, [])` | ~0.33 ms |
-| `encode` (pre-rewrite figure; expect far less now) | ~13.3 ms |
-| Branching | median 18 · p90 126 · p99 1,114 · max 1,675 |
+| `encode` (pre-rewrite figure; expect far less from the imperative `Writer`) | ~13.3 ms |
+| Branching (raw, pre-dedupe) | median 18 · p90 126 · p99 1,114 · max 1,675 |
+
+## Design notes & tradeoffs
+
+- **Realistic replayed corpus vs synthetic states.** Synthetic states (hand-
+  built tableaus) are easy to generate in volume but miss exactly what makes
+  the engine slow: late-game landscapes full of buildings, fat
+  `usableBuildings` lists, and SETTLE/USE payment explosions. The branching
+  tail (p99 > 1,000) only exists in real mid/late-game states. Replay is
+  slightly more code (corpus extraction) but measures the distribution the
+  search will actually see. Chosen: replayed states, with seeded generated
+  games as the zero-maintenance default and self-play JSONL as the preferred
+  source once it exists.
+- **Median/p90/p99 vs mean.** Branching factor and therefore enumeration cost
+  are heavy-tailed (median 18 vs max 1,675); a mean is dominated by a few
+  SETTLE states and by GC pauses, and "improved the mean" can hide a
+  regression on the p99 states that actually stall workers. Percentiles keep
+  the tail visible. Means are still printed as a minor column since
+  throughput math (games/day) is a mean-flavored quantity.
+- **Pinning numbers in docs vs CI perf gates.** A CI gate on wall-clock
+  numbers is flaky on shared runners (noisy neighbors, differing CPUs) and
+  would either be so loose it never fires or so tight it cries wolf; this
+  project has one developer machine and one GPU box. Chosen: pinned numbers
+  in this doc, re-run manually per relevant PR, with the `--json` output
+  checked into the PR description when a claim is made. Revisit only if a
+  silent regression actually burns us. (Non-perf properties — the checksum,
+  corpus determinism — *are* asserted and safe to run anywhere.)
+- **Plain `hrtime` loop vs a benchmark library (tinybench, mitata).** A
+  library buys statistical niceties but adds a dependency to a package that
+  currently has exactly `ramda` + the game engine, and its auto-tuned
+  iteration counts make cross-run comparisons noisier. The ops here are
+  microseconds-to-milliseconds — a warmup pass plus fixed rep counts is
+  sufficient and keeps the harness fully deterministic. Chosen: hand-rolled.
+- **Where fixtures live.** Importing command lists from `game/src/__tests__/`
+  would couple the agent to another package's test internals (and
+  `game21872.test.ts` doesn't even hold a list — it's inline code). Copying
+  one or two lists into `agent/src/bench/fixtures/` duplicates data that
+  never changes (finished games are immutable) — acceptable, and it keeps
+  `pnpm --dir agent bench` self-contained.

--- a/docs/trainer/09-game-adapter.md
+++ b/docs/trainer/09-game-adapter.md
@@ -1,0 +1,64 @@
+# 09 — GameAdapter interface
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [02](02-engine-adapter.md)–[06](06-selfplay-v1.md) |
+| Milestone | M2 |
+
+## Goal
+
+Make the search/self-play/training core game-blind. Adding a second
+Uwe-style game should mean implementing one interface, not touching MCTS or
+the trainer.
+
+## Design
+
+`agent/src/game/adapter.ts`:
+
+```ts
+export type GameAdapter<TState, TMove> = {
+  name: string                                   // 'oel'
+  initial(cfg: unknown, seed: number): TState
+  apply(state: TState, move: TMove): TState | undefined
+  isTerminal(state: TState): boolean
+  playerToMove(state: TState): number
+  numPlayers(state: TState): number
+  outcome(state: TState): number[]               // per-player [0,1]
+  legalMoves(state: TState, caps?: Caps): TMove[] // curated, canonical, deduped
+  sampleMove(state: TState, rng: Rng): TMove | undefined
+  moveKey(move: TMove): string                   // canonical serialization
+
+  featureSpec: FeatureSpecMeta                   // featureLen, version, offsets…
+  encodeState(state: TState, perspective: number, out: Float32Array): void
+
+  actionSpec: ActionSpec                         // see project 11
+  encodeMove(state: TState, perspective: number, move: TMove, out: Float32Array): void
+}
+```
+
+- `agent/src/game/oel.ts` implements it by delegating to the existing
+  `engine.ts` / `moves.ts` (kept as internal modules) and to `encodeInto`
+  from [07](07-engine-fast-paths.md). `legalMoves` folds in canonicalization
+  ([10](10-move-canonicalization.md)); `encodeMove` lands with
+  [11](11-action-encoder.md) (stubbed until then).
+- Search, policies, arena, and self-play take an adapter instead of importing
+  `engine.ts` directly. Policies become async
+  (`pick(state, rng): Promise<TMove | undefined>`) now, so the evaluator seam
+  ([12](12-evaluator-interface.md)) doesn't force a second churn.
+
+## Inputs
+
+- The existing agent modules (02–06) and the game package.
+
+## Outputs
+
+- `adapter.ts` (types), `oel.ts` (the one concrete adapter), and refactored
+  call sites throughout `agent/src/`.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — the entire existing suite passes through the
+  adapter with **identical seeded behavior** (same seeds ⇒ same games as
+  before the refactor); a golden-game regression test pins this.

--- a/docs/trainer/09-game-adapter.md
+++ b/docs/trainer/09-game-adapter.md
@@ -9,56 +9,188 @@
 
 ## Goal
 
-Make the search/self-play/training core game-blind. Adding a second
-Uwe-style game should mean implementing one interface, not touching MCTS or
-the trainer.
+Make the search/self-play/training core game-blind. Adding a second Uwe-style
+game should mean implementing one interface, not touching MCTS or the
+trainer.
+
+## What exists today (what gets refactored)
+
+The agent is already layered, but the layers are hard-wired to Ora et Labora:
+
+- `agent/src/engine.ts` — `Move = string[]`, `apply` (reducer +
+  throw→undefined), `replay`, `isPlaying`, `isTerminal`, `playerToMove`
+  (`frame.activePlayerIndex`, correct across WORK_CONTRACT interrupts),
+  `numPlayers`, `scores` (via `control(state, []).score`), `outcome`
+  (rank-based per-player vector in [0,1], **defined mid-game too** — the
+  rollout score-margin cutoff in `mcts/search.ts` depends on that).
+- `agent/src/moves.ts` — `enumerateMovesInfo`/`enumerateMoves` (capped DFS
+  over the completion tree), `sampleMove` (random walk + apply-verify +
+  capped-enumeration fallback).
+- `agent/src/policy.ts` — `Policy = { name, pick(state, rng): Move |
+  undefined }` — **synchronous**.
+- `agent/src/policies/{random,greedy,mcts}.ts` — thin `Policy` factories over
+  `sampleMove`, `enumerateMoves`+`scores`, and `search`.
+- `agent/src/arena.ts` — `GameConfig`, `opening(cfg, seed)` (CONFIG/START
+  command pair), synchronous `playGame` / `runMatch` (seat-alternating,
+  seeded).
+- `agent/src/selfplay.ts` — synchronous `selfPlayGame` recording
+  per-decision `visits` keyed by raw `Move` arrays.
+- `agent/src/mcts/search.ts` — synchronous UCT `search(state, rng, options)`
+  importing `engine`/`moves` directly.
+
+Every one of these imports `hathora-et-labora-game` or a sibling directly.
+The refactor threads a single adapter value through instead; `engine.ts` and
+`moves.ts` **stay as internal modules** that the OeL adapter delegates to.
 
 ## Design
 
 `agent/src/game/adapter.ts`:
 
 ```ts
-export type GameAdapter<TState, TMove> = {
-  name: string                                   // 'oel'
-  initial(cfg: unknown, seed: number): TState
+export type GameAdapter<TState, TMove, TCfg = unknown> = {
+  name: string                                    // 'oel'
+  initial(cfg: TCfg, seed: number): TState
   apply(state: TState, move: TMove): TState | undefined
   isTerminal(state: TState): boolean
   playerToMove(state: TState): number
   numPlayers(state: TState): number
-  outcome(state: TState): number[]               // per-player [0,1]
+  outcome(state: TState): number[]                // per-player [0,1]; defined mid-game (rollout cutoff)
   legalMoves(state: TState, caps?: Caps): TMove[] // curated, canonical, deduped
   sampleMove(state: TState, rng: Rng): TMove | undefined
-  moveKey(move: TMove): string                   // canonical serialization
+  moveKey(move: TMove): string                    // canonical serialization
+  heuristic?(state: TState): number[]             // per-player scalar (greedy baseline); optional
 
-  featureSpec: FeatureSpecMeta                   // featureLen, version, offsets…
+  featureSpec: FeatureSpecMeta                    // featureLen, version, offsets…
   encodeState(state: TState, perspective: number, out: Float32Array): void
 
-  actionSpec: ActionSpec                         // see project 11
+  actionSpec: ActionSpec                          // see [11](11-action-encoder.md)
   encodeMove(state: TState, perspective: number, move: TMove, out: Float32Array): void
 }
 ```
 
-- `agent/src/game/oel.ts` implements it by delegating to the existing
-  `engine.ts` / `moves.ts` (kept as internal modules) and to `encodeInto`
-  from [07](07-engine-fast-paths.md). `legalMoves` folds in canonicalization
-  ([10](10-move-canonicalization.md)); `encodeMove` lands with
-  [11](11-action-encoder.md) (stubbed until then).
-- Search, policies, arena, and self-play take an adapter instead of importing
-  `engine.ts` directly. Policies become async
-  (`pick(state, rng): Promise<TMove | undefined>`) now, so the evaluator seam
-  ([12](12-evaluator-interface.md)) doesn't force a second churn.
+`Caps` is today's `EnumerateOpts` (`maxPerLevel`/`maxMoves`), renamed into
+the adapter module. `Rng` stays the existing `agent/src/rng.ts` type.
+
+`agent/src/game/oel.ts` implements `GameAdapter<GameState, Move, GameConfig>`
+by delegation, not reimplementation:
+
+- `initial` = `replay(opening(cfg, seed))` (moving `GameConfig`/`opening`
+  from `arena.ts` into the adapter; a bad opening throws).
+- `apply`/`isTerminal`/`playerToMove`/`numPlayers`/`outcome` = the `engine.ts`
+  functions verbatim; `heuristic` = `scores(state).map(s => s.total)` (kept
+  optional on the interface because it's a baseline convenience, not a core
+  requirement for a new game).
+- `legalMoves(state, caps)` = `enumerateMoves(state, caps)` piped through
+  `canonicalize` + dedupe-by-`moveKey` from
+  [10](10-move-canonicalization.md); until 10 lands, identity + join-space
+  key.
+- `encodeState` = `encodeInto` from [07](07-engine-fast-paths.md).
+  `featureSpec` re-exports the game package's `featureSpec` plus a `version`
+  field (the game's spec has no version yet — added here, asserted by
+  [16](16-shard-exporter.md)/[21](21-onnx-evaluator.md)).
+- `encodeMove`/`actionSpec` land with [11](11-action-encoder.md); until then
+  the stub throws with a pointer to project 11 (nothing in M2 calls it).
+
+**Async policies now.** `Policy.pick` becomes
+`pick(state, rng): Promise<TMove | undefined>`, so the evaluator seam
+([12](12-evaluator-interface.md)) and ONNX inference
+([21](21-onnx-evaluator.md)) don't force a second churn through every policy,
+`playGame`, `runMatch`, `selfPlayGame`, and both CLIs. The migration is
+mechanical: current implementations are synchronous, so `async` + `await`
+change no rng-call ordering — same seeds produce the same games.
+
+## Implementation plan
+
+1. **Types first** — add `agent/src/game/adapter.ts` (`GameAdapter`, `Caps`,
+   `FeatureSpecMeta`, `ActionSpec` placeholder). No behavior change.
+2. **OeL adapter** — add `agent/src/game/oel.ts` delegating as above; move
+   `GameConfig`/`CONFIG_2P_LONG`/`CONFIG_2P_SHORT`/`opening` here (re-export
+   from `arena.ts` temporarily to keep the diff reviewable).
+3. **Thread the adapter, still sync** — `mcts/search.ts` takes
+   `(adapter, state, rng, options)`; `policies/*` become
+   `randomPolicy(adapter)`, `greedyPolicy(adapter, caps)`,
+   `mctsPolicy(adapter, options)`; `arena.ts` `playGame`/`runMatch` and
+   `selfplay.ts` `selfPlayGame` take the adapter. Generic in
+   `<TState, TMove>` throughout; `Move`-typed imports from `engine.ts`
+   disappear from these files.
+4. **Async flip in one commit** — `Policy.pick` → `Promise`; `playGame` loop
+   awaits `policy.pick`; `runMatch`'s `range(...).map(...)` becomes a
+   sequential `for` loop (deterministic order preserved); `selfPlayGame` →
+   async; `cli/arena.ts` and `cli/selfplay.ts` top-level `await`. `search()`
+   itself stays synchronous until PUCT ([13](13-puct-search.md)) needs the
+   async evaluator.
+5. **Tests** — update `agent/src/__tests__/{engine,moves,mcts,arena}.test.ts`
+   mechanically (adapter arg + `await`); add the golden-game regression
+   (below) *before* steps 3–4 so the refactor is pinned by it.
+
+## Migration / back-compat
+
+- `engine.ts` and `moves.ts` keep their exports; only their *callers* change.
+  Their own unit tests keep passing untouched.
+- Seeded determinism is the contract: the golden test records, for a couple
+  of seeds, the full command list of `playGame(random vs random)` and a
+  `selfPlayGame` at tiny sims **before** the refactor, and asserts identity
+  after. Awaiting already-resolved promises does not reorder rng draws.
+- JSONL from [06](06-selfplay-v1.md) is unaffected (same `Decision` shape);
+  key stability changes arrive with [10](10-move-canonicalization.md) /
+  [14](14-selfplay-v2.md).
 
 ## Inputs
 
-- The existing agent modules (02–06) and the game package.
+- The existing agent modules (02–06) and the game package (07 exports:
+  `encodeInto`, `scores`, `completions`).
 
 ## Outputs
 
-- `adapter.ts` (types), `oel.ts` (the one concrete adapter), and refactored
-  call sites throughout `agent/src/`.
+- `agent/src/game/adapter.ts` (types), `agent/src/game/oel.ts` (the one
+  concrete adapter), and refactored call sites throughout `agent/src/`
+  (search, policies, arena, selfplay, CLIs) — all generic over
+  `<TState, TMove>`.
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — the entire existing suite passes through the
-  adapter with **identical seeded behavior** (same seeds ⇒ same games as
-  before the refactor); a golden-game regression test pins this.
+- `pnpm --dir agent test && pnpm --dir agent typecheck` — the entire existing
+  suite passes through the adapter with **identical seeded behavior** (same
+  seeds ⇒ same command lists as before the refactor); the golden-game
+  regression test pins this.
+- Grep-level check: nothing under `agent/src/` outside `game/` and
+  `engine.ts`/`moves.ts` imports `hathora-et-labora-game`.
+- A 10-game `pnpm --dir agent arena` smoke run matches pre-refactor results
+  for the same seeds.
+
+## Design notes & tradeoffs
+
+- **Generic `TState`/`TMove` type params vs concrete types.** Concrete
+  `GameState`/`string[]` everywhere would be less ceremony, but then "game-
+  agnostic" is a comment, not a compiler guarantee — the whole point of M2 is
+  that search/selfplay *cannot* reach into OeL specifics. Generics cost a few
+  type parameters on `search`/`playGame` signatures and nothing at runtime.
+  `TCfg` defaults to `unknown` so the core never inspects configs. Chosen:
+  generics, with `oel.ts` as the only place the concrete types appear.
+- **Adapter as object-of-functions vs class.** A class invites inheritance
+  and `this`-state; the adapter is a bag of pure functions plus two constant
+  specs, exactly what a plain object literal expresses. It also matches the
+  existing house style (`Policy` is already an object literal) and keeps
+  `oel.ts` trivially tree-shakeable. Chosen: object type.
+- **Policies async now (one churn) vs later (double churn).** Making `pick`
+  async today touches every policy, `playGame`, `runMatch`, `selfPlayGame`,
+  and the CLIs — but the edits are `async`/`await` insertions with zero
+  behavioral risk while everything underneath is still synchronous, and the
+  golden test proves it. Deferring means re-touching the same files in
+  [12](12-evaluator-interface.md)/[13](13-puct-search.md) when the change is
+  *not* behaviorally trivial (real awaits interleave). Chosen: now. `search()`
+  is the one exception — it stays sync until 13 replaces it, so pure-UCT hot
+  loops don't pay promise overhead for nothing.
+- **Keep `engine.ts`/`moves.ts` as internal modules vs inlining into
+  `oel.ts`.** Inlining would make `oel.ts` the single source of truth but
+  produce a 300-line file mixing concerns and churning tests that target the
+  modules directly. Delegation keeps the diff small and the modules
+  independently testable; if a second game ever lands, its adapter gets its
+  own internal modules the same way. Chosen: delegate.
+- **`outcome()` defined mid-game vs terminal-only.** AlphaZero formally only
+  needs terminal outcomes, but the current rollout cutoff
+  (`mcts/search.ts`) evaluates non-terminal states by score rank, and gen-0
+  self-play depends on it. Encoding that contract in the adapter (documented
+  on the `outcome` field) beats adding a second `evaluateHeuristically`
+  method; `heuristic?` exists separately only because greedy wants a raw
+  score, not a rank.

--- a/docs/trainer/09-game-adapter.md
+++ b/docs/trainer/09-game-adapter.md
@@ -77,7 +77,19 @@ by delegation, not reimplementation:
 - `initial` = `replay(opening(cfg, seed))` (moving `GameConfig`/`opening`
   from `arena.ts` into the adapter; a bad opening throws).
 - `apply`/`isTerminal`/`playerToMove`/`numPlayers`/`outcome` = the `engine.ts`
-  functions verbatim; `heuristic` = `scores(state).map(s => s.total)` (kept
+  functions verbatim — **except solo**: `engine.ts` returns the raw score for
+  1-player games, which violates the `[0,1]` contract (it would swamp UCT's
+  exploration term and saturate the sigmoid value head). The adapter maps
+  solo to `σ((score − 500) / 100)`: 0.5 exactly at the score-500 success
+  threshold, monotone in score so maximizing value maximizes score, and a
+  useful gradient across the realistic 200–800 range. The threshold/scale
+  live in the adapter's config (`solo: { target: 500, scale: 100 }`), not in
+  code — the binary "score > 500" rate stays the *reported* success metric
+  ([22](22-arena-gating.md)/[26](26-first-run.md)); the squash is what search
+  backs up and the net trains on (denser signal per expensive solo game than
+  a sparse 0/1 label, at the cost of baking a fixed squash into the target —
+  revisit the scale only if solo value calibration looks flat).
+  `heuristic` = `scores(state).map(s => s.total)` (kept
   optional on the interface because it's a baseline convenience, not a core
   requirement for a new game).
 - `legalMoves(state, caps)` = `enumerateMoves(state, caps)` piped through

--- a/docs/trainer/10-move-canonicalization.md
+++ b/docs/trainer/10-move-canonicalization.md
@@ -12,39 +12,177 @@
 Guarantee that one *distinct* move has exactly one representation, so policy
 mass is never split across duplicates and JSONL candidates are stable keys.
 
-## Why it's needed
+## Why it's needed (the exact mechanism)
 
-`erectableLocations` (`game/src/board/landscape.ts`) emits joined
-`"col row"` coordinate tokens, and the column completion path can re-offer the
-row afterwards — so enumeration can produce e.g. `['BUILD','G07','3 2']` and
-`['BUILD','G07','3 2','2']` (or `['BUILD','G07','3','2']`) which the reducer
-parses identically. Left alone, these appear as separate candidates: the
-policy target and the PUCT priors would each get a fraction of the true mass.
+`erectableLocations` (`game/src/board/landscape.ts`) emits **joined
+`"col row"` tokens** (`` `${colIndex - 2} ${rowIndex - landscapeOffset}` ``),
+and the next completion level re-offers **every** row in that column:
+`completeBuild` (`game/src/commands/build.ts`) passes the whole joined token
+as `rawCol` into `erectableLocationsCol`, whose
+`Number.parseInt(rawCol, 10)` reads only the leading integer — the row baked
+into the token is ignored. The reducer (`game/src/reducer.ts`) then parses
+`BUILD [building, col, row]` positionally with `Number.parseInt` per token,
+so the row also comes from the *fourth* token, never from the joined one.
+
+Consequences, for a column with k erectable rows:
+
+- enumeration emits k joined tokens × k row tokens = **k² complete commands
+  that collapse to k distinct placements** — e.g. `['BUILD','G07','3 0','2']`
+  and `['BUILD','G07','3 2','2']` both apply as col 3, row 2;
+- none of them equals the human/web form `['BUILD','G07','3','2']`, which the
+  reducer parses identically, so JSONL keys wouldn't even match replayed
+  human games.
+
+The same joined-token → per-column-rows → parseInt shape appears in:
+`SETTLE` (`game/src/commands/settle.ts`, with a trailing resources param),
+`FELL_TREES` / `CUT_PEAT` (`forestLocations` / `moorLocations`), and USE
+params of forest-clearing buildings (`game/src/buildings/carpentry.ts`,
+`forestHut.ts`, `printingOffice.ts` — e.g. `use.ts` calls
+`carpentry(parseInt(params[0]), parseInt(params[1]))`). Left alone, these
+duplicates split the policy target and PUCT priors ([13](13-puct-search.md)),
+and waste curation budget: `maxPerLevel`/`maxMoves` caps in
+`agent/src/moves.ts` count raw paths, so up to (k−1)/k of a column's budget
+is spent re-discovering the same k placements.
 
 ## Design
 
-- `canonicalize(move: Move): Move` in `agent/src/game/oelMoves.ts`:
-  split params on whitespace, re-tokenize coordinates as separate
-  `col`,`row` integer strings, drop redundant trailing duplicates, keep
-  resource-param strings verbatim (their internal order is already normalized
-  by `combinations()` in the engine).
-- `moveKey(move) = canonical tokens joined with a space` — the dedupe and
-  serialization key used by the adapter, JSONL v2, and the exporter.
-- `legalMoves()` (adapter, 09) canonicalizes then dedupes by `moveKey`.
+`agent/src/game/oelMoves.ts`:
+
+- **`canonicalize(move: Move): Move`** — token-count-preserving truncation:
+  for each param token matching `/^-?\d+\s+-?\d+$/` (integer, whitespace,
+  integer — coordinates can be negative after landscape expansion), replace
+  it with `String(Number.parseInt(token, 10))`. All other tokens (command,
+  building/settlement ids, resource strings like `'GnGnWo'`, `'Jo'`,
+  `'MOUNTAIN'`) pass through verbatim.
+
+  **Truncation, not splitting.** The reducer parses positionally: splitting
+  `['SETTLE','SR1','3 2','2','ShSh']` into `[…,'3','2','2','ShSh']` would
+  shift `resources` into the row slot and change the parse. Truncating the
+  joined token to its leading integer (`'3 2'` → `'3'`) reproduces exactly
+  what `Number.parseInt` already does, preserves every other token's
+  position, and lands on the reducer-minimal form real players emit:
+  `['SETTLE','SR1','3','2','ShSh']`.
+
+- **`moveKey(move: Move): string`** = canonical tokens joined with a single
+  space. Canonical tokens contain no whitespace, so the key is unambiguous
+  and round-trips via `split(' ')`. This is the dedupe and serialization key
+  for the adapter, JSONL v2 ([14](14-selfplay-v2.md)), and the exporter
+  ([16](16-shard-exporter.md)).
+
+- **Dedupe** — `legalMoves()` in the adapter ([09](09-game-adapter.md)) maps
+  `canonicalize` over enumerated moves and keeps first occurrence per
+  `moveKey` (a `Map<string, Move>` preserves insertion order). Additionally,
+  fold a seen-`moveKey` set **into the DFS** in `enumerateMovesInfo`
+  (`agent/src/moves.ts`) so `maxMoves` counts *distinct* moves and the
+  curation budget stops paying the k² tax. `sampleMove` results are
+  canonicalized too, so rollout-chosen moves share the same key space.
+
+- **Resource params stay verbatim.** The engine generates each payment
+  multiset once, in a deterministic stage order
+  (`foodCostOptions`/`energyCostOptions` pipelines and `combinations()` in
+  `game/src/board/resource.ts`; `rewardCostOptions` even sorts+uniqs), so
+  re-normalizing them buys nothing. The legacy aliases `Po`/`Ho` that
+  `parseResourceParam` accepts are never *emitted* by completions, so no
+  alias collision arises from enumeration.
+
+## Implementation plan
+
+1. Add `canonicalize` + `moveKey` in `agent/src/game/oelMoves.ts` with the
+   regex rule above (pure functions over `Move = string[]`).
+2. Add the seen-set to `enumerateMovesInfo` (`agent/src/moves.ts`): push
+   `canonicalize(partial)` and skip when `moveKey` was already seen;
+   `truncated` semantics unchanged.
+3. Wire `legalMoves` and `moveKey` into the OeL adapter
+   ([09](09-game-adapter.md)); canonicalize `sampleMove` output there.
+4. Re-run the [08](08-benchmarks.md) branching column and record raw vs
+   deduped counts (expect the p99 tail to drop substantially on
+   placement-heavy states).
+
+## Edge cases
+
+- **Canonicalize complete moves only, never partials.** Partial token lists
+  feed back into `completions()` mid-walk, and some completion code inspects
+  raw tokens structurally (e.g. `printingOffice.ts` rebuilds `"c r"` pair
+  strings from prior params and matches with `startsWith`). Canonicalization
+  is a boundary transform on finished commands.
+- Multi-pair USE params (`printingOffice` takes up to four `[joined, row]`
+  pairs, 8 params): per-token truncation is still correct because
+  `printingOffice(...coords)` parseInts every param positionally.
+- `FELL_TREES`/`CUT_PEAT` optional trailing `'Jo'` token: untouched by the
+  regex; `['FELL_TREES','3 0','2','Jo']` → `['FELL_TREES','3','2','Jo']`.
+- Idempotence: `canonicalize(canonicalize(m)) ≡ canonicalize(m)` (canonical
+  tokens never match the regex again).
+- `CONFIG`/`START` are only produced by `opening()`, never enumerated —
+  excluded by construction, but the functions are total over any `Move`.
 
 ## Inputs
 
-- Raw enumerated moves from `enumerateMoves` / completion walks.
+- Raw enumerated moves from `enumerateMoves` / completion walks /
+  `sampleMove`.
 
 ## Outputs
 
-- `canonicalize`, `moveKey`; adapter `legalMoves` returns canonical, deduped
-  moves only.
+- `canonicalize`, `moveKey` in `agent/src/game/oelMoves.ts`; dedupe inside
+  `enumerateMovesInfo`; adapter `legalMoves` returns canonical, deduped moves
+  only.
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — property tests over states replayed from fixture
-  games:
-  - applying a raw move and its canonical form yields deep-equal states;
-  - dedupe never merges two moves whose applied states differ;
-  - explicit cases for joined `"col row"` tokens and redundant row re-offers.
+- `pnpm --dir agent test` — new `agent/src/__tests__/canonical.test.ts`:
+  - **Unit**: table tests for the regex rule (joined tokens, negatives,
+    resource strings, `'Jo'`, idempotence, `moveKey` round-trip via
+    `split(' ')`).
+  - **Explicit duplicates**: from an early fixture state, assert raw
+    enumeration contains `['BUILD',b,'3 0','1']`-style variants, that
+    `canonicalize` maps them all to `['BUILD',b,'3','1']`, and that
+    `legalMoves` returns each placement once.
+  - **Property, over a state corpus** (states replayed from the
+    [08](08-benchmarks.md) fixture command lists plus seeded random/greedy
+    games): for every enumerated raw move `m`,
+    `apply(state, m)` deep-equals `apply(state, canonicalize(m))` — the
+    canonical form is behavior-preserving; and for every `moveKey` group, all
+    members apply to deep-equal states — dedupe never merges two moves whose
+    applied states differ.
+- M2 exit criterion ("canonical dedupe proven") = these properties green over
+  the corpus, plus the before/after branching numbers in
+  [08](08-benchmarks.md).
+
+## Design notes & tradeoffs
+
+- **Canonicalizing in `agent/` vs fixing token emission in the engine.** The
+  root cause is `erectableLocations`' joined tokens plus
+  `erectableLocationsCol`'s re-offer — fixable in `game/`, which would also
+  speed up enumeration (no k² walk at all). But the completion-token grammar
+  is de-facto published API: the web UI's move picker and the MCP tools
+  (`web/src/context/InstanceContext.ts`, `web/src/mcp/tools/*.ts`) drive the
+  UX off these exact tokens, and the package is versioned for external
+  consumers. Changing emission is a breaking `game/` change requiring UI
+  redesign of the two-click location flow; canonicalizing at the agent
+  boundary is additive and ships in M2. The engine-side fix stays on the
+  table as a later coordinated change — this doc's rule keeps working either
+  way (already-canonical tokens pass through).
+- **Dedupe by `moveKey` vs by applied-state hash.** Hashing
+  `apply(state, m)` per candidate would be maximally correct (merges *any*
+  behavioral duplicates, e.g. two payment strings with identical effect) but
+  costs a reducer call (~0.011 ms) per raw candidate — at a p99 of 1,000+
+  raw moves that's ~10+ ms per node, dwarfing the enumeration it's cleaning
+  up. It would also merge moves whose *commands* differ, making JSONL keys
+  ambiguous on replay. `moveKey` dedupe is O(1) per move and merges exactly
+  the parse-identical forms. State-hash comparison is used only in tests, as
+  the ground truth the property suite checks `moveKey` against.
+- **Risk of over-merging.** The truncation rule fires only on
+  whitespace-joined integer pairs, which the engine emits solely as
+  coordinate tokens; every other token class is untouched. The
+  never-merge-distinct-states property over the corpus is the guard — if a
+  future engine token legitimately contains `"int int"` with different
+  semantics, that test fails before training data corrupts. The converse
+  (under-merging: distinct keys, same applied state — e.g. equivalent
+  payments) is deliberately tolerated: those are genuinely different
+  commands, and merging them would need state hashing (above).
+- **Seen-set inside the DFS vs dedupe-after.** Dedupe-after is simpler but
+  leaves `maxMoves`/`maxPerLevel` counting duplicates, so curated candidate
+  lists shrink by up to k× on placement-heavy states and `truncated`
+  over-reports. The in-DFS set costs one `moveKey` per complete path and
+  makes caps mean what [13](13-puct-search.md)/[14](14-selfplay-v2.md) assume
+  they mean. Both layers ship (the adapter dedupes defensively regardless of
+  which enumerator produced the moves).

--- a/docs/trainer/10-move-canonicalization.md
+++ b/docs/trainer/10-move-canonicalization.md
@@ -1,0 +1,50 @@
+# 10 — Move canonicalization & dedupe
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [03](03-move-enumeration.md), [07](07-engine-fast-paths.md) |
+| Milestone | M2 |
+
+## Goal
+
+Guarantee that one *distinct* move has exactly one representation, so policy
+mass is never split across duplicates and JSONL candidates are stable keys.
+
+## Why it's needed
+
+`erectableLocations` (`game/src/board/landscape.ts`) emits joined
+`"col row"` coordinate tokens, and the column completion path can re-offer the
+row afterwards — so enumeration can produce e.g. `['BUILD','G07','3 2']` and
+`['BUILD','G07','3 2','2']` (or `['BUILD','G07','3','2']`) which the reducer
+parses identically. Left alone, these appear as separate candidates: the
+policy target and the PUCT priors would each get a fraction of the true mass.
+
+## Design
+
+- `canonicalize(move: Move): Move` in `agent/src/game/oelMoves.ts`:
+  split params on whitespace, re-tokenize coordinates as separate
+  `col`,`row` integer strings, drop redundant trailing duplicates, keep
+  resource-param strings verbatim (their internal order is already normalized
+  by `combinations()` in the engine).
+- `moveKey(move) = canonical tokens joined with a space` — the dedupe and
+  serialization key used by the adapter, JSONL v2, and the exporter.
+- `legalMoves()` (adapter, 09) canonicalizes then dedupes by `moveKey`.
+
+## Inputs
+
+- Raw enumerated moves from `enumerateMoves` / completion walks.
+
+## Outputs
+
+- `canonicalize`, `moveKey`; adapter `legalMoves` returns canonical, deduped
+  moves only.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — property tests over states replayed from fixture
+  games:
+  - applying a raw move and its canonical form yields deep-equal states;
+  - dedupe never merges two moves whose applied states differ;
+  - explicit cases for joined `"col row"` tokens and redundant row re-offers.

--- a/docs/trainer/11-action-encoder.md
+++ b/docs/trainer/11-action-encoder.md
@@ -1,0 +1,66 @@
+# 11 — ActionSpec & move feature encoder
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [07](07-engine-fast-paths.md), [10](10-move-canonicalization.md) |
+| Milestone | M3 |
+
+## Goal
+
+A fixed-length feature vector per *move*, so the policy head can score any
+enumerated candidate. This is the design decision that makes full AlphaZero
+tractable here.
+
+## Why move-scoring (and not the alternatives)
+
+- **Flat indexed action space**: a full move is (command, erection, col, row,
+  payment…). Payments are multisets over 22 goods, context-dependent, with
+  observed tails of 1,662 legal variants — a flat head needs tens of
+  thousands of mostly-dead outputs plus masking computed by enumerating
+  anyway. Infeasible and game-specific.
+- **Token-factorized policy / token-level tree**: principled, but the payment
+  *level* is a single fat token (`'ShShWo'` is one completion string), partial
+  commands aren't states the reducer can apply, and tree depth ×3–5 means
+  *more* oracle calls per simulation, not fewer.
+- **Move-scoring**: median branching is 18 and curation caps candidates at
+  ~64–128; scoring each candidate with a small net conditioned on the state
+  embedding handles variable action sets natively, keeps priors and visit
+  targets on the same list, and is trivially game-agnostic.
+
+## Design
+
+`agent/src/game/oelAction.ts`, egocentric, ~90 floats per move:
+
+| Block | Size | Encoding |
+| --- | --- | --- |
+| Command | 14 | one-hot in `featureSpec.vocab.commands` order (append-only stable) |
+| Primary erection param | 1 | categorical id, same vocab as the grid's erection channel (shared embedding table in the net) |
+| Placement col | 9 | one-hot |
+| Placement row | 38 | one-hot, anchored via the mover's `landscapeOffset` so policy rows align with state-grid rows |
+| Resource params | 22 | all remaining params through `parseResourceParam`, summed into per-good counts — this is what makes 1,600 payment variants learnable |
+| Scalars | ~6 | param count, isCommit, isConvert, … |
+
+`ActionSpec` (in `adapter.ts`): `{ moveFeatureLen, version, categorical:
+[{name, offset, capacity, vocab}] }` — emitted as JSON next to shards so the
+PyTorch model builds itself data-driven ([18](18-model.md)) and the trainer
+can assert version compatibility.
+
+## Inputs
+
+- Canonical moves ([10](10-move-canonicalization.md)); the mover's state (for
+  `landscapeOffset` anchoring); helpers exported in
+  [07](07-engine-fast-paths.md).
+
+## Outputs
+
+- `encodeMove(state, perspective, move, out: Float32Array): void` wired into
+  the OeL adapter; `actionSpec` constant; `spec.json` emit helper.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — property tests over fixture-game states: every
+  enumerated move encodes NaN-free and in-bounds; distinct canonical moves
+  encode to distinct vectors on a large sample; coordinate anchoring matches
+  the state grid for known positions.

--- a/docs/trainer/11-action-encoder.md
+++ b/docs/trainer/11-action-encoder.md
@@ -15,43 +15,85 @@ tractable here.
 
 ## Why move-scoring (and not the alternatives)
 
+The numbers below are from the code, not estimates. `GameCommandEnum`
+(`game/src/types.ts`) has **14 commands**; `allResource`
+(`game/src/board/resource.ts`) lists **22 goods** (`ResourceEnum` has 24
+tokens, but `Bp`/`Jo` are not goods — `parseResourceParam` drops them); the
+color-collapsed erection vocabulary in `game/src/encode.ts` is **80 ids**
+(72 generic buildings + 8 settlement types, id 0 = empty).
+
 - **Flat indexed action space**: a full move is (command, erection, col, row,
-  payment…). Payments are multisets over 22 goods, context-dependent, with
-  observed tails of 1,662 legal variants — a flat head needs tens of
-  thousands of mostly-dead outputs plus masking computed by enumerating
-  anyway. Infeasible and game-specific.
-- **Token-factorized policy / token-level tree**: principled, but the payment
+  payments…). Even ignoring payments, command × erection × col × row is
+  14 × 80 × 9 × 38 ≈ 383k cells; payments are multisets over 22 goods with
+  measured branching median 18, p99 1,114, max ~1,675
+  ([03](03-move-enumeration.md)). A flat head needs hundreds of thousands of
+  mostly-dead outputs plus a legality mask computed by enumerating anyway.
+  Infeasible and game-specific.
+- **Token-factorized policy / token-level tree**: principled, but a payment
   *level* is a single fat token (`'ShShWo'` is one completion string), partial
   commands aren't states the reducer can apply, and tree depth ×3–5 means
   *more* oracle calls per simulation, not fewer.
 - **Move-scoring**: median branching is 18 and curation caps candidates at
-  ~64–128; scoring each candidate with a small net conditioned on the state
-  embedding handles variable action sets natively, keeps priors and visit
-  targets on the same list, and is trivially game-agnostic.
+  ~24–128 (`DEFAULTS.curation` in `agent/src/mcts/search.ts`); scoring each
+  candidate with a small net conditioned on the state embedding handles
+  variable action sets natively, keeps priors and visit targets on the same
+  list, and is trivially game-agnostic.
 
 ## Design
 
-`agent/src/game/oelAction.ts`, egocentric, ~90 floats per move:
+`agent/src/game/oelAction.ts`. Layout (91 floats, `moveFeatureLen = 91`):
 
-| Block | Size | Encoding |
-| --- | --- | --- |
-| Command | 14 | one-hot in `featureSpec.vocab.commands` order (append-only stable) |
-| Primary erection param | 1 | categorical id, same vocab as the grid's erection channel (shared embedding table in the net) |
-| Placement col | 9 | one-hot |
-| Placement row | 38 | one-hot, anchored via the mover's `landscapeOffset` so policy rows align with state-grid rows |
-| Resource params | 22 | all remaining params through `parseResourceParam`, summed into per-good counts — this is what makes 1,600 payment variants learnable |
-| Scalars | ~6 | param count, isCommit, isConvert, … |
+| Block | Offset | Size | Encoding |
+| --- | --- | --- | --- |
+| Command | 0 | 14 | one-hot in `featureSpec.vocab.commands` order (append-only stable) |
+| Erection id | 14 | 1 | categorical 0–80 (0 = none), the *same* ids as the grid's erection channel (`erectionId` in `encode.ts`), capacity 256 |
+| Placement col | 15 | 9 | one-hot at index `col + 2` (command cols are raw grid cols minus 2 — see `landscape.ts` `[col + 2]`) |
+| Placement row | 24 | 38 | one-hot at index `row + gridAnchor` (18); also holds `BUY_PLOT`/`BUY_DISTRICT`'s `y` param |
+| Buy side | 62 | 4 | one-hot over `MOUNTAIN`/`COAST`/`PLAINS`/`HILLS` (`GameCommandBuyPlotParams`/`…BuyDistrictParams`) |
+| Resource counts | 66 | 22 | every remaining param through `parseResourceParam`, **summed** into per-good counts in `featureSpec.vocab.resources` order — this is what makes 1,600+ payment variants learnable |
+| Scalars | 88 | 3 | `numParams`, `usesJoker` (any `Jo` token — see below), `totalGoods` |
 
-`ActionSpec` (in `adapter.ts`): `{ moveFeatureLen, version, categorical:
-[{name, offset, capacity, vocab}] }` — emitted as JSON next to shards so the
-PyTorch model builds itself data-driven ([18](18-model.md)) and the trainer
-can assert version compatibility.
+Coordinate anchoring, corrected: command coordinates are already **logical**
+— the engine adds the offset when indexing
+(`player.landscape[row + player.landscapeOffset][col + 2]` in
+`game/src/board/landscape.ts`) and subtracts it when emitting
+(`forestLocations`). The state encoder places logical row `r` at output row
+`r + ANCHOR` (`t.landscape[outputRow + t.landscapeOffset - ANCHOR]` in
+`encode.ts`). So `encodeMove` uses the constants `gridAnchor = 18` and
+`col + 2` and never reads `landscapeOffset`; policy rows align with
+state-grid rows by construction. Out-of-range indices are clipped silently,
+same as the state writer's `hot()`.
+
+Token classifier (moves are canonical per [10](10-move-canonicalization.md),
+so coords are separate integer tokens):
+
+1. token 0 → command one-hot;
+2. `/^-?\d+$/` → first numeric is col, second is row — except for
+   `BUY_PLOT`/`BUY_DISTRICT`, whose single numeric is a row (`y`);
+3. `MOUNTAIN|COAST|PLAINS|HILLS` → side one-hot;
+4. member of the `ErectionEnum` value set → erection id via the exported
+   lookup from [07](07-engine-fast-paths.md);
+5. anything else → resource param: `parseResourceParam`, add counts; if any
+   2-char slice is `Jo`, set `usesJoker` (the `USE LR1 Jo` / `CUT_PEAT 0 0 Jo`
+   / `FELL_TREES 2 0 Jo` forms — `parseResourceParam` drops `Jo`, so without
+   this flag `USE LR1` and `USE LR1 Jo` would encode identically).
+
+Unknown tokens (future expansions) fall into case 5 and at worst contribute
+only to `numParams` — the encoder never throws.
+
+`ActionSpec` (in `adapter.ts`):
+`{ version: 1, moveFeatureLen: 91, categorical: [{ name: 'erection',
+offset: 14, capacity: 256, vocab }], blocks: [{name, offset, len}…] }` —
+emitted as JSON next to shards so the PyTorch model builds itself data-driven
+([18](18-model.md)) and the trainer asserts version compatibility.
 
 ## Inputs
 
-- Canonical moves ([10](10-move-canonicalization.md)); the mover's state (for
-  `landscapeOffset` anchoring); helpers exported in
-  [07](07-engine-fast-paths.md).
+- Canonical moves ([10](10-move-canonicalization.md)); the mover's state
+  (kept in the signature for adapter uniformity and asserts, though the OeL
+  encoder needs no per-state data — see anchoring note above); helpers
+  exported in [07](07-engine-fast-paths.md) (`parseResourceParam`,
+  erection-id lookup).
 
 ## Outputs
 
@@ -60,7 +102,49 @@ can assert version compatibility.
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — property tests over fixture-game states: every
-  enumerated move encodes NaN-free and in-bounds; distinct canonical moves
-  encode to distinct vectors on a large sample; coordinate anchoring matches
-  the state grid for known positions.
+- `pnpm --dir agent test` — property tests over fixture-game states:
+  - every enumerated move encodes NaN-free and in-bounds;
+  - joker discrimination: `['USE','LR1']` ≠ `['USE','LR1','Jo']`;
+  - **collision soundness**: whenever two distinct canonical moves encode to
+    the same vector, applying both to the state yields deep-equal states
+    (the pilgrimage-site case below), on a large fixture sample;
+  - coordinate anchoring: for a known `BUILD G07 c r`, the row one-hot index
+    equals the state-grid output row of that tile.
+
+## Design notes & tradeoffs
+
+- **Move-scoring vs flat vs token-factorized** — see the numbers above; the
+  clincher is that the flat head's mask and the token tree's oracle calls
+  both require the same enumeration move-scoring already does, so the
+  alternatives pay move-scoring's cost *plus* their own.
+- **One-hot coords vs two scalars**: one-hots cost 45 extra floats
+  (~180 B f32; ≤128 candidates ⇒ ~23 KB per decision — trivial), let the
+  first dense layer learn location-specific weights aligned with the state
+  grid, and are exactly zero for coordinate-less moves (`COMMIT`,
+  `WITH_PRIOR`) instead of a fake `(0, 0)`. Scalars force the net to learn
+  coordinate arithmetic through ReLUs and conflate "no coordinate" with
+  "row 0". Chosen: one-hot.
+- **Shared erection embedding vs a separate table**: emitting the same
+  0–80 id space as the grid channel lets the model use one `nn.Embedding`
+  for both, so "the move builds G07" and "the board contains G07" meet in
+  the same learned space — free transfer, fewer parameters. Cost: the
+  embedding dim is coupled between state and action towers. The `spec.json`
+  categorical block carries `name`/`capacity`/`vocab`, so splitting into a
+  separate table later is a model-side change only. Chosen: share.
+- **Resource counts lose payment order — does order matter?** Two levels:
+  - *Within one param string*: no. Every consumer parses via
+    `parseResourceParam`, which sums into a `Cost` bag — `'ShWo'` and
+    `'WoSh'` are the same move to the reducer (and `combinations()` already
+    emits one ordering).
+  - *Across params*: only two buildings take two resource params
+    (`grep params\[1\]`-equivalent audit): `houseOfTheBrotherhood.ts`
+    (param1 = coins in, param2 = point-goods out — **disjoint good sets**,
+    so the summed bag is unambiguous) and `pilgrimageSite.ts` (param1/param2
+    each upgrade one relic; `Bo Ce` and `Ce Bo` both net −Book +Ornament —
+    order-swapped variants are state-equivalent).
+  So summing collapses only moves whose applied states are deep-equal. The
+  one genuine information loss was the joker token, fixed by the
+  `usesJoker` scalar. Residual effect of benign collisions: equivalent
+  candidates get equal priors and split visits between them — which is the
+  *correct* target, and [10](10-move-canonicalization.md) already merges
+  literal duplicates before they reach the encoder.

--- a/docs/trainer/12-evaluator-interface.md
+++ b/docs/trainer/12-evaluator-interface.md
@@ -1,0 +1,57 @@
+# 12 — Evaluator interface
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [09](09-game-adapter.md) |
+| Milestone | M4 |
+
+## Goal
+
+One async seam through which PUCT gets leaf values and priors, so rollouts
+(gen-0), CPU ONNX inference, and a future GPU batch server are
+interchangeable without touching search code.
+
+## Design
+
+`agent/src/evaluator.ts`:
+
+```ts
+export type EvalRequest = {
+  state: Float32Array        // encoded via adapter.encodeState
+  candFeats: Float32Array    // numCands × moveFeatureLen, adapter.encodeMove
+  numCands: number
+}
+export type EvalResult = { value: number[]; priors: number[] }
+export type Evaluator = {
+  id: string                 // recorded in JSONL (netId) for provenance
+  evaluate(reqs: EvalRequest[]): Promise<EvalResult[]>
+}
+```
+
+- **Async and batched from day one** (an array of requests), even though the
+  first implementation is synchronous under the hood — this is what makes
+  in-worker cross-game batching (Stage 2) and a GPU server (Stage 3) drop-in
+  later.
+- `RolloutEvaluator(adapter, { rolloutDepth })`: value = depth-capped random
+  rollout + `outcome()` (exactly project 05's evaluation), priors = uniform.
+  Gen-0 self-play and NN generations share one search code path.
+- Staging plan: Stage 1 = `OnnxEvaluator` per worker, CPU
+  ([21](21-onnx-evaluator.md)); Stage 2 = in-worker leaf batching across
+  concurrent games (only if profiling shows NN-bound search); Stage 3 =
+  Python GPU inference server behind this same interface (only if measured
+  necessary — do not build speculatively).
+
+## Inputs
+
+- Encoded state + candidate tensors from the adapter.
+
+## Outputs
+
+- `Evaluator` type, `RolloutEvaluator` implementation.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — `RolloutEvaluator` is deterministic under a
+  seeded Rng; priors sum to 1; value components lie in [0,1].

--- a/docs/trainer/12-evaluator-interface.md
+++ b/docs/trainer/12-evaluator-interface.md
@@ -18,40 +18,112 @@ interchangeable without touching search code.
 `agent/src/evaluator.ts`:
 
 ```ts
-export type EvalRequest = {
-  state: Float32Array        // encoded via adapter.encodeState
-  candFeats: Float32Array    // numCands × moveFeatureLen, adapter.encodeMove
-  numCands: number
+export type EvalRequest<TState, TMove> = {
+  state: TState              // the raw game state at the leaf
+  perspective: number        // adapter.playerToMove(state)
+  candidates: TMove[]        // canonical list from adapter.legalMoves — priors align to this
 }
-export type EvalResult = { value: number[]; priors: number[] }
-export type Evaluator = {
+export type EvalResult = {
+  value: number[]            // per-player, ABSOLUTE seat order, each in [0, 1]
+  priors: number[]           // length === candidates.length, sums to 1
+}
+export type Evaluator<TState, TMove> = {
   id: string                 // recorded in JSONL (netId) for provenance
-  evaluate(reqs: EvalRequest[]): Promise<EvalResult[]>
+  evaluate(reqs: EvalRequest<TState, TMove>[]): Promise<EvalResult[]>
 }
 ```
 
-- **Async and batched from day one** (an array of requests), even though the
-  first implementation is synchronous under the hood — this is what makes
-  in-worker cross-game batching (Stage 2) and a GPU server (Stage 3) drop-in
-  later.
-- `RolloutEvaluator(adapter, { rolloutDepth })`: value = depth-capped random
-  rollout + `outcome()` (exactly project 05's evaluation), priors = uniform.
-  Gen-0 self-play and NN generations share one search code path.
-- Staging plan: Stage 1 = `OnnxEvaluator` per worker, CPU
-  ([21](21-onnx-evaluator.md)); Stage 2 = in-worker leaf batching across
-  concurrent games (only if profiling shows NN-bound search); Stage 3 =
-  Python GPU inference server behind this same interface (only if measured
-  necessary — do not build speculatively).
+Two contracts worth spelling out because they are classic bug sources:
+
+- **Value order is absolute seat order** (index = player index, exactly what
+  `outcome()` in `agent/src/engine.ts` returns), *not* rotated to the
+  perspective. Evaluators whose model output is egocentric (slot 0 = mover,
+  per the state encoder) must rotate back using `perspective` before
+  returning. PUCT's per-player backup indexes `value[mover]` at every node
+  on the path, so a rotation bug corrupts every backup silently.
+- **Requests carry raw state + moves, not tensors.** Encoding happens
+  *inside* evaluators that need it (the adapter is injected at
+  construction). Rationale: `RolloutEvaluator` physically needs the state
+  object to call `sampleMove`/`apply` — a `Float32Array` is useless to it —
+  and gen-0 should not pay ~57 KB of state encoding plus 91 floats × up to
+  128 candidates per expansion for tensors nobody reads. `OnnxEvaluator`
+  ([21](21-onnx-evaluator.md)) calls `adapter.encodeState`/`encodeMove`
+  into reused scratch buffers; a future GPU server still encodes Node-side
+  and ships tensors, so nothing about Stage 3 changes.
+
+### RolloutEvaluator
+
+`RolloutEvaluator(adapter, rng, { rolloutDepth = 30 })` — per request:
+
+- **value**: exactly project [05](05-uct-search.md)'s leaf evaluation
+  (`rollout()` in `agent/src/mcts/search.ts`): loop `sampleMove` → `apply`
+  up to `rolloutDepth` commands or terminal, breaking on `undefined` from
+  either (same guards), then `adapter.outcome(s)` — which on a non-terminal
+  state ranks by current score totals, the score-margin cutoff that lets
+  rollouts stay shallow.
+- **priors**: uniform `1 / candidates.length`.
+- Processes the request array sequentially with the evaluator's own seeded
+  `Rng`, so results are deterministic given (seed, request sequence). Gen-0
+  self-play and NN generations share one search code path.
+
+Malformed results are search-fatal by design: PUCT asserts
+`priors.length === candidates.length` and finite values, and lets a rejected
+`evaluate()` propagate (the self-play worker catches per game —
+[15](15-selfplay-workers.md)); a half-evaluated tree must never back up.
+
+### Staging plan
+
+Stage 1 = `OnnxEvaluator` per worker, CPU ([21](21-onnx-evaluator.md)).
+Stage 2 = in-worker leaf batching across concurrent simulations/games (only
+if profiling shows NN-bound search — the interface already takes request
+arrays, so this is an evaluator + `concurrency` option change, not a search
+change). Stage 3 = Python GPU inference server behind this same interface
+(only if measured necessary — do not build speculatively).
 
 ## Inputs
 
-- Encoded state + candidate tensors from the adapter.
+- Leaf states + canonical candidate lists from the adapter
+  ([09](09-game-adapter.md)); encoded tensors are produced internally by
+  evaluators that need them.
 
 ## Outputs
 
-- `Evaluator` type, `RolloutEvaluator` implementation.
+- `Evaluator` / `EvalRequest` / `EvalResult` types, `RolloutEvaluator`
+  implementation.
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — `RolloutEvaluator` is deterministic under a
-  seeded Rng; priors sum to 1; value components lie in [0,1].
+- `pnpm --dir agent test` —
+  - `RolloutEvaluator` is deterministic under a seeded Rng; priors sum to 1;
+    value components lie in [0,1];
+  - parity: on a fixture state, its value matches project 05's `rollout()`
+    given the same seed (guards the "same search behavior at gen-0" claim);
+  - absolute-order contract: a nearly-won fixture position yields
+    `value[leader] > value[trailer]` regardless of `perspective`.
+
+## Design notes & tradeoffs
+
+- **Batched-async now vs per-leaf sync**: the sync version reads slightly
+  better (`const {value, priors} = evaluator.evaluate(req)`) and avoids
+  async plumbing in the sim loop. But the cost of async is one microtask
+  per expansion — noise next to a single `control()` call — while the cost
+  of sync is refitting the `Evaluator` type, `puct.ts`, and every test
+  exactly when Stage-2 batching or a GPU server is needed, i.e. when the
+  system is under load and regressions are most expensive. Policies already
+  go async in [09](09-game-adapter.md) for this reason. Chosen: async,
+  array-in/array-out from day one; first implementation is synchronous
+  under the hood.
+- **Uniform priors vs cheap heuristic priors** for gen-0: a hand heuristic
+  (boost `USE`/`BUILD`, score-delta greedy priors) would sharpen gen-0
+  search, but (a) it injects hand-tuned bias into the very data meant to
+  bootstrap the net — the net then learns the heuristic's blind spots as
+  ground truth; (b) it is a second scoring code path to maintain and A/B;
+  (c) M4's gate is "PUCT + uniform priors ≈ UCT at equal sims", which
+  uniform satisfies by construction. If gen-1 gating fails, raising gen-0
+  sims is an unbiased, measurable lever. Chosen: uniform; revisit only on
+  evidence.
+- **Raw state in the request vs pre-encoded tensors**: covered above —
+  tensors would make the interface look "ML-native" but force the wrong
+  party to pay encoding costs and make `RolloutEvaluator` impossible
+  without carrying the state anyway. The adapter-injection pattern keeps
+  the request game-generic (`TState`/`TMove` type params, no OeL types).

--- a/docs/trainer/13-puct-search.md
+++ b/docs/trainer/13-puct-search.md
@@ -1,0 +1,56 @@
+# 13 — PUCT search
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [09](09-game-adapter.md), [12](12-evaluator-interface.md) |
+| Milestone | M4 |
+
+## Goal
+
+AlphaZero-style search: evaluator-driven leaf evaluation with policy priors
+guiding selection, replacing (but preserving as an option) rollout
+evaluation.
+
+## Design
+
+`agent/src/mcts/puct.ts` (new; `search.ts` stays as the sync UCT reference):
+
+- Node expansion: `adapter.legalMoves()` once, encode state + every candidate,
+  one `evaluate()` call → per-player `value` vector and softmax `priors`
+  aligned to the candidate list.
+- Selection: `argmax_a Q(s,a)[mover] + cPuct · P(a) · √N / (1 + n(a))`, with
+  the per-player vector backup kept unchanged from project 05 (multiplayer +
+  interrupt correctness).
+- **Root Dirichlet noise**: `P ← (1−ε)·P + ε·Dir(α)`, ε = 0.25,
+  α ≈ 10/⟨branching⟩ ≈ 0.5 — self-play exploration only, off for arena play.
+- **Virtual loss** on in-flight paths, so Stage-2 evaluator batching can run
+  several simulations concurrently without collapsing onto one path.
+- Async throughout (`await evaluator.evaluate(…)`).
+- **Complete visit output**: the result carries the *full canonical candidate
+  list with visit counts, zeros included* — project 05 reports only expanded
+  edges, which breaks policy-target support. Training needs the whole softmax
+  support.
+
+```ts
+puct(state, rng, { sims, cPuct=1.5, dirichlet?, curation? }, evaluator)
+  → { best, candidates: TMove[], visits: number[], q: number[] }
+```
+
+## Inputs
+
+- Root state, seeded `Rng`, options, an `Evaluator`
+  (RolloutEvaluator ⇒ gen-0 behavior; OnnxEvaluator ⇒ NN generations).
+
+## Outputs
+
+- `puct()` search function + an async `puctPolicy` wrapper for the arena.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — seeded determinism; visits sum to sims; candidate
+  list matches `adapter.legalMoves` exactly.
+- Strength sanity via arena: PUCT with `RolloutEvaluator` (uniform priors) ≈
+  UCT at equal sims against `random`/`greedy` — the refactor must not lose
+  strength before the net adds any.

--- a/docs/trainer/13-puct-search.md
+++ b/docs/trainer/13-puct-search.md
@@ -10,38 +10,105 @@
 ## Goal
 
 AlphaZero-style search: evaluator-driven leaf evaluation with policy priors
-guiding selection, replacing (but preserving as an option) rollout
-evaluation.
+guiding selection, replacing (but preserving as an option, via
+`RolloutEvaluator`) rollout evaluation.
+
+## What is preserved from project 05, and what changes
+
+`agent/src/mcts/puct.ts` is new; `agent/src/mcts/search.ts` stays untouched
+as the sync UCT reference. Preserved semantics from `search.ts`:
+
+- **Per-player value vectors**: edges accumulate `w: number[]` and selection
+  maximizes the *mover-at-that-node* component (`edge.w[node.mover]`). This
+  is what makes runs of same-player nodes (a turn is several commands ending
+  in `COMMIT`) and `WORK_CONTRACT` interrupts correct — each node keys off
+  its own `playerToMove` (`frame.activePlayerIndex`).
+- Terminal leaves evaluated by `adapter.outcome()`; curation cap defaults
+  (`{ maxPerLevel: 24, maxMoves: 128 }`); imperative hot loops.
+
+What changes: expansion creates **all** edges at once with priors (needed to
+align priors to candidates), selection uses PUCT instead of UCB1, the sim
+loop is async around `evaluator.evaluate`, root noise and virtual loss are
+added, and the result reports the **complete** candidate list.
 
 ## Design
 
-`agent/src/mcts/puct.ts` (new; `search.ts` stays as the sync UCT reference):
-
-- Node expansion: `adapter.legalMoves()` once, encode state + every candidate,
-  one `evaluate()` call → per-player `value` vector and softmax `priors`
-  aligned to the candidate list.
-- Selection: `argmax_a Q(s,a)[mover] + cPuct · P(a) · √N / (1 + n(a))`, with
-  the per-player vector backup kept unchanged from project 05 (multiplayer +
-  interrupt correctness).
-- **Root Dirichlet noise**: `P ← (1−ε)·P + ε·Dir(α)`, ε = 0.25,
-  α ≈ 10/⟨branching⟩ ≈ 0.5 — self-play exploration only, off for arena play.
-- **Virtual loss** on in-flight paths, so Stage-2 evaluator batching can run
-  several simulations concurrently without collapsing onto one path.
-- Async throughout (`await evaluator.evaluate(…)`).
-- **Complete visit output**: the result carries the *full canonical candidate
-  list with visit counts, zeros included* — project 05 reports only expanded
-  edges, which breaks policy-target support. Training needs the whole softmax
-  support.
+Structures (generic over the adapter's `TState`/`TMove`):
 
 ```ts
-puct(state, rng, { sims, cPuct=1.5, dirichlet?, curation? }, evaluator)
-  → { best, candidates: TMove[], visits: number[], q: number[] }
+type Edge<TMove> = { move: TMove; prior: number; child: Node | null;
+                     n: number; w: number[]; vloss: number }
+class Node { mover: number; terminal: boolean; n: number;
+             value: number[]           // evaluator value at expansion
+             edges: Edge<TMove>[] }    // one per candidate, aligned
 ```
+
+- **Expansion**: `adapter.legalMoves(state, curation)` once, then one
+  `evaluate([{ state, perspective: mover, candidates }])` call → store the
+  per-player `value` vector on the node and one edge per candidate with its
+  prior (defensively re-normalized; length-mismatch throws). Children stay
+  `null` until first traversal (`apply` is deferred, so a node costs one
+  enumeration + one evaluation, not `k` reducer calls).
+- **Selection** at a node with total visits `N = node.n`:
+  `score(a) = Q(a) + cPuct · P(a) · √max(N,1) / (1 + nEff(a))` where
+  `nEff(a) = n(a) + vloss(a)`, `Q(a) = nEff > 0 ? w(a)[mover] / nEff
+  : node.value[mover]` (first-play urgency = the node's own evaluated value
+  for the mover; unvisited edges are neither free wins at Q=1 nor dead at
+  Q=0). Argmax, first-index tie-break — deterministic.
+- **Backup**: walk the stored path; for every node `n++`, for every edge
+  `n++`, `w[p] += value[p]` for all `p`, and `vloss--` (see below). Values
+  are always full per-player vectors in absolute seat order
+  ([12](12-evaluator-interface.md)).
+- **Root Dirichlet noise** (self-play only, off for arena):
+  `P ← (1−ε)·P + ε·Dir(α)` with ε = 0.25 and **α scaled by branching**:
+  `α = alphaScale / k`, `alphaScale = 10`, `k` = root candidate count
+  (median 18 ⇒ α ≈ 0.55). Sampling: JS has no gamma sampler, so
+  `agent/src/mcts/dirichlet.ts` implements per-candidate `Gamma(α, 1)`
+  normalized to a simplex, with gamma via **Marsaglia–Tsang**: for α ≥ 1,
+  `d = α − 1/3`, `c = 1/√(9d)`, repeat { `x ~ N(0,1)` (Box–Muller over two
+  draws from the seeded `Rng`), `v = (1 + c·x)³`, accept when `v > 0` and
+  `ln(u) < x²/2 + d − d·v + d·ln(v)` } → `d·v`; for α < 1 (the common case
+  here), sample `Gamma(α+1)` and multiply by `u^(1/α)`. All randomness
+  flows from the search `Rng` — seeded determinism holds noise included.
+- **Virtual loss**: during descent each traversed edge gets `vloss++`
+  (counted in `nEff` but adding nothing to `w`, i.e. an in-flight sim looks
+  like a value-0 result to whichever mover inspects the edge — with
+  per-player vectors this "loss for the local mover" falls out for free).
+  Backup decrements it. With the default `concurrency = 1` this is
+  add-then-remove within one simulation — bit-identical to no virtual loss
+  — but `concurrency > 1` (Stage-2 batching) launches that many
+  `runSimulation()` promises and the bookkeeping already keeps them off one
+  path. Invariant: all `vloss === 0` after search (asserted in tests).
+- **Complete visit output**: the result carries the full canonical candidate
+  list with visit counts, zeros included — project 05 reports only expanded
+  edges, which breaks policy-target support. Training needs the whole
+  softmax support.
+
+```ts
+puct(adapter, state, rng, { sims, cPuct = 1.5, dirichlet?: { epsilon: 0.25,
+     alphaScale: 10 }, curation?, concurrency = 1 }, evaluator)
+  → Promise<{ best, candidates: TMove[], visits: number[], q: number[],
+              value: number[], forced: boolean }>
+```
+
+Edge cases:
+
+- **Terminal root** → `{ best: undefined, candidates: [], visits: [],
+  forced: false }`; callers (self-play, arena) treat it as game over.
+- **Single candidate** → short-circuit: no evaluator call, no simulations,
+  return `visits = [sims]`, `forced = true`. Forced decisions are common
+  (interrupt replies, lone `COMMIT`) and this saves entire searches.
+- **No candidates while non-terminal** (enumeration hiccup) → `best:
+  undefined`, mirroring `search.ts`'s `res.best === undefined` path.
+- **Evaluator failure mid-search** → the rejection propagates out of
+  `puct()`; no partial result is returned and no backup happens for the
+  failed simulation (the game is abandoned by the caller,
+  [15](15-selfplay-workers.md)).
 
 ## Inputs
 
 - Root state, seeded `Rng`, options, an `Evaluator`
-  (RolloutEvaluator ⇒ gen-0 behavior; OnnxEvaluator ⇒ NN generations).
+  (`RolloutEvaluator` ⇒ gen-0 behavior; `OnnxEvaluator` ⇒ NN generations).
 
 ## Outputs
 
@@ -49,8 +116,47 @@ puct(state, rng, { sims, cPuct=1.5, dirichlet?, curation? }, evaluator)
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — seeded determinism; visits sum to sims; candidate
-  list matches `adapter.legalMoves` exactly.
+- `pnpm --dir agent test` — seeded determinism (with and without Dirichlet);
+  visits sum to sims; candidate list matches `adapter.legalMoves` exactly;
+  virtual-loss invariant (`vloss === 0` everywhere post-search); forced
+  short-circuit; Dirichlet sampler moments (mean ≈ 1/k, sums to 1) and
+  α < 1 branch coverage.
 - Strength sanity via arena: PUCT with `RolloutEvaluator` (uniform priors) ≈
   UCT at equal sims against `random`/`greedy` — the refactor must not lose
   strength before the net adds any.
+
+## Design notes & tradeoffs
+
+- **New `puct.ts` vs modifying `search.ts` in place**: `mcts:400` is the
+  permanent arena yardstick (see [README](README.md)) and golden-seed tests
+  pin `search.ts`'s exact `Rng` consumption; editing it in place would
+  silently move the yardstick the new net is measured against. The cost is
+  ~150 duplicated lines (node/backup skeleton); shared scraps (`zeros`,
+  option types) can migrate to a common module without touching behavior.
+- **Expand-all-candidates vs progressive widening**: priors are only
+  meaningful over the full candidate list, and the evaluator scores all
+  candidates in the one call expansion already makes — so widening would
+  not save evaluations, only per-edge allocation on fat nodes. With median
+  branching 18 and curation capping the p99 tail at 128
+  ([03](03-move-enumeration.md)), that saving is marginal, while widening
+  would break the "complete visit support" training target and complicate
+  prior renormalization. Curation *is* our widening.
+- **Virtual loss now vs when batching lands**: it is one integer per edge
+  and ±1 in two loops now, versus reopening a validated backup path later
+  and re-certifying every determinism test under concurrency. Since
+  `concurrency = 1` makes it provably behavior-neutral, the risk of
+  carrying it early is nil and Stage 2 becomes a config change.
+- **Dirichlet α scaled by branching**: a fixed α (chess's 0.3) assumes a
+  roughly constant action count; here the root varies from 1–2 (forced
+  replies) to the 128 cap, so fixed α would over-flatten narrow roots and
+  under-perturb wide ones. `α = 10/k` keeps the expected noise mass per
+  candidate constant — the same reasoning behind AlphaZero's per-game α
+  (0.3 / 0.15 / 0.03 for chess / shogi / Go tracks ~10/⟨branching⟩).
+- **Rollout fallback inside PUCT vs behind the evaluator**: baking a
+  rollout branch into `puct.ts` would mean two leaf-evaluation code paths
+  to test and a gen-0/gen-N behavioral fork inside search. Keeping rollouts
+  as `RolloutEvaluator` ([12](12-evaluator-interface.md)) means the only
+  difference between generations is which evaluator is constructed. The one
+  cost worth documenting: the rollout `Rng` is the evaluator's, separate
+  from the search `Rng`, so seeds are reported as a pair in JSONL
+  provenance.

--- a/docs/trainer/14-selfplay-v2.md
+++ b/docs/trainer/14-selfplay-v2.md
@@ -12,35 +12,79 @@
 Self-play games recorded in a format the training pipeline can actually
 consume: complete policy-target support, O(steps) size, full provenance.
 
+## What v1 gets wrong (measured in the code)
+
+`agent/src/selfplay.ts` today stores, per decision, `commands: [...commands]`
+— a copy of the *entire prefix* — so a 214-step game serializes
+≈ 214²/2 ≈ 23k command copies (multi-MB lines, O(steps²)); and it records
+`res.visits` from `search()`, which covers only *expanded* edges
+(`root.edges` in `agent/src/mcts/search.ts`), silently dropping unexpanded
+curated candidates and breaking policy-target support. There is also no
+temperature or exploration noise: `chosen` is always the argmax.
+
 ## Design
 
-`agent/src/selfplay.ts` rewritten around PUCT + evaluator:
+`agent/src/selfplay.ts` rewritten around PUCT + evaluator (async now, since
+`puct()` awaits the evaluator):
 
-- **Temperature schedule**: sample the move ∝ `visits^(1/τ)` with τ = 1 for
-  the first ~30 decisions, then argmax. Root Dirichlet noise on
-  ([13](13-puct-search.md)).
-- **JSONL v2**, one game per line:
-
-```jsonc
-{
-  "v": 2,
-  "gameId": "…", "cfg": {…}, "seed": 123,
-  "netId": "rollout | gen-007",
-  "search": { "sims": 200, "cPuct": 1.5, "dirichlet": {…}, "tempMoves": 30 },
-  "commands": [["CONFIG",…], …],          // the whole game, replayable
-  "decisions": [{
-    "step": 12,                            // index into commands — no prefix copies
-    "perspective": 1,
-    "candidates": ["USE LR2 Jo", …],       // FULL canonical list (moveKey strings)
-    "visits": [120, 40, 0, …],             // aligned, zeros included
-    "chosen": 0
-  }],
-  "outcome": [1, 0], "finished": true, "steps": 214
-}
+```ts
+selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): Promise<SelfPlayGameV2>
+// opts: { sims, cPuct?, dirichlet?, tempMoves = 30, curation?, maxSteps = 8000 }
 ```
 
-Fixes v1's two data bugs: per-decision command-prefix copies (O(steps²)) and
-missing unexpanded candidates.
+- **Loop**: from `opening(cfg, seed)` (the `CONFIG`/`START` pair,
+  `agent/src/arena.ts`), while playing: `await puct(...)`; record a decision;
+  sample the move (below); `apply`; push onto `commands`. Stops on terminal,
+  `maxSteps`, or `best === undefined` (engine stall ⇒ `finished: false`).
+  Per-game `rng` derivation stays a pure function of `seed` (v1 uses
+  `mulberry32(seed * 7919 + 3)`), so a game is reproducible from its JSONL
+  line alone, independent of worker assignment.
+- **Temperature schedule**: for the first `tempMoves = 30` *decisions*,
+  sample `π(a) ∝ visits(a)^(1/τ)` with τ = 1 (i.e. sample proportional to
+  raw visits — one `rng()` draw against the cumulative sum); afterwards
+  τ → 0 (argmax, first-index tie-break). If a general τ is ever configured,
+  compute weights as `exp(ln n(a)/τ − max)` over `n(a) > 0` for numerical
+  stability. Root Dirichlet noise is on throughout self-play
+  ([13](13-puct-search.md)); both are off in arena play.
+- **Forced decisions** (`forced: true` from PUCT, single candidate) are
+  still recorded — visits `[sims]`, policy loss over a 1-way softmax is 0,
+  but the state row still feeds the value head in
+  [16](16-shard-exporter.md).
+- **Evaluator failure**: the rejection propagates out of `selfPlayGame`; a
+  game either produces one complete JSONL line or nothing (the worker CLI
+  catches, logs, and moves on — [15](15-selfplay-workers.md)).
+
+### JSONL v2 schema, one game per line
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `v` | `2` | schema version, first field, cheap to sniff |
+| `gameId` | `string` | `"g" + seed` — stable, dedupe-able across resumes |
+| `cfg` | `GameConfig` | `{ players, country, length, colors }` (`agent/src/arena.ts`) |
+| `seed` | `number` | opening + rng-derivation seed (see above) |
+| `netId` | `string` | `evaluator.id` — `"rollout"` or e.g. `"gen-007"` |
+| `search` | `object` | `{ sims, cPuct, dirichlet: {epsilon, alphaScale} \| null, tempMoves, curation: {maxPerLevel, maxMoves} }` |
+| `commands` | `string[][]` | the whole game incl. opening — replayable |
+| `decisions` | `Decision[]` | see below |
+| `outcome` | `number[]` | per-player [0,1] from `outcome()`; mid-game score-rank if unfinished |
+| `finished` | `boolean` | reached `GameStatusEnum.FINISHED` |
+| `steps` | `number` | decisions taken |
+
+`Decision`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `step` | `number` | index into `commands` of the chosen move — replay `commands[0..step)` to reconstruct the state; no prefix copies |
+| `perspective` | `number` | `playerToMove` at the decision (encode slot 0) |
+| `candidates` | `string[]` | FULL canonical list as `moveKey` strings ([10](10-move-canonicalization.md)), order = `adapter.legalMoves` |
+| `visits` | `number[]` | aligned to `candidates`, zeros included, sums to `sims` |
+| `q` | `number[]` | aligned per-candidate mover-Q from PUCT, rounded to 4 dp |
+| `chosen` | `number` | index into `candidates` of the played move; `commands[step]` ≡ `candidates[chosen].split(' ')` |
+| `forced` | `boolean?` | present-and-true only for single-candidate short-circuits |
+
+Size check: a 214-decision long game at median 18 candidates × ~14 chars plus
+two aligned number arrays is ~100–150 KB — linear in steps, versus multi-MB
+quadratic v1 lines.
 
 ## Inputs
 
@@ -48,14 +92,42 @@ missing unexpanded candidates.
 
 ## Outputs
 
-- `selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): SelfPlayGameV2`
+- `selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): Promise<SelfPlayGameV2>`
 - JSONL v2 lines (written by the worker CLI, [15](15-selfplay-workers.md)).
 
 ## How it runs / verification
 
 - `pnpm --dir agent test` —
-  - round-trip: replaying `commands` reproduces `outcome`; replaying
-    `commands[0..step)` yields a state whose `legalMoves` equals
-    `candidates` under the same caps and seed;
+  - round-trip: replaying `commands` reproduces `outcome`; for sampled
+    decisions, replaying `commands[0..step)` yields a state whose
+    `legalMoves` (same caps + seed) equals `candidates`, and
+    `candidates[chosen]` splits to `commands[step]`;
   - visits sum to sims at every decision;
+  - temperature: with a fixed seed, sampled indices match the visit CDF; after
+    `tempMoves`, chosen is always the argmax;
   - file size scales linearly with steps (regression guard vs v1).
+
+## Design notes & tradeoffs
+
+- **Full candidate list vs top-K truncation**: median cost is ~18 keys
+  ≈ 250 B/decision and the curation cap bounds the worst case at
+  128 × ~15 B ≈ 2 KB; a whole generation (≈2,000 games × ~100 KB) is
+  ~200 MB — disk is the cheapest resource in this pipeline. Top-K would
+  renormalize the visit mass over survivors, producing *biased* softmax
+  targets whose support no longer matches what the net will see at play
+  time, and it would break the `legalMoves ≡ candidates` replay invariant
+  the tests (and the exporter) lean on. Truncation belongs, if ever, in the
+  trainer's sampler — not in the durable archive.
+- **`moveKey` strings vs token arrays**: one string per candidate halves
+  the JSON overhead of an array of quoted tokens, is grep-able and directly
+  usable as a dedupe/map key, and `split(' ')` recovers tokens losslessly
+  because canonicalization ([10](10-move-canonicalization.md)) guarantees
+  single-space-joined tokens with no embedded spaces. Token arrays would
+  only re-encode the same information more verbosely.
+- **Storing `q` or not**: `q` is the one field not recoverable by replay —
+  it exists only inside the search that produced the game. It costs ~10% of
+  line size and buys post-hoc diagnostics (search-vs-outcome calibration,
+  blunder mining) and optional auxiliary value targets later. Since JSONL
+  is the *durable* archive and shards are disposable
+  ([16](16-shard-exporter.md)), we keep it: dropping an unused field later
+  is free, regretting a missing one costs a regeneration run at ~1–3 s/move.

--- a/docs/trainer/14-selfplay-v2.md
+++ b/docs/trainer/14-selfplay-v2.md
@@ -1,0 +1,61 @@
+# 14 — Self-play v2 (JSONL v2)
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [10](10-move-canonicalization.md), [13](13-puct-search.md) |
+| Milestone | M4 |
+
+## Goal
+
+Self-play games recorded in a format the training pipeline can actually
+consume: complete policy-target support, O(steps) size, full provenance.
+
+## Design
+
+`agent/src/selfplay.ts` rewritten around PUCT + evaluator:
+
+- **Temperature schedule**: sample the move ∝ `visits^(1/τ)` with τ = 1 for
+  the first ~30 decisions, then argmax. Root Dirichlet noise on
+  ([13](13-puct-search.md)).
+- **JSONL v2**, one game per line:
+
+```jsonc
+{
+  "v": 2,
+  "gameId": "…", "cfg": {…}, "seed": 123,
+  "netId": "rollout | gen-007",
+  "search": { "sims": 200, "cPuct": 1.5, "dirichlet": {…}, "tempMoves": 30 },
+  "commands": [["CONFIG",…], …],          // the whole game, replayable
+  "decisions": [{
+    "step": 12,                            // index into commands — no prefix copies
+    "perspective": 1,
+    "candidates": ["USE LR2 Jo", …],       // FULL canonical list (moveKey strings)
+    "visits": [120, 40, 0, …],             // aligned, zeros included
+    "chosen": 0
+  }],
+  "outcome": [1, 0], "finished": true, "steps": 214
+}
+```
+
+Fixes v1's two data bugs: per-decision command-prefix copies (O(steps²)) and
+missing unexpanded candidates.
+
+## Inputs
+
+- Adapter, evaluator, run config (game cfg, sims, temperature, noise), seeds.
+
+## Outputs
+
+- `selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): SelfPlayGameV2`
+- JSONL v2 lines (written by the worker CLI, [15](15-selfplay-workers.md)).
+
+## How it runs / verification
+
+- `pnpm --dir agent test` —
+  - round-trip: replaying `commands` reproduces `outcome`; replaying
+    `commands[0..step)` yields a state whose `legalMoves` equals
+    `candidates` under the same caps and seed;
+  - visits sum to sims at every decision;
+  - file size scales linearly with steps (regression guard vs v1).

--- a/docs/trainer/14-selfplay-v2.md
+++ b/docs/trainer/14-selfplay-v2.md
@@ -60,7 +60,7 @@ selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): Promise<SelfPlayGameV2>
 | --- | --- | --- |
 | `v` | `2` | schema version, first field, cheap to sniff |
 | `gameId` | `string` | `"g" + seed` — stable, dedupe-able across resumes |
-| `cfg` | `GameConfig` | `{ players, country, length, colors }` (`agent/src/arena.ts`) |
+| `cfg` | `GameConfig` | `{ players, country, length, colors }` (`agent/src/arena.ts`) — per game, so one generation's files mix configs freely (the run config's weighted mix, [15](15-selfplay-workers.md)); solo games label `outcome` with the σ((score−500)/100) mapping from [09](09-game-adapter.md) |
 | `seed` | `number` | opening + rng-derivation seed (see above) |
 | `netId` | `string` | `evaluator.id` — `"rollout"` or e.g. `"gen-007"` |
 | `search` | `object` | `{ sims, cPuct, dirichlet: {epsilon, alphaScale} \| null, tempMoves, curation: {maxPerLevel, maxMoves} }` |

--- a/docs/trainer/15-selfplay-workers.md
+++ b/docs/trainer/15-selfplay-workers.md
@@ -14,23 +14,72 @@ resume-by-default so an interrupted overnight job loses nothing.
 
 ## Design
 
-- `agent/src/cli/selfplay.ts` rewritten around run dirs (the v1 positional
-  form keeps working during transition):
+`agent/src/cli/selfplay.ts` rewritten around run dirs (the v1 positional
+form `pnpm --dir agent selfplay [games] [short|long] [sims]` keeps working
+during transition):
 
 ```sh
 pnpm --dir agent selfplay --run runs/r1 --gen 3 --games 500 --workers 12 \
   [--net runs/r1/best.onnx] [--sims 200]
 ```
 
-- `worker_threads` pool; each worker owns its own evaluator instance
-  (RolloutEvaluator when `--net` is absent ⇒ gen-0 needs no new concepts;
-  OnnxEvaluator per [21](21-onnx-evaluator.md) when present) and appends to
-  its own `gen-NNN/selfplay/worker-K.jsonl` (no write contention).
-- Seeds: `baseSeed + gameIndex`, assigned by a main-thread dispenser —
-  deterministic set of games regardless of worker count.
-- **Resume**: on start, count existing JSONL lines across workers and only
-  generate the remainder. Rerunning the same command is the resume story.
-- Progress: one status line per N games (games/hr, avg steps, avg ms/move).
+Flags default from `runs/<id>/config.json`; CLI overrides win. Output goes
+to `runs/<id>/gen-NNN/selfplay/worker-K.jsonl`.
+
+### Worker mechanics
+
+- `worker_threads`: main spawns `--workers` module workers via
+  `new Worker(new URL('../selfplayWorker.ts', import.meta.url),
+  { workerData: { workerIndex, runCfg }, execArgv: process.execArgv })`.
+  The package runs everything through `node --import tsx/esm`
+  (`agent/package.json` scripts), and workers inherit `execArgv`, so the
+  tsx loader resolves the `.ts` worker file in dev; a compiled-JS deployment
+  needs no change because the `URL` resolves relative to the emitted module.
+- Each worker owns its own **evaluator instance** — `RolloutEvaluator` when
+  `--net` is absent (gen-0 needs no new concepts) or `OnnxEvaluator` with a
+  private `InferenceSession` per [21](21-onnx-evaluator.md) — plus its own
+  scratch buffers. Nothing search-related is shared across threads.
+- Each worker **appends to its own file**: one
+  `appendFileSync(path, line + '\n')` per finished game, whole line in a
+  single write. Game payloads never cross the thread boundary — only small
+  status messages do.
+
+### Seed-dispenser protocol (main ⇄ worker)
+
+| Direction | Message | Meaning |
+| --- | --- | --- |
+| worker → main | `{ type: 'ready' }` | evaluator constructed, ask for work |
+| main → worker | `{ type: 'game', gameIndex, seed }` | play & write one game |
+| worker → main | `{ type: 'done', gameIndex, seed, steps, finished, ms }` | line appended; send next |
+| worker → main | `{ type: 'error', gameIndex, seed, message }` | game abandoned (e.g. evaluator failure); nothing written; send next |
+| main → worker | `{ type: 'stop' }` | drain and exit |
+
+Seeds are `baseSeed + gameIndex` for `gameIndex ∈ [0, games)`, `baseSeed`
+from config (default `gen * 1_000_000`). The *set* of games is therefore
+fixed by the target count alone; the dispenser hands out the lowest
+not-yet-done index on every `ready`/`done`, so assignment is
+work-stealing while the corpus stays deterministic
+([14](14-selfplay-v2.md) makes each game a pure function of its seed).
+
+### Resume protocol
+
+On start, scan `gen-NNN/selfplay/worker-*.jsonl`: parse each line's `seed`
+(and `v`), building the completed-seed set. A truncated final line (crash
+mid-append) is detected by JSON parse failure, logged, truncated off the
+file, and its seed simply regenerated. The dispenser then skips completed
+indices — rerunning the same command *is* the resume story, and finishing
+early (count already met) is a no-op that just advances `STATE`.
+
+### Failure & progress
+
+- **Worker crash** (`exit` with nonzero code / `error` event): its in-flight
+  `gameIndex` returns to the dispenser and a replacement worker is spawned;
+  after 3 crashes total the run aborts nonzero (a systematic bug, not a
+  blip). Repeated `{type:'error'}` games (say >1% of target) also abort.
+- **Progress**: main aggregates `done` messages and prints one status line
+  per N games — done/target, games/hr, avg steps, avg ms/move, ETA.
+- When the target count is reached: workers get `stop`, main writes the
+  `STATE` marker → `selfplay` (run layout in the [README](README.md)).
 
 ## Inputs
 
@@ -44,6 +93,45 @@ pnpm --dir agent selfplay --run runs/r1 --gen 3 --games 500 --workers 12 \
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — seed dispenser determinism; resume counting.
+- `pnpm --dir agent test` — seed dispenser determinism (same target ⇒ same
+  seed set regardless of worker count); resume counting incl. the
+  truncated-final-line case; crash-requeue logic (unit-tested around the
+  dispenser, no real threads needed).
 - Manual: run with `--games 8 --workers 2`, kill mid-way, rerun, verify
-  exactly 8 games and no duplicate seeds.
+  exactly 8 games across the files and no duplicate seeds.
+
+## Design notes & tradeoffs
+
+- **`worker_threads` vs child processes vs single-threaded async**: search
+  is CPU-bound synchronous JS (engine `control()` calls dominate,
+  [README](README.md) risk section), so single-threaded async parallelizes
+  nothing — there is no I/O wait to overlap. Child processes would work
+  (each V8 isolate is separate either way, so no JIT/heap sharing is lost),
+  but threads spawn cheaper, keep one PID/one Ctrl-C, give typed
+  `postMessage` instead of hand-rolled stdio framing, and leave
+  `SharedArrayBuffer` open as a zero-copy option if Stage-2 batching ever
+  wants to ship tensors to a coordinator. `onnxruntime-node` supports a
+  session per thread, so [21](21-onnx-evaluator.md) fits unchanged.
+- **Per-worker files vs a single writer**: a single writer means every
+  ~100 KB game line is structured-clone-copied over `postMessage` to a
+  main-thread bottleneck, and every crash risk concentrates in one file's
+  tail. Per-worker append has zero contention, a blast radius of one
+  file's final line, and costs only that the exporter globs
+  `worker-*.jsonl` (which [16](16-shard-exporter.md) does anyway). Game
+  order interleaves across files — irrelevant, training shuffles decisions.
+- **Deterministic seed dispenser vs pure work-stealing throughput**: a
+  static partition (worker k takes indices ≡ k mod m) is deterministic down
+  to file placement but strands cores behind whichever worker draws the
+  long games (game length varies ~2×). Pure work-stealing with
+  "generate until count" would make the *seed set* depend on timing. The
+  hybrid — fixed seed set, dynamic assignment — gets full utilization and a
+  reproducible corpus; only which file a game lands in varies, and nothing
+  downstream keys on that.
+- **Resume by scanning JSONL vs a manifest**: a manifest (count/index file)
+  is a second source of truth that can disagree with the data after a
+  crash — whichever of (data line, manifest update) wasn't flushed wins,
+  and both orders are wrong in one failure mode. The JSONL files *are* the
+  ground truth; scanning a generation (≤ a few hundred MB) takes seconds at
+  startup and cannot desync. If gens grow to many GB, add a per-file cache
+  of `{size, mtime, seeds}` as a pure optimization over the same protocol —
+  still no authority handed to a side file.

--- a/docs/trainer/15-selfplay-workers.md
+++ b/docs/trainer/15-selfplay-workers.md
@@ -1,0 +1,49 @@
+# 15 — Worker-pool self-play CLI
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [14](14-selfplay-v2.md) |
+| Milestone | M4 |
+
+## Goal
+
+Saturate all CPU cores generating self-play games into a run directory, with
+resume-by-default so an interrupted overnight job loses nothing.
+
+## Design
+
+- `agent/src/cli/selfplay.ts` rewritten around run dirs (the v1 positional
+  form keeps working during transition):
+
+```sh
+pnpm --dir agent selfplay --run runs/r1 --gen 3 --games 500 --workers 12 \
+  [--net runs/r1/best.onnx] [--sims 200]
+```
+
+- `worker_threads` pool; each worker owns its own evaluator instance
+  (RolloutEvaluator when `--net` is absent ⇒ gen-0 needs no new concepts;
+  OnnxEvaluator per [21](21-onnx-evaluator.md) when present) and appends to
+  its own `gen-NNN/selfplay/worker-K.jsonl` (no write contention).
+- Seeds: `baseSeed + gameIndex`, assigned by a main-thread dispenser —
+  deterministic set of games regardless of worker count.
+- **Resume**: on start, count existing JSONL lines across workers and only
+  generate the remainder. Rerunning the same command is the resume story.
+- Progress: one status line per N games (games/hr, avg steps, avg ms/move).
+
+## Inputs
+
+- `runs/<id>/config.json` (game cfg + search params), `--gen`, `--games`,
+  `--workers`, optional `--net` ONNX path.
+
+## Outputs
+
+- `runs/<id>/gen-NNN/selfplay/worker-*.jsonl` (JSONL v2), and the `STATE`
+  marker advanced to `selfplay` when the target count is reached.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — seed dispenser determinism; resume counting.
+- Manual: run with `--games 8 --workers 2`, kill mid-way, rerun, verify
+  exactly 8 games and no duplicate seeds.

--- a/docs/trainer/15-selfplay-workers.md
+++ b/docs/trainer/15-selfplay-workers.md
@@ -55,11 +55,15 @@ to `runs/<id>/gen-NNN/selfplay/worker-K.jsonl`.
 | main → worker | `{ type: 'stop' }` | drain and exit |
 
 Seeds are `baseSeed + gameIndex` for `gameIndex ∈ [0, games)`, `baseSeed`
-from config (default `gen * 1_000_000`). The *set* of games is therefore
-fixed by the target count alone; the dispenser hands out the lowest
-not-yet-done index on every `ready`/`done`, so assignment is
-work-stealing while the corpus stays deterministic
-([14](14-selfplay-v2.md) makes each game a pure function of its seed).
+from config (default `gen * 1_000_000`). Each `game` message also carries a
+`cfg`: the run config's `game` field is a **weighted config mix** (e.g. all
+16 player-count × length × country combinations, weighted toward the configs
+that matter most right now), and `gameIndex` maps to a cfg by deterministic
+weighted round-robin — so the *set* of (seed, cfg) games is fixed by the
+target count alone. The dispenser hands out the lowest not-yet-done index on
+every `ready`/`done`, so assignment is work-stealing while the corpus stays
+deterministic ([14](14-selfplay-v2.md) makes each game a pure function of
+its seed and cfg, and each JSONL line records its own `cfg`).
 
 ### Resume protocol
 

--- a/docs/trainer/16-shard-exporter.md
+++ b/docs/trainer/16-shard-exporter.md
@@ -14,33 +14,195 @@ Python cannot run the TS engine, so all replay + encoding happens here.
 
 ## Design
 
-- **JSONL is the durable archive; shards are disposable.** Regenerated per
-  training run, pruned after gating — an encoder/actionSpec version bump never
-  strands data (re-export is a replay away).
-- `agent/src/npy.ts`: minimal `.npy` writer (the format is a ~128-byte header
-  + raw little-endian data; trivially emitted from Node, memory-mappable by
-  numpy with zero extra Python deps).
-- `agent/src/cli/export.ts`: replay each game once, and at each decision
-  `encodeInto` the state and `encodeMove` every candidate into preallocated
-  buffers. Shards of 4,096 decisions:
+**JSONL is the durable archive; shards are disposable.** Regenerated per
+training run, pruned after gating — an encoder/actionSpec version bump never
+strands data (re-export is a replay away).
+
+### Dimensions (recomputed from `game/src/encode.ts`)
+
+`FEATURE_LEN = 14,670`: 4 player blocks of 3,455 (35 scalars — 22 resources +
+1 wonders + 4 clergy buckets + 8 settlement types — plus a 38×9×10 grid =
+3,420) + frame 549 + shared 301. Block offsets: players at
+`[0, 3455, 6910, 10365]`, frame at 13,820, shared at 14,369. One f16 state row
+is 29,340 bytes (~28.7 KiB). `moveFeatureLen ≈ 90` per
+[11](11-action-encoder.md) (14 command + 1 erection id + 9 col + 38 row + 22
+resources + ~6 scalars).
+
+### Shard directory layout
+
+Shards of 4,096 decisions, zero-padded sequence names:
 
 ```
 gen-NNN/shards/shard-00042/
-  states.npy        [N, featureLen]      float16   (~29 KB/row)
-  values.npy        [N, maxPlayers]      float32   (outcome rotated: slot0 = perspective)
-  value_mask.npy    [N, maxPlayers]      uint8     (live seats)
-  cand_feats.npy    [M, moveFeatureLen]  float16   (ragged concat)
-  cand_offsets.npy  [N+1]                int64     (prefix sums into M)
-  policy.npy        [M]                  float32   (visit fractions, normalized)
-  chosen.npy        [N]                  int32
-  meta.json         { featureSpecVersion, actionSpecVersion, featureLen,
-                      moveFeatureLen, games, decisions, netId }
+  states.npy        [N, 14670]           <f2   (~28.7 KiB/row)
+  values.npy        [N, maxPlayers=4]    <f4   (outcome rotated: slot0 = perspective)
+  value_mask.npy    [N, 4]               |u1   (live seats)
+  cand_feats.npy    [M, moveFeatureLen]  <f2   (ragged concat)
+  cand_offsets.npy  [N+1]                <i8   (prefix sums into M; offsets[0]=0)
+  policy.npy        [M]                  <f4   (visit fractions, sum to 1 per slice)
+  chosen.npy        [N]                  <i4   (index into the decision's slice)
+  meta.json         { featureSpecVersion, actionSpecVersion, featureLen: 14670,
+                      moveFeatureLen, rows, cands, games, netId, exporterGitSha }
 ```
 
-- Sizing at first-config scale: ~250–350 decisions/game × 500–2,000 games/gen
-  → ~4–20 GB f16 per generation. Fine to hold transiently, wasteful to keep.
-- Optional later: 2× value-only augmentation by re-encoding each state from
-  the non-mover's perspective (policy loss masked for those rows).
+Sizing at first-config scale: ~250–350 decisions/game × 500–2,000 games/gen →
+125k–700k rows → ~4–21 GB of f16 states per generation (states dominate;
+candidates add ~10–15%). Fine to hold transiently, wasteful to keep.
+
+### `agent/src/npy.ts` — minimal .npy writer
+
+The v1.0 format is: magic `\x93NUMPY` (6 bytes) · version `\x01\x00` ·
+`HEADER_LEN` as uint16 LE · an ASCII Python-dict literal, space-padded so
+`10 + HEADER_LEN` is a multiple of 64, with a final `\n`. Example header dict:
+
+```
+{'descr': '<f2', 'fortran_order': False, 'shape': (4096, 14670), }
+```
+
+Data follows as raw little-endian bytes, C-order. numpy mmaps it with zero
+extra deps. API:
+
+```ts
+export type NpyDtype = '<f2' | '<f4' | '<i4' | '<i8' | '|u1'
+export const npyHeader = (dtype: NpyDtype, shape: number[]): Buffer
+export const writeNpySync = (path: string, dtype: NpyDtype, shape: number[], data: NodeJS.ArrayBufferView): void
+```
+
+### f32 → f16 conversion
+
+JS has no native f16 array (until `Float16Array` is everywhere); convert
+explicitly, `Float32Array` → `Uint16Array`, round-to-nearest-even:
+
+```ts
+const f32 = new Float32Array(1)
+const u32 = new Uint32Array(f32.buffer)
+export const f16bits = (v: number): number => {
+  f32[0] = v
+  const x = u32[0]
+  const sign = (x >>> 16) & 0x8000
+  const exp = (x >>> 23) & 0xff
+  let mant = x & 0x7fffff
+  if (exp === 0xff) return sign | 0x7c00 | (mant ? 0x200 : 0) // Inf / NaN
+  const e = exp - 127 + 15 // rebias
+  if (e >= 0x1f) return sign | 0x7c00 // overflow → Inf
+  if (e <= 0) {
+    if (e < -10) return sign // underflow → signed zero
+    mant |= 0x800000 // make the implicit 1 explicit; shift into subnormal
+    const shift = 14 - e
+    const h = mant >>> shift
+    const rem = mant & ((1 << shift) - 1)
+    const half = 1 << (shift - 1)
+    return sign | (rem > half || (rem === half && h & 1) ? h + 1 : h)
+  }
+  const h = sign | (e << 10) | (mant >>> 13)
+  const rem = mant & 0x1fff
+  return rem > 0x1000 || (rem === 0x1000 && h & 1) ? h + 1 : h // RNE; carry into exponent is still correct
+}
+```
+
+Golden vectors for the unit test: `1.0 → 0x3C00`, `-2.0 → 0xC000`,
+`65504 → 0x7BFF`, `65520 → 0x7C00` (Inf), `2049 → 0x6800` (ties-to-even →
+2048), `1/13 → 0x2CEC`, `NaN → 0x7E00`, `-0 → 0x8000`.
+
+### Replay & encode loop — `agent/src/cli/export.ts`
+
+```ts
+type ExportOpts = { run: string; gen: number; shardRows?: number /* 4096 */ }
+export const exportGen = (opts: ExportOpts): Promise<{ rows: number; shards: number }>
+```
+
+Per JSONL v2 game ([14](14-selfplay-v2.md)): decisions carry `step` (index
+into `commands`) and the **full** canonical candidate list, so no search or
+`legalMoves` rerun is needed — just one incremental replay cursor:
+
+```ts
+for (const game of jsonlLines(file)) {
+  let state = initialState; let step = 0
+  for (const dec of game.decisions) {
+    while (step < dec.step) state = apply(state, game.commands[step++])!
+    adapter.encodeInto(state, dec.perspective, stateScratch)      // Float32 scratch
+    f16Into(stateScratch, shard.stateRow())                       // → Uint16 shard buf
+    for (const key of dec.candidates)
+      adapter.encodeMove(state, dec.perspective, parseMoveKey(key), shard.candRow())
+    shard.pushTargets(rotateOutcome(game.outcome, dec.perspective), normalize(dec.visits), dec.chosen)
+    if (shard.rows === opts.shardRows) shard.flush()
+  }
+}
+```
+
+Buffers are preallocated per shard (`Uint16Array(4096 × 14670)` ≈ 115 MiB
+etc.); the last partial shard flushes at end. `parseMoveKey` is the canonical
+moveKey → `Move` parser from [10](10-move-canonicalization.md).
+
+**Value-target rotation** — the JSONL `outcome` is seat-indexed; states are
+egocentric (encoder slot 0 = perspective), so values must rotate identically
+to `encode.ts`'s `rotateOrder`:
+
+```
+values[slot]     = slot < P ? outcome[(perspective + slot) % P] : 0   // P = numPlayers
+value_mask[slot] = slot < P ? 1 : 0                                   // slot in 0..3
+```
+
+**Policy** — `policy[i] = visits[i] / Σ visits` over the decision's slice
+(sims > 0 guarantees the sum is positive); `chosen` is copied through as the
+slice-local index.
+
+### Atomic write & idempotency
+
+Each shard is assembled in `shards/.tmp-shard-00042-<pid>/`, files fsynced,
+`meta.json` written last, then the directory `fs.rename`d to
+`shard-00042/` — a rename on the same filesystem is atomic, so a crash never
+leaves a half-shard with a valid name. On start the exporter deletes any
+`.tmp-*` leftovers and any existing `shard-*` for the gen (export is
+regenerate-from-scratch, so rerun-after-crash is safe). `STATE` →
+`exported` only after the final rename.
+
+### Throughput estimate
+
+Per decision: one `apply` (~0.1–0.5 ms with the [07](07-engine-fast-paths.md)
+fast paths — the dominant cost), one `encodeInto` (~20 µs), 14,670 f16
+conversions (~15 µs), ~18 (median) candidate encodes (~10 µs). Call it
+0.2–0.7 ms/decision single-threaded → 600k decisions ≈ 2–7 minutes plus
+~20 GB of sequential writes (NVMe-trivial). Single process first; fan out
+over JSONL files with workers only if [08](08-benchmarks.md) shows it matters.
+
+Optional later: 2× value-only augmentation by re-encoding each state from the
+non-mover's perspective (policy loss masked for those rows).
+
+## Design notes & tradeoffs
+
+- **.npy vs safetensors vs parquet vs raw+index.** `.npy` wins on both ends:
+  ~60 lines of Node to write, `np.load(mmap_mode='r')` to read, no schema
+  library on either side. safetensors would need a JS writer dep and buys
+  features (single file, named tensors) we don't need across seven small
+  arrays. Parquet is row-group/columnar machinery for tabular data — wrong
+  shape for dense tensors and heavy on the Node side. Raw bytes + a JSON index
+  is basically .npy minus the self-describing header, i.e. strictly worse.
+- **f16 states vs f32.** Audit of what the encoder actually writes: one-hots
+  and masks (exact in f16); normalized rondel deltas/yields in [0,1] (f16 has
+  ~10 bits of mantissa → error ≤ 5e-4, irrelevant to a net); raw integer
+  counts — resources, wonders, clergy buckets, prices, round number, erection
+  ids ≤ 80. f16 represents integers exactly up to 2,048; no OeL quantity
+  plausibly approaches that (a hoarding player might reach a few hundred
+  coins). So f16 halves 20 GB of states at zero effective loss. Targets
+  (`values`, `policy`) stay f32: they're tiny and it keeps loss math exact.
+- **Regenerated per run vs archived.** Regenerate. Shards are a pure function
+  of (JSONL, featureSpec, actionSpec); archiving them means versioning them,
+  and 20 GB/gen × dozens of gens is real disk for zero information. The
+  orchestrator ([23](23-orchestrator.md)) prunes them after gating.
+- **4,096-row shards vs bigger.** 4,096 rows ≈ 115 MiB of states — big enough
+  that header/inode overhead vanishes and sequential read is long, small
+  enough that (a) the writer's preallocated buffer stays modest, (b) an
+  atomic-rename unit is quick, and (c) shard-granularity shuffling
+  ([17](17-trainer-scaffold.md)) still mixes ~150 shards per generation.
+  1M-row shards would pin GB-scale buffers and reduce shuffle granularity to
+  a handful of units.
+- **Ragged concat + offsets vs padded `[N, maxCands]`.** Median branching is
+  18, curation caps at ~128. Padded at the cap: 4,096 × 128 × 90 × 2 B ≈
+  94 MiB/shard, >85% zeros. Ragged at the mean: 4,096 × ~18 × 90 × 2 B ≈
+  13 MiB — a ~7× saving, and the offsets array is 32 KiB. The cost is a
+  segment-aware model/loss ([18](18-model.md)), which we need anyway for
+  variable candidate counts at inference.
 
 ## Inputs
 
@@ -57,7 +219,11 @@ gen-NNN/shards/shard-00042/
 pnpm --dir agent export --run runs/r1 --gen 3
 ```
 
-- `pnpm --dir agent test` — npy writer golden bytes; offsets/policy
-  normalization invariants.
+- `pnpm --dir agent test` — npy writer golden bytes (header for a known
+  dtype/shape byte-for-byte); `f16bits` golden vectors above; offsets are
+  monotone with `offsets[N] = M`; every policy slice sums to 1 ± 1e-6;
+  rotation invariant `values[0] === outcome[perspective]`.
 - Cross-language: Python (`trainer/tests/`) mmaps a Node-written shard and
   asserts bit-exact values on a golden decision ([17](17-trainer-scaffold.md)).
+- Crash-safety: kill mid-export, rerun, assert no `.tmp-*` residue and shard
+  count/contents identical to an uninterrupted run.

--- a/docs/trainer/16-shard-exporter.md
+++ b/docs/trainer/16-shard-exporter.md
@@ -1,0 +1,63 @@
+# 16 — Tensor shard exporter
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [07](07-engine-fast-paths.md), [11](11-action-encoder.md), [14](14-selfplay-v2.md) |
+| Milestone | M5 |
+
+## Goal
+
+Bridge Node → Python: turn JSONL games into numpy-readable tensor shards.
+Python cannot run the TS engine, so all replay + encoding happens here.
+
+## Design
+
+- **JSONL is the durable archive; shards are disposable.** Regenerated per
+  training run, pruned after gating — an encoder/actionSpec version bump never
+  strands data (re-export is a replay away).
+- `agent/src/npy.ts`: minimal `.npy` writer (the format is a ~128-byte header
+  + raw little-endian data; trivially emitted from Node, memory-mappable by
+  numpy with zero extra Python deps).
+- `agent/src/cli/export.ts`: replay each game once, and at each decision
+  `encodeInto` the state and `encodeMove` every candidate into preallocated
+  buffers. Shards of 4,096 decisions:
+
+```
+gen-NNN/shards/shard-00042/
+  states.npy        [N, featureLen]      float16   (~29 KB/row)
+  values.npy        [N, maxPlayers]      float32   (outcome rotated: slot0 = perspective)
+  value_mask.npy    [N, maxPlayers]      uint8     (live seats)
+  cand_feats.npy    [M, moveFeatureLen]  float16   (ragged concat)
+  cand_offsets.npy  [N+1]                int64     (prefix sums into M)
+  policy.npy        [M]                  float32   (visit fractions, normalized)
+  chosen.npy        [N]                  int32
+  meta.json         { featureSpecVersion, actionSpecVersion, featureLen,
+                      moveFeatureLen, games, decisions, netId }
+```
+
+- Sizing at first-config scale: ~250–350 decisions/game × 500–2,000 games/gen
+  → ~4–20 GB f16 per generation. Fine to hold transiently, wasteful to keep.
+- Optional later: 2× value-only augmentation by re-encoding each state from
+  the non-mover's perspective (policy loss masked for those rows).
+
+## Inputs
+
+- `gen-NNN/selfplay/*.jsonl` (v2); the OeL adapter's `encodeState` /
+  `encodeMove` / specs.
+
+## Outputs
+
+- `gen-NNN/shards/shard-*/` as above; `STATE` marker → `exported`.
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent export --run runs/r1 --gen 3
+```
+
+- `pnpm --dir agent test` — npy writer golden bytes; offsets/policy
+  normalization invariants.
+- Cross-language: Python (`trainer/tests/`) mmaps a Node-written shard and
+  asserts bit-exact values on a golden decision ([17](17-trainer-scaffold.md)).

--- a/docs/trainer/17-trainer-scaffold.md
+++ b/docs/trainer/17-trainer-scaffold.md
@@ -1,0 +1,57 @@
+# 17 — Trainer scaffold (Python / uv)
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `trainer/` (new top-level dir, not in pnpm workspace) |
+| Depends on | [16](16-shard-exporter.md) |
+| Milestone | M5 |
+
+## Goal
+
+A uv-managed Python package that loads shards and stands up the device
+story: same code on ROCm (the RX 7800 XT), CUDA (rented), and CPU.
+
+## Design
+
+```
+trainer/
+  pyproject.toml         # deps: torch, numpy, onnx; dev: onnxruntime, pytest
+  uv.lock
+  src/hathora_trainer/
+    data.py              # ShardDataset: mmap npy, ragged candidate batching
+    device.py            # --device auto|cpu|cuda (ROCm masquerades as cuda)
+    check_gpu.py         # prints torch version, device, and a tiny matmul benchmark
+    model.py train.py export_onnx.py   # projects 18–20
+  tests/
+```
+
+- Console scripts: `oel-train`, `oel-export-onnx`, `oel-check-gpu`.
+- `data.py`: memory-map every `.npy` in a shard list; batches carry
+  `(states, values, value_mask, cand_feats, cand_offsets, policy)`; a custom
+  collate packs ragged candidates via offsets (segment ops in the model, no
+  padding waste).
+- Version guard: refuse to train if `meta.json`'s
+  featureSpec/actionSpec versions differ across shards or from a resumed
+  checkpoint.
+- Torch install extras: `rocm` (ROCm wheel index), `cu12` (CUDA index),
+  default CPU — the ≤$50 cloud path is `uv sync --extra cu12` on the same
+  rsynced run dir.
+
+## Inputs
+
+- `gen-NNN/shards/` from [16](16-shard-exporter.md); `spec.json`
+  (featureSpec + actionSpec).
+
+## Outputs
+
+- Importable `hathora_trainer` package; a working `DataLoader` over shards;
+  `oel-check-gpu` diagnostics.
+
+## How it runs / verification
+
+```sh
+cd trainer && uv sync
+uv run oel-check-gpu                       # device visible, matmul runs
+uv run pytest                              # incl. Node-shard bit-exact read test
+```

--- a/docs/trainer/17-trainer-scaffold.md
+++ b/docs/trainer/17-trainer-scaffold.md
@@ -14,29 +14,181 @@ story: same code on ROCm (the RX 7800 XT), CUDA (rented), and CPU.
 
 ## Design
 
+### Placement in the repo
+
+`pnpm-workspace.yaml` lists only `game` and `agent`; `web/` already sets the
+precedent of a top-level dir that is deliberately **not** a workspace member.
+`trainer/` follows it — pnpm never sees it, `uv` owns it entirely. Repo-root
+`.gitignore` additions: `.venv`, `__pycache__`, `*.egg-info`, and `runs/`
+(run dirs are data, shared with the Node side, never committed). `uv.lock`
+**is** committed — it is the Python `pnpm-lock.yaml`.
+
 ```
 trainer/
-  pyproject.toml         # deps: torch, numpy, onnx; dev: onnxruntime, pytest
+  pyproject.toml
   uv.lock
   src/hathora_trainer/
-    data.py              # ShardDataset: mmap npy, ragged candidate batching
-    device.py            # --device auto|cpu|cuda (ROCm masquerades as cuda)
-    check_gpu.py         # prints torch version, device, and a tiny matmul benchmark
-    model.py train.py export_onnx.py   # projects 18–20
+    __init__.py
+    spec.py              # load + validate spec.json (featureSpec/actionSpec)
+    data.py              # ShardDataset, collate, window discovery, version guard
+    device.py            # resolve('auto' | 'cpu' | 'cuda') -> torch.device
+    check_gpu.py         # oel-check-gpu entry point
+    model.py             # project 18
+    train.py             # project 19
+    export_onnx.py       # project 20
   tests/
+    fixtures/            # one tiny Node-exported shard, checked in (~2 MB)
+    test_data.py         # bit-exact shard read, collate invariants
+    test_model.py test_train.py test_onnx.py   # projects 18–20
 ```
 
-- Console scripts: `oel-train`, `oel-export-onnx`, `oel-check-gpu`.
-- `data.py`: memory-map every `.npy` in a shard list; batches carry
-  `(states, values, value_mask, cand_feats, cand_offsets, policy)`; a custom
-  collate packs ragged candidates via offsets (segment ops in the model, no
-  padding waste).
-- Version guard: refuse to train if `meta.json`'s
-  featureSpec/actionSpec versions differ across shards or from a resumed
-  checkpoint.
-- Torch install extras: `rocm` (ROCm wheel index), `cu12` (CUDA index),
-  default CPU — the ≤$50 cloud path is `uv sync --extra cu12` on the same
-  rsynced run dir.
+### `pyproject.toml` (written out)
+
+The torch extras follow uv's documented PyTorch pattern: three mutually
+exclusive extras, each pinning `torch` to a dedicated wheel index.
+
+```toml
+[project]
+name = "hathora-trainer"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["numpy>=2.0", "onnx>=1.16"]
+
+[project.optional-dependencies]
+cpu   = ["torch>=2.5"]
+rocm  = ["torch>=2.5"]
+cu12  = ["torch>=2.5"]
+
+[project.scripts]
+oel-train       = "hathora_trainer.train:main"
+oel-export-onnx = "hathora_trainer.export_onnx:main"
+oel-check-gpu   = "hathora_trainer.check_gpu:main"
+
+[dependency-groups]
+dev = ["pytest>=8", "onnxruntime>=1.18"]
+
+[tool.uv]
+conflicts = [[{ extra = "cpu" }, { extra = "rocm" }, { extra = "cu12" }]]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cpu",  extra = "cpu" },
+  { index = "pytorch-rocm", extra = "rocm" },
+  { index = "pytorch-cu12", extra = "cu12" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-rocm"
+url = "https://download.pytorch.org/whl/rocm6.2"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu12"
+url = "https://download.pytorch.org/whl/cu124"
+explicit = true
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+`uv sync --extra rocm` on the 7800 XT box ([25](25-rocm-runbook.md));
+`uv sync --extra cu12` on a rental; `uv sync --extra cpu` in CI. The exact
+`rocm6.x`/`cu12x` index suffixes get pinned when 25 is executed.
+
+### `data.py` — ShardDataset
+
+Shard files ([16](16-shard-exporter.md)) are opened with
+`np.load(path, mmap_mode='r')` — zero-copy, lazy, OS page cache does the
+work. One dataset item = one decision row.
+
+```python
+@dataclass
+class Shard:
+    states: np.memmap        # [N, 14670] f16
+    values: np.memmap        # [N, 4] f32
+    value_mask: np.memmap    # [N, 4] u1
+    cand_feats: np.memmap    # [M, moveFeatureLen] f16
+    cand_offsets: np.ndarray # [N+1] i64 (small; load eagerly)
+    policy: np.memmap        # [M] f32
+    chosen: np.memmap        # [N] i32
+    meta: dict
+
+def discover(run: Path, gen: int, window: int) -> list[Path]  # shard dirs, last K gens
+def load_shard(d: Path) -> Shard
+
+class ShardDataset(torch.utils.data.Dataset):
+    def __init__(self, dirs: list[Path]): ...   # cumulative row index across shards
+    def __len__(self) -> int
+    def __getitem__(self, i) -> Row              # numpy views, no copies yet
+
+def collate(rows: list[Row]) -> Batch
+    # states:      f16 -> torch.float32  [B, 14670]
+    # values/mask:                        [B, 4]
+    # cand_feats:  np.concatenate -> f32  [Mb, moveFeatureLen]  (ragged)
+    # cand_counts: i64                    [B]   (offsets rebuilt batch-locally)
+    # policy:      f32                    [Mb]
+    # chosen:      i64                    [B]  (slice-local index)
+```
+
+The collate is where ragged happens: candidate slices are concatenated in
+batch order and `cand_counts` carries the segment structure; the model
+([18](18-model.md)) turns counts into segment ids. States upcast f16→f32 at
+collate time (CPU convs/gemms want f32; the copy is per-batch, not per-epoch).
+
+Shuffling: `DataLoader(shuffle=True)` over the row index is correct but
+random-access across ~20 GB of mmap causes page-fault storms on cold cache.
+Default: shuffle shard order per epoch + shuffle rows *within* each shard,
+reading shards mostly sequentially (an `IterableDataset` variant with a
+small cross-shard mixing buffer, e.g. 8 shards ≈ 32k rows). Row-level global
+shuffle stays available behind `--shuffle rows` for small windows.
+
+### Version guard
+
+```python
+def assert_compatible(shard_metas: list[dict], spec: Spec, ckpt_meta: dict | None) -> None
+```
+
+Every shard's `meta.json` must agree on `featureSpecVersion`,
+`actionSpecVersion`, `featureLen` (14,670) and `moveFeatureLen` — with each
+other, with `spec.json`, and with a resumed checkpoint's recorded versions.
+Any mismatch aborts with a message naming the offending shard; silently
+training across an encoder change is the worst bug class this pipeline can
+have.
+
+### `device.py` / `check_gpu.py`
+
+`resolve('auto')` → `cuda` if `torch.cuda.is_available()` else `cpu` — ROCm
+torch masquerades as `cuda`, so nothing is ROCm-specific here.
+`oel-check-gpu` prints torch version, device name, VRAM, a 4096² matmul
+TFLOP/s number, and — when `/dev/kfd` exists but no device is visible —
+explicitly suggests the `HSA_OVERRIDE_GFX_VERSION=11.0.0` fix from
+[25](25-rocm-runbook.md).
+
+## Design notes & tradeoffs
+
+- **uv vs pip/poetry.** uv gives a committed cross-platform lockfile,
+  per-extra index routing (the torch problem, solved natively via
+  `tool.uv.sources` + `conflicts`), and `uv run` entry points with zero
+  activation ceremony. pip has no lockfile story; poetry fights custom
+  indexes for torch. The `≤$50 rental` path being literally `uv sync --extra
+  cu12` is the argument.
+- **Outside vs inside the pnpm workspace.** Inside buys nothing — pnpm can't
+  install Python and its lockfile would churn on a package it doesn't manage.
+  Outside (the `web/` precedent) keeps both toolchains blind to each other;
+  the only contract is files on disk (`shards/`, `spec.json`, `model.onnx`),
+  which is exactly the seam we want to test across.
+- **mmap vs loading to RAM.** A 5-gen window can hit ~100 GB — off the table
+  for eager load. mmap costs nothing when access is sequential-ish (hence
+  shard-order shuffling) and lets the OS cache hot shards across epochs for
+  free. Eager per-shard load into pinned buffers is a contained later
+  optimization inside `load_shard` if profiling shows input-bound steps;
+  the Dataset interface doesn't change.
 
 ## Inputs
 
@@ -55,3 +207,9 @@ cd trainer && uv sync
 uv run oel-check-gpu                       # device visible, matmul runs
 uv run pytest                              # incl. Node-shard bit-exact read test
 ```
+
+- `test_data.py`: mmap the checked-in Node-exported fixture shard; assert
+  bit-exact f16 payloads on a golden decision (the [16](16-shard-exporter.md)
+  cross-language test); collate invariants — `cand_counts.sum() == Mb`,
+  policy slices sum to 1, `chosen < count` per row.
+- Version guard: corrupt one fixture `meta.json` field, assert loud failure.

--- a/docs/trainer/18-model.md
+++ b/docs/trainer/18-model.md
@@ -1,0 +1,52 @@
+# 18 — Network architecture
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `trainer/` |
+| Depends on | [17](17-trainer-scaffold.md) |
+| Milestone | M5 |
+
+## Goal
+
+A policy+value net sized for minutes-per-epoch training on the 7800 XT *and*
+sub-millisecond CPU ONNX inference inside Node self-play workers.
+
+## Design
+
+Built **data-driven from `spec.json`** (offsets, grid geometry, vocab sizes)
+so encoder changes don't touch Python code. ~1.5–2.5 M parameters.
+
+- **Per-player grid** `[38, 9, 10]`: land one-hots + clergy flags stay
+  continuous; the categorical erection-id channel goes through
+  `nn.Embedding(256, 16)` → ~25 channels. A conv stem (3×3 → 64) + **4
+  residual blocks (64 ch, GroupNorm)** shared across all four player slots,
+  then per-slot global avg+max pooling → 128 each, with a learned slot
+  embedding (me / next / …) added before pooling concat.
+- **Scalars**: player scalars + frame + shared (~1k floats; the two 256-wide
+  building masks are embedded by the first linear layer) → MLP → 256.
+- **Trunk**: concat (4×128 + 256) → 512 → 256, ReLU, LayerNorm.
+- **Value head**: 256 → 64 → `maxPlayers`, sigmoid — targets are the
+  rank-based `[0,1]` vectors, masked by live seats. Egocentric, so 3–4-player
+  support needs zero architecture change.
+- **Policy head** (move-scoring, per [11](11-action-encoder.md)): move
+  encoder = erection embedding (**shared table** with the grid channel) +
+  linear over remaining move floats → 64; `logit = MLP(proj(trunk) ⊕ move64)`;
+  segment-softmax over each decision's ragged candidate slice
+  (`cand_offsets`).
+- Scale up (128 ch / 8 blocks) only after the loop demonstrably learns.
+
+## Inputs
+
+- Batches from `data.py`; `spec.json`.
+
+## Outputs
+
+- `model.py`: `OelNet(spec)` returning `(values [B, maxPlayers],
+  logits [M])`; segment-softmax/CE utilities shared with the training loop.
+
+## How it runs / verification
+
+- `uv run pytest trainer/tests/test_model.py` — forward pass on a real
+  Node-exported shard: correct shapes, finite outputs, per-decision softmax
+  sums to 1, gradient flows to every parameter group (embedding included).

--- a/docs/trainer/18-model.md
+++ b/docs/trainer/18-model.md
@@ -10,43 +10,155 @@
 ## Goal
 
 A policy+value net sized for minutes-per-epoch training on the 7800 XT *and*
-sub-millisecond CPU ONNX inference inside Node self-play workers.
+low-millisecond CPU ONNX inference inside Node self-play workers.
 
 ## Design
 
 Built **data-driven from `spec.json`** (offsets, grid geometry, vocab sizes)
-so encoder changes don't touch Python code. ~1.5–2.5 M parameters.
+so encoder changes don't touch Python code. Baseline ≈ **1.53 M parameters**
+(arithmetic below).
 
-- **Per-player grid** `[38, 9, 10]`: land one-hots + clergy flags stay
-  continuous; the categorical erection-id channel goes through
-  `nn.Embedding(256, 16)` → ~25 channels. A conv stem (3×3 → 64) + **4
-  residual blocks (64 ch, GroupNorm)** shared across all four player slots,
-  then per-slot global avg+max pooling → 128 each, with a learned slot
-  embedding (me / next / …) added before pooling concat.
-- **Scalars**: player scalars + frame + shared (~1k floats; the two 256-wide
-  building masks are embedded by the first linear layer) → MLP → 256.
-- **Trunk**: concat (4×128 + 256) → 512 → 256, ReLU, LayerNorm.
-- **Value head**: 256 → 64 → `maxPlayers`, sigmoid — targets are the
-  rank-based `[0,1]` vectors, masked by live seats. Egocentric, so 3–4-player
-  support needs zero architecture change.
-- **Policy head** (move-scoring, per [11](11-action-encoder.md)): move
-  encoder = erection embedding (**shared table** with the grid channel) +
-  linear over remaining move floats → 64; `logit = MLP(proj(trunk) ⊕ move64)`;
-  segment-softmax over each decision's ragged candidate slice
-  (`cand_offsets`).
-- Scale up (128 ch / 8 blocks) only after the loop demonstrably learns.
+### Input slicing (numbers from `game/src/encode.ts`)
+
+A state row is a flat `[14,670]` f32 vector: 4 player blocks of 3,455
+(35 scalars + a 38×9×10 grid = 3,420), then frame 549, then shared 301.
+`model.py` reslices via `spec.offsets`, never hardcodes:
+
+- **Grids**: for each slot, `states[:, off+35 : off+3455]` →
+  `[B, 38, 9, 10]` → permute to `[B, 10, 38, 9]`. Channels 0–5 are land
+  one-hots, channel 6 is the categorical erection id (0 = empty, ids 1–80
+  live in a 256 capacity), channels 7–9 are clergy flags. Channel 6 is cast
+  to long and embedded; the rest stay continuous floats.
+- **Scalars**: 4×35 player scalars + frame 549 + shared 301 = **990 floats**
+  (this includes the frame's two 256-wide usable/unusable building masks and
+  the shared 256-wide availability mask, absorbed by the first linear layer).
+
+### Layer-by-layer, with parameter arithmetic
+
+| # | Stage | In → out | Params |
+| --- | --- | --- | --- |
+| 1 | Erection embedding `nn.Embedding(256, 16)` (shared with 8) | id → 16 | 256·16 = **4,096** |
+| 2 | Grid assembly: 6 land + 3 clergy + 16 emb | `[B·4, 25, 38, 9]` | 0 |
+| 3 | Conv stem 3×3, 25→64 + GN(8, 64) | → `[B·4, 64, 38, 9]` | 25·64·9+64 = 14,400+64; GN 128 → **14,592** |
+| 4 | 4× residual block: (conv3×3 64→64 + GN + ReLU) ×2 + skip | same | 4·(2·(64·64·9+64) + 2·128) = 4·74,112 = **296,448** |
+| 5 | Slot embedding (4 learned 64-vectors, added per-channel), then per-slot global avg+max pool | → 4 × 128 → concat 512 | 4·64 = **256** |
+| 6 | Scalar MLP: 990 → 512 → ReLU → 256 | → 256 | 990·512+512 + 512·256+256 = 507,392+131,328 = **638,720** |
+| 7 | Trunk: concat(512+256=768) → 512 → ReLU → 256, LayerNorm(256) | → 256 | 768·512+512 + 512·256+256 + 512 = **525,568** |
+| 8 | Move encoder: 89 move floats ⊕ emb(erection id, table from 1) = 105 → 64 | `[Mb, 64]` | 105·64+64 = **6,784** |
+| 9 | Policy head: proj 256→64; logit MLP concat(64+64=128) → 64 → 1 | → `[Mb]` | 16,448 + 8,256 + 65 = **24,769** |
+| 10 | Value head: 256 → 64 → 4, sigmoid | → `[B, 4]` | 16,448 + 260 = **16,708** |
+
+Total: 4,096 + 14,592 + 296,448 + 256 + 638,720 + 525,568 + 6,784 + 24,769 +
+16,708 = **1,527,941 ≈ 1.53 M**. Room to 2.5 M exists (channels 64→96 or a
+wider scalar MLP) without touching the interface.
+
+The four player grids run through **one shared conv trunk** by folding slots
+into the batch dim (`[B, 4, 25, 38, 9] → [B·4, 25, 38, 9]`): one conv call,
+4× weight sharing, and the slot embedding (added before pooling) tells the
+net *which* seat a grid is (slot 0 = "me" carries most signal).
+
+### Heads
+
+- **Value**: `sigmoid`, target = the rank-based `[0,1]` outcome vector
+  rotated to the perspective ([16](16-shard-exporter.md)), masked by
+  `value_mask`. Egocentric, so 3–4-player support needs zero architecture
+  change.
+- **Policy** (move-scoring, per [11](11-action-encoder.md)): each candidate's
+  logit is `MLP(proj(trunk[row]) ⊕ moveEnc(cand))` where `row` is the
+  candidate's decision. Signature:
+  `forward(states [B,14670], cand_feats [Mb,90], cand_counts [B]) →
+  (values [B,4], logits [Mb])`. Softmax is *not* in `forward`; it lives in
+  the loss (below) and in the consumers ([19](19-training-loop.md),
+  [21](21-onnx-evaluator.md)).
+
+### Segment softmax over ragged candidates
+
+Two workable torch implementations:
+
+```python
+# A — index ops on the flat [Mb] layout (chosen)
+def segment_log_softmax(logits, counts):
+    B, dev = counts.numel(), logits.device
+    seg = torch.repeat_interleave(torch.arange(B, device=dev), counts)      # [Mb]
+    mx  = torch.full((B,), -torch.inf, device=dev).scatter_reduce(0, seg, logits, 'amax')
+    ex  = (logits - mx[seg]).exp()
+    den = torch.zeros(B, device=dev).index_add(0, seg, ex)
+    return logits - mx[seg] - den[seg].log(), seg
+```
+
+```python
+# B — pad to the batch max count, mask with -inf, F.log_softmax(dim=1)
+```
+
+A works directly on the shard layout with zero padding waste and O(Mb)
+memory; B is simpler to read but allocates `[B, max_count]` (up to the 128
+cap) and needs pack/unpack at both ends. A is the implementation;
+B is kept in tests as a reference oracle for A's correctness.
+
+### Normalization & init
+
+- **GroupNorm (8 groups)**, not BatchNorm: batch statistics here are
+  correlated (many decisions from the same game in one batch) and inference
+  runs at batch sizes 1–16 in Node — BN's train/eval running-stats gap is a
+  known source of silent parity failures across the ONNX boundary. GN is
+  deterministic per-sample, exports cleanly (native op at opset 18), costs
+  ~nothing at these widths.
+- **Init**: Kaiming fan-in (ReLU gain) for convs/linears; the second GN of
+  each residual block starts at γ=0 (identity-at-init residuals); the final
+  policy-logit layer and final value layer start at **zero** → step-0 priors
+  are exactly uniform and step-0 values are 0.5, i.e. the net begins as the
+  uniform-prior evaluator PUCT already tolerates ([13](13-puct-search.md)).
+
+## Design notes & tradeoffs
+
+- **Shared trunk over 4 grids vs concatenating 4×25 channels.** Concat
+  (`[B, 100, 38, 9]`) makes the stem 4× wider, hard-wires seat count into
+  conv weights, and loses the symmetry that seats are the *same kind* of
+  object. Shared trunk + slot embedding is fewer params, seat-count-agnostic
+  (empty slots are zero grids), and the fold-into-batch trick makes it one
+  kernel launch either way.
+- **Pooling vs flatten.** Flatten of `[64, 38, 9]` is 21,888 features/slot,
+  87,552 over 4 slots; a mere 512-wide first linear on that is 87,552·512 ≈
+  **44.8 M params** — 30× the entire budget, gone on positional weights the
+  anchored grid mostly wastes. Avg+max pooling (128/slot) keeps "what exists"
+  plus "strongest activation" at zero params; precise geometry is the conv
+  stack's job.
+- **Embedding dim.** 80 live erection ids (capacity 256). The
+  `1.6·n^0.56` rule of thumb gives ≈19; 16 keeps the shared table (grid +
+  move encoder) at 4 K params. 8 would likely bottleneck building identity —
+  the single most game-relevant signal; 32 buys little at 2× cost.
+- **Model size vs CPU inference latency.** Conv cost dominates:
+  342 cells × (stem 4.9 M + 8×12.6 M res MACs) ≈ 106 M MACs/slot → **~0.42 G
+  MACs ≈ 0.85 GFLOPs per eval** at 64 ch / 4 blocks. On onnxruntime CPU
+  (~50–200 GFLOP/s effective) that's ~4–15 ms at batch 1 — likely NN-bound at
+  200 sims/move, in tension with [21](21-onnx-evaluator.md)'s sub-ms hope.
+  The scaling knob is nearly quadratic in channels: 48 ch/3 blocks ≈ 0.37
+  GFLOPs, 32 ch/2 blocks ≈ 0.12 GFLOPs (~1–2 ms). Decision rule: baseline
+  64/4 for training; if the [08](08-benchmarks.md)/[21](21-onnx-evaluator.md)
+  micro-bench shows search NN-bound, drop to 32/2 *before* building batching
+  infrastructure. Scale up (128 ch / 8 blocks) only after the loop
+  demonstrably learns.
+- **Sigmoid multi-player value vs tanh scalar.** A scalar tanh "my winrate"
+  is the 2-player classic but bakes zero-sum-between-two into the head. The
+  masked per-seat sigmoid vector costs 3 extra outputs, reads directly as
+  "expected rank score per seat", matches the exporter's rotated targets,
+  and makes 3–4-player configs a data change. PUCT consumes `value[0]`
+  either way.
 
 ## Inputs
 
-- Batches from `data.py`; `spec.json`.
+- Batches from `data.py` ([17](17-trainer-scaffold.md)); `spec.json`.
 
 ## Outputs
 
 - `model.py`: `OelNet(spec)` returning `(values [B, maxPlayers],
-  logits [M])`; segment-softmax/CE utilities shared with the training loop.
+  logits [Mb])`; `segment_log_softmax` / loss utilities shared with the
+  training loop ([19](19-training-loop.md)).
 
 ## How it runs / verification
 
-- `uv run pytest trainer/tests/test_model.py` — forward pass on a real
-  Node-exported shard: correct shapes, finite outputs, per-decision softmax
-  sums to 1, gradient flows to every parameter group (embedding included).
+- `uv run pytest trainer/tests/test_model.py` — forward pass on the real
+  Node-exported fixture shard: correct shapes, finite outputs, per-decision
+  softmax sums to 1 (implementation A ≡ padded oracle B within 1e-6),
+  gradient flows to every parameter group (embedding included), zero-init
+  heads produce uniform priors and 0.5 values at step 0.

--- a/docs/trainer/19-training-loop.md
+++ b/docs/trainer/19-training-loop.md
@@ -1,0 +1,50 @@
+# 19 — Training loop
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `trainer/` |
+| Depends on | [18](18-model.md) |
+| Milestone | M5 |
+
+## Goal
+
+Turn shards into a checkpoint: supervised AlphaZero targets (visit
+distributions + outcomes), resumable, with enough logging to see learning or
+its absence immediately.
+
+## Design
+
+- Loss: `L = CE(π, p) + λ·MSE(z, v) + c·‖θ‖²` with λ = 1.0, weight decay
+  1e-4 (AdamW), cosine LR. Policy CE against visit fractions over each
+  decision's candidate slice; value MSE masked by `value_mask`.
+- **Sliding window**: train on shards from the last K generations (start
+  K = 5), freshest generation not oversampled initially (a tunable later).
+- Warm start from the previous generation's checkpoint; gen-0's net trains
+  from scratch on pure-UCT data.
+- Logging: `train-log.jsonl` per step — losses, policy top-1 agreement with
+  `chosen`, value calibration buckets. Early-exit knobs: `--epochs`,
+  `--max-steps`.
+- Checkpoint: `gen-NNN/ckpt/model.pt` = weights + optimizer + spec versions +
+  window definition.
+
+## Inputs
+
+```sh
+uv run oel-train --run runs/r1 --gen 3 [--device auto] [--epochs 2] [--window 5]
+```
+
+- Shard dirs for the window; previous checkpoint if any; `spec.json`.
+
+## Outputs
+
+- `gen-NNN/ckpt/model.pt`, `gen-NNN/train-log.jsonl`; `STATE` → `trained`.
+
+## How it runs / verification
+
+- **Overfit test** (the pipeline-truth test, in `trainer/tests/`): 10 games'
+  shards, no window, many epochs → total loss ≈ 0 and policy top-1 = chosen
+  on every decision. If this fails, the bug is in data plumbing, not the
+  model.
+- Resume: kill mid-epoch, rerun same command, verify continuation from the
+  checkpoint.

--- a/docs/trainer/19-training-loop.md
+++ b/docs/trainer/19-training-loop.md
@@ -15,18 +15,146 @@ its absence immediately.
 
 ## Design
 
-- Loss: `L = CE(π, p) + λ·MSE(z, v) + c·‖θ‖²` with λ = 1.0, weight decay
-  1e-4 (AdamW), cosine LR. Policy CE against visit fractions over each
-  decision's candidate slice; value MSE masked by `value_mask`.
-- **Sliding window**: train on shards from the last K generations (start
-  K = 5), freshest generation not oversampled initially (a tunable later).
-- Warm start from the previous generation's checkpoint; gen-0's net trains
-  from scratch on pure-UCT data.
-- Logging: `train-log.jsonl` per step — losses, policy top-1 agreement with
-  `chosen`, value calibration buckets. Early-exit knobs: `--epochs`,
-  `--max-steps`.
-- Checkpoint: `gen-NNN/ckpt/model.pt` = weights + optimizer + spec versions +
-  window definition.
+### Loss (exact formulas)
+
+For a batch of `B` decisions with ragged candidates (`Mb` total), targets
+`π` (visit fractions) and `z` (rotated outcome vector + mask `m`), model
+outputs `p = segment_softmax(logits)` and `v = sigmoid(value)`:
+
+```
+L_policy = −(1/B) · Σ_d Σ_{i ∈ cand(d)} π_{d,i} · log p_{d,i}      (CE vs a soft target)
+L_value  = (1 / Σ m) · Σ_{d,s} m_{d,s} · (v_{d,s} − z_{d,s})²      (masked MSE)
+L        = L_policy + λ · L_value                                   λ = 1.0
+```
+
+Regularization is **decoupled weight decay** via AdamW
+(`weight_decay = 1e-4`), *not* an explicit `c·‖θ‖²` term in `L`; decay is
+skipped for norms, biases, and embedding rows (standard no-decay groups).
+`L_policy` uses `segment_log_softmax` from [18](18-model.md) — never
+`exp().log()`.
+
+### Optimizer & LR schedule
+
+- AdamW, β = (0.9, 0.999), `weight_decay = 1e-4`, gradient clip at
+  `‖g‖₂ ≤ 1.0` (logged, so spikes are visible).
+- Batch: 256 decisions (≈ 4,600 candidate rows at median branching).
+- Schedule per invocation: linear warmup over the first 200 steps →
+  cosine decay from `lr_max = 1e-3` to `lr_min = 1e-5` across the planned
+  step budget. The budget is computed up front (below), so cosine has a
+  defined horizon; `--max-steps` overrides it.
+
+### Window sampling
+
+- **Sliding window**: train on shards from the last `K = 5` generations
+  (`--window`), discovered via `data.py` ([17](17-trainer-scaffold.md));
+  fewer if the run is young. Gen-0 trains on gen-0 alone.
+- Sampling is uniform over all rows in the window (shard-order shuffling per
+  [17](17-trainer-scaffold.md)); the freshest generation is **not**
+  oversampled initially — recency weighting is a recorded tunable, not a
+  day-one feature.
+- **Step budget instead of epochs**: `steps = ceil(E · rows_window / 256)`
+  with `E = 1.0` effective epochs by default (`--epochs` scales it). This
+  keeps wall-clock and sample-reuse constant as the window fills up: with a
+  full window each row is seen ~once per generation, ~K times total across
+  its lifetime — squarely in AlphaZero's healthy reuse range.
+
+### Logging — `train-log.jsonl` schema
+
+One JSON object per logging interval (every 50 steps) plus a `"type":
+"summary"` line at the end:
+
+```jsonc
+{ "type": "step", "ts": "2026-07-01T12:00:00Z", "gen": 3, "step": 1250,
+  "lr": 4.1e-4, "loss": 2.31, "policy_loss": 1.98, "value_loss": 0.33,
+  "top1_agree": 0.44,          // argmax p == chosen (fraction of batch)
+  "policy_entropy": 2.1,       // mean per-decision entropy of p
+  "value_mae": 0.31, "grad_norm": 0.8, "rows_seen": 320000 }
+{ "type": "summary", "gen": 3, "steps": 5860, "wall_s": 1410,
+  "final": { "loss": 1.71, "top1_agree": 0.58 },
+  "value_calibration": [[0.05, 0.11], [0.15, 0.18], …] }  // pred-bucket → actual mean
+```
+
+`top1_agree` and `policy_entropy` are the two instant sanity signals:
+agreement should climb from ~1/branching, entropy should fall from
+`log(branching)` but not to ~0 (that's the overfit signature).
+
+### Checkpoint & resume
+
+`gen-NNN/ckpt/model.pt` (torch.save of a dict):
+
+```python
+{ "model": state_dict, "optimizer": state_dict, "sched_step": int,
+  "global_step": int, "rows_seen": int,
+  "spec": { "featureSpecVersion": …, "actionSpecVersion": …,
+            "featureLen": 14670, "moveFeatureLen": … },
+  "window": { "gens": [0,1,2,3], "shards": 512, "rows": 2_100_000 },
+  "rng": { "torch": …, "numpy": …, "python": … },
+  "config_hash": "…", "torch_version": "2.5.1" }
+```
+
+Written atomically (`model.pt.tmp` + rename) every 500 steps and at the end.
+**Resume semantics**: `oel-train --run … --gen N` first looks for
+`gen-N/ckpt/model.pt`; if present and its `config_hash` + spec versions
+match, training continues from `global_step` with optimizer/scheduler/RNG
+restored (data order is re-derived from the restored RNG, so a killed run and
+an uninterrupted run see the same schedule, modulo the partial batch at the
+kill point). If absent, **warm start**: load `model` weights (only) from the
+previous promoted generation's checkpoint; fresh optimizer. Gen-0 starts from
+[18](18-model.md)'s init. Version guard ([17](17-trainer-scaffold.md)) runs
+before any of this.
+
+### Overfit test — the pipeline-truth test, step by step
+
+Lives in `trainer/tests/test_train.py`, CPU, minutes:
+
+1. Fixture: 10 self-play games' JSONL (checked in), exported by
+   [16](16-shard-exporter.md) into one shard (also checked in, so the test
+   doesn't need Node).
+2. Run the real `train()` entry with: window = that shard only, batch 64,
+   constant `lr = 1e-3` (schedule disabled), no weight decay, ~2,000 steps.
+3. Assert monotone-ish descent: loss at step 2,000 < 5% of loss at step 0.
+4. Assert memorization: `policy_loss < 0.05`, masked `value_loss < 1e-3`,
+   and policy top-1 == `chosen` on **every** decision (temperature sampling
+   means the target π isn't one-hot; assert argmax agreement, not CE = 0).
+5. If this fails, the bug is in data plumbing (slicing, rotation, offsets),
+   not the model — that is the point of the test.
+
+### CLI
+
+```sh
+uv run oel-train --run runs/r1 --gen 3 [--device auto] [--window 5]
+                 [--epochs 1.0] [--max-steps N] [--batch 256] [--lr 1e-3]
+```
+
+## Design notes & tradeoffs
+
+- **AdamW vs SGD-momentum.** Big-AZ used SGD+momentum with hand-tuned LR
+  drops across millions of steps. At ~1.5 M params, thousands of steps per
+  generation, and nobody babysitting LR, AdamW's per-parameter scaling is
+  worth its memory (2× params ≈ 12 MB — nothing) and removes the most
+  fiddly hyperparameter. The known generalization gap of Adam-family
+  optimizers matters less than iteration speed here; revisit only if gating
+  ([22](22-arena-gating.md)) plateaus suspiciously early.
+- **Window K = 5.** Too small (1–2) and the net chases the newest data —
+  policy oscillation and forgetting of openings it no longer visits. Too
+  large (20+) anchors training to generations of much weaker play, diluting
+  fresh signal. K = 5 at 500–2,000 games/gen ≈ 2.5k–10k games ≈ 0.6–3.5 M
+  decisions — proportionally comparable to AZ's 500k-game window. Tune with
+  gate results, not intuition.
+- **Warm start vs fresh init each generation.** Fresh init (AlphaZero's
+  original re-train-from-scratch) maximizes plasticity and can't inherit
+  bad minima, but needs many more steps per gen and a big window to
+  reconverge. Warm start reuses computation and is the standard modern
+  choice; its risk — catastrophic drift compounding across gens — is exactly
+  what arena gating exists to catch (a drifted net fails the gate; the
+  champion's weights remain the warm-start source). Warm start, with
+  "fresh-init every N gens" kept as a documented escape hatch.
+- **Epochs-per-gen vs fixed step budget.** "2 epochs" means 5× more steps
+  once the window is full — silently changing the reuse ratio as the run
+  ages. A rows-derived step budget keeps effective sample reuse constant and
+  makes generation wall-clock predictable for the orchestrator
+  ([23](23-orchestrator.md)). `--max-steps` remains the blunt override for
+  smoke runs ([24](24-smoke-e2e.md)).
 
 ## Inputs
 
@@ -42,9 +170,10 @@ uv run oel-train --run runs/r1 --gen 3 [--device auto] [--epochs 2] [--window 5]
 
 ## How it runs / verification
 
-- **Overfit test** (the pipeline-truth test, in `trainer/tests/`): 10 games'
-  shards, no window, many epochs → total loss ≈ 0 and policy top-1 = chosen
-  on every decision. If this fails, the bug is in data plumbing, not the
-  model.
-- Resume: kill mid-epoch, rerun same command, verify continuation from the
-  checkpoint.
+- **Overfit test** (`uv run pytest -k overfit`): the five-step procedure
+  above — total loss ≈ 0 and policy top-1 = chosen on every decision.
+- Resume: kill mid-run, rerun same command, verify continuation from
+  `global_step` (log line sequence is contiguous) and final metrics match an
+  uninterrupted run within noise.
+- `train-log.jsonl` lines validate against the schema; the summary line's
+  calibration buckets are monotone on the overfit fixture.

--- a/docs/trainer/20-onnx-export.md
+++ b/docs/trainer/20-onnx-export.md
@@ -14,17 +14,140 @@ identical outputs to torch, dynamic batch and ragged-candidate friendly.
 
 ## Design
 
-- `uv run oel-export-onnx --ckpt gen-NNN/ckpt/model.pt --out gen-NNN/model.onnx`
-- Graph interface (fixed contract with [21](21-onnx-evaluator.md)):
-  - inputs: `states [B, featureLen] f32`, `cand_feats [M, moveFeatureLen] f32`,
-    `cand_offsets [B+1] i64`
-  - outputs: `values [B, maxPlayers] f32`, `logits [M] f32`
-  - Softmax stays **outside** the graph (Node applies it per candidate slice) —
-    keeps the graph free of ragged-segment ops that export poorly.
-- Dynamic axes on `B` and `M`; opset pinned; f32 weights (quantization is a
-  later experiment).
-- `spec.json` (featureSpec + actionSpec versions + graph interface version)
-  written next to the model; every consumer asserts it.
+### CLI
+
+```sh
+uv run oel-export-onnx --ckpt gen-NNN/ckpt/model.pt --out gen-NNN/model.onnx
+```
+
+### Graph interface (fixed contract with [21](21-onnx-evaluator.md))
+
+- inputs: `states [B, 14670] f32` · `cand_feats [M, moveFeatureLen] f32` ·
+  `cand_offsets [B+1] i64` (prefix sums, `offsets[0] = 0`, `offsets[B] = M`)
+- outputs: `values [B, maxPlayers] f32` (post-sigmoid) · `logits [M] f32`
+  (raw, pre-softmax)
+- Softmax stays **outside** the graph — Node applies it per candidate slice
+  on the way out ([21](21-onnx-evaluator.md)).
+
+### Export wrapper — offsets → rows without ragged ops
+
+`OelNet.forward` takes `cand_counts`; the graph contract takes
+`cand_offsets`. The exported `OnnxWrapper(nn.Module)` bridges them, and maps
+each candidate to its decision's trunk row using only ONNX-clean ops
+(ScatterND + CumSum + Gather) — deliberately avoiding
+`repeat_interleave` with data-dependent repeats, which lowers to loops or
+fails outright:
+
+```python
+class OnnxWrapper(nn.Module):
+    def forward(self, states, cand_feats, cand_offsets):
+        M = cand_feats.shape[0]
+        starts = cand_offsets[1:-1]                      # segment boundaries
+        ind = torch.zeros(M, dtype=torch.long, device=states.device)
+        ind = ind.index_put((starts,), torch.ones_like(starts))
+        rows = ind.cumsum(0)                             # [M] candidate -> batch row
+        return self.net.heads(self.net.trunk(states), cand_feats, rows)
+```
+
+Precondition (asserted at export and by the evaluator): every decision has
+≥ 1 candidate, so offsets are strictly increasing and the scatter never
+collides. `OelNet` gets a small refactor so trunk/head paths accept
+precomputed `rows` — training keeps `counts`, export uses `rows`, weights are
+shared.
+
+### Exporter choice: classic `torch.onnx.export` (TorchScript tracer)
+
+Chosen over the `dynamo=True` / `torch.export` path, because:
+
+1. The graph is **trace-safe by construction** — no data-dependent control
+   flow anywhere (the cumsum trick above exists precisely to keep it that
+   way), so tracing's one weakness doesn't apply.
+2. The tracer + onnxruntime pairing is a decade old; the dynamo exporter is
+   still churning (op coverage, dynamic-shape corner cases) and
+   `onnxruntime-node` lags desktop ORT — conservative is right where a silent
+   numeric mismatch costs a full generation.
+3. Everything used here (Conv, GroupNormalization, Gemm, Gather, ScatterND,
+   CumSum, Sigmoid, embedding-as-Gather) is mature in both exporters — the
+   dynamo path buys nothing today. Revisit when torch deprecates the tracer;
+   the parity test is the safety net either way.
+
+### Dynamic axes & opset
+
+```python
+torch.onnx.export(wrapper, (states, cand_feats, cand_offsets), out,
+    input_names=["states", "cand_feats", "cand_offsets"],
+    output_names=["values", "logits"],
+    dynamic_axes={"states": {0: "B"}, "cand_feats": {0: "M"},
+                  "cand_offsets": {0: "B1"}, "values": {0: "B"}, "logits": {0: "M"}},
+    opset_version=18)
+```
+
+**Opset 18**, pinned: it is the first opset with native `GroupNormalization`
+(otherwise GN decomposes into a reshape/InstanceNorm chain — correct but
+slower and noisier to diff), and it is comfortably supported by
+onnxruntime ≥ 1.16, including `onnxruntime-node`. Weights export as **f32**;
+quantization is a later experiment (below).
+
+### Why softmax stays outside the graph
+
+A per-slice softmax over ragged segments inside the graph needs the same
+scatter-max/index-add dance as training — exportable, but it triples the
+fiddly-op surface for zero benefit: Node already walks each candidate slice
+to build PUCT priors, and a slice-local softmax over ≤128 floats is
+nanoseconds. Keeping logits raw also lets the consumer apply temperature
+without a re-export.
+
+### `spec.json` + golden-batch fixture (shared with [21](21-onnx-evaluator.md))
+
+`spec.json` is written next to the model: featureSpec + actionSpec versions,
+`featureLen: 14670`, `moveFeatureLen`, `maxPlayers: 4`, graph interface
+version, opset, and source ckpt path — every consumer asserts it before
+inference.
+
+`test_onnx.py` additionally writes `gen-NNN/parity/golden.json`, the fixture
+the Node parity test in [21](21-onnx-evaluator.md) replays against the same
+`model.onnx`:
+
+```jsonc
+{ "v": 1, "specVersions": { "feature": …, "action": … }, "opset": 18,
+  "tolerance": 1e-4,
+  "cases": [ { "B": 7, "M": 131,
+    "inputs":   { "states":       { "shape": [7, 14670], "dtype": "f32", "b64": "…" },
+                  "cand_feats":   { "shape": [131, 90],  "dtype": "f32", "b64": "…" },
+                  "cand_offsets": { "shape": [8],        "dtype": "i64", "b64": "…" } },
+    "expected": { "values": { "shape": [7, 4], "dtype": "f32", "b64": "…" },
+                  "logits": { "shape": [131],  "dtype": "f32", "b64": "…" } } } ] }
+```
+
+Tensors are base64 of little-endian bytes (the exact layout both
+`Float32Array` and numpy speak natively); inputs are drawn from a real shard,
+expected outputs are **torch** outputs — so 21's test transitively proves
+Node-packing ≡ torch, not just Node ≡ Python-ORT.
+
+## Design notes & tradeoffs
+
+- **ONNX vs TorchScript vs a Python inference server.** TorchScript in Node
+  means embedding libtorch behind an unmaintained binding — a dead end.
+  A Python server keeps torch as the single runtime but adds a process, a
+  socket protocol, batching logic, and a failure mode to every self-play
+  worker — [12](12-evaluator-interface.md) explicitly defers that to Stage 3
+  *if measured necessary*. ONNX + `onnxruntime-node` is one file and one
+  battle-tested dependency in-process with the search — the only cost is
+  this project's parity discipline, which the golden batch makes mechanical.
+- **f32 export vs quantization.** Dynamic int8 quantization would cut model
+  size ~4× and speed up the MLP-heavy parts ~2–3×, but conv trunks are the
+  hot path ([18](18-model.md)) and int8 conv gains on ORT CPU are workload
+  dependent; meanwhile value-head precision drives PUCT directly. Ship f32
+  until [21](21-onnx-evaluator.md)'s micro-bench proves NN-bound search,
+  then evaluate `quantize_dynamic` behind the same parity test (with a
+  loosened, measured tolerance).
+- **Graph-internal vs external softmax.** Internal would make the graph
+  self-contained ("logits in, probabilities out") and marginally simplify
+  consumers — but it hard-codes temperature 1, adds ragged-segment ops to
+  the export surface, and duplicates work Node does anyway while walking
+  slices. External keeps the graph a pure function of dense tensors; the
+  ragged semantics live in exactly two audited places (training loss,
+  evaluator).
 
 ## Inputs
 
@@ -32,12 +155,18 @@ identical outputs to torch, dynamic batch and ragged-candidate friendly.
 
 ## Outputs
 
-- `gen-NNN/model.onnx` + `gen-NNN/spec.json`.
+- `gen-NNN/model.onnx` + `gen-NNN/spec.json` (+ `gen-NNN/parity/golden.json`
+  from the parity test).
 
 ## How it runs / verification
 
 - `uv run pytest trainer/tests/test_onnx.py` — torch vs onnxruntime (Python)
-  on a golden batch from a real shard: max |Δ| ≤ 1e-4 on values and logits,
-  across batch sizes {1, 7, 64} and ragged candidate counts.
-- The same golden batch + expected outputs are written to a fixture file for
-  the Node-side parity test in [21](21-onnx-evaluator.md).
+  on golden batches from a real shard: max |Δ| ≤ 1e-4 on values and logits,
+  across batch sizes {1, 7, 64} and ragged candidate counts (including a
+  decision with exactly 1 candidate, and B = 1).
+- The same golden batches + expected outputs land in
+  `gen-NNN/parity/golden.json` for the Node-side parity test in
+  [21](21-onnx-evaluator.md).
+- Structural check: exported graph contains no Loop/If nodes
+  (`onnx.helper` walk) — guards against a future torch version silently
+  lowering the row-mapping into a loop.

--- a/docs/trainer/20-onnx-export.md
+++ b/docs/trainer/20-onnx-export.md
@@ -1,0 +1,43 @@
+# 20 — ONNX export & parity
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `trainer/` |
+| Depends on | [18](18-model.md) |
+| Milestone | M5 |
+
+## Goal
+
+A checkpoint becomes a single `model.onnx` that onnxruntime can serve —
+identical outputs to torch, dynamic batch and ragged-candidate friendly.
+
+## Design
+
+- `uv run oel-export-onnx --ckpt gen-NNN/ckpt/model.pt --out gen-NNN/model.onnx`
+- Graph interface (fixed contract with [21](21-onnx-evaluator.md)):
+  - inputs: `states [B, featureLen] f32`, `cand_feats [M, moveFeatureLen] f32`,
+    `cand_offsets [B+1] i64`
+  - outputs: `values [B, maxPlayers] f32`, `logits [M] f32`
+  - Softmax stays **outside** the graph (Node applies it per candidate slice) —
+    keeps the graph free of ragged-segment ops that export poorly.
+- Dynamic axes on `B` and `M`; opset pinned; f32 weights (quantization is a
+  later experiment).
+- `spec.json` (featureSpec + actionSpec versions + graph interface version)
+  written next to the model; every consumer asserts it.
+
+## Inputs
+
+- A `.pt` checkpoint from [19](19-training-loop.md).
+
+## Outputs
+
+- `gen-NNN/model.onnx` + `gen-NNN/spec.json`.
+
+## How it runs / verification
+
+- `uv run pytest trainer/tests/test_onnx.py` — torch vs onnxruntime (Python)
+  on a golden batch from a real shard: max |Δ| ≤ 1e-4 on values and logits,
+  across batch sizes {1, 7, 64} and ragged candidate counts.
+- The same golden batch + expected outputs are written to a fixture file for
+  the Node-side parity test in [21](21-onnx-evaluator.md).

--- a/docs/trainer/21-onnx-evaluator.md
+++ b/docs/trainer/21-onnx-evaluator.md
@@ -14,32 +14,186 @@ Serve the trained net inside Node self-play and arena workers: an
 
 ## Design
 
-- New dependency: `onnxruntime-node` (CPU execution provider).
-- `agent/src/evaluators/onnx.ts`: `OnnxEvaluator(modelPath)` — each
-  `worker_thread` owns its own `InferenceSession`; a reused scratch buffer
-  packs `EvalRequest[]` into the `states` / `cand_feats` / `cand_offsets`
-  graph inputs from [20](20-onnx-export.md); softmax is applied per candidate
-  slice on the way out; `id` = the model file's spec version + gen tag (lands
-  in JSONL `netId`).
-- Asserts `spec.json` versions against the adapter's featureSpec/actionSpec
-  at construction — a stale model fails loudly, not silently.
-- Why CPU is fine at first: at ~2M params a fused forward is ~0.1–0.5 ms,
-  the same order as one `completions()` call — search stays engine-bound.
-  If profiling ever shows NN-bound workers, Stage-2 in-worker batching (the
-  interface already takes request arrays) comes before any GPU server.
+### Dependency and module shape
+
+- New dependency: `onnxruntime-node` (CPU execution provider), added to
+  `agent/package.json` only — `game/` and `web/` never see it.
+- `agent/` is ESM (`"type": "module"`, run via `node --import tsx/esm`);
+  `onnxruntime-node` is a CJS native addon. Import via default-interop —
+  `import ort from 'onnxruntime-node'` — and destructure
+  `const { InferenceSession, Tensor } = ort`. Named ESM imports happen to
+  work through cjs-module-lexer today, but the default form is the shape
+  the package documents and won't break on a packaging change.
+- `onnxruntime-node` ships a postinstall script. This workspace blocks
+  dependency build scripts by default (`onlyBuiltDependencies` in
+  `pnpm-workspace.yaml` currently lists only `esbuild`), so
+  `onnxruntime-node` must be added there or the install silently produces a
+  non-functional package. The parity test below is what catches this if it
+  regresses.
+
+### Construction
+
+`agent/src/evaluators/onnx.ts`:
+
+```ts
+export const createOnnxEvaluator = async (
+  modelPath: string,              // …/gen-NNN/model.onnx; spec.json read from the sibling path
+  adapter: GameAdapter,           // supplies featureSpec/actionSpec for the assertion
+  opts?: { threads?: number }     // intra-op threads, default 1
+): Promise<Evaluator>
+```
+
+An async factory (not a class constructor) because `InferenceSession.create`
+is async. Each `worker_thread` calls it once at startup and owns its session
+for the worker's lifetime; sessions are never shared or transferred across
+threads.
+
+Session options, deliberately minimal:
+
+```ts
+const session = await ort.InferenceSession.create(modelPath, {
+  executionProviders: ['cpu'],
+  intraOpNumThreads: opts?.threads ?? 1,
+  interOpNumThreads: 1,
+  graphOptimizationLevel: 'all',
+})
+```
+
+**Why one intra-op thread**: the self-play pool ([15](15-selfplay-workers.md))
+already runs ~one worker per core. ORT's default sizes a thread pool per
+session from the machine's core count, which with 12 workers means ~144
+threads fighting over 12 cores — contention, not speedup. One thread per
+worker keeps the parallelism where it already lives.
+
+### spec.json assertion
+
+At construction, read `spec.json` next to the model and fail loudly on any
+mismatch — a stale model must never silently emit garbage priors:
+
+```
+assert spec.graphInterfaceVersion is one this evaluator implements
+assert spec.featureSpecVersion === adapter.featureSpec.version
+assert spec.actionSpecVersion  === adapter.actionSpec.version
+assert spec.featureLen         === adapter.featureSpec.featureLen
+assert spec.moveFeatureLen     === adapter.actionSpec.moveFeatureLen
+```
+
+Every failure names both sides ("model built against featureSpec v3,
+adapter is v4"). `Evaluator.id` is derived from the model (`spec.netId`,
+falling back to the gen directory name, e.g. `gen-007`) — it lands in JSONL
+`netId` for provenance ([14](14-selfplay-v2.md)).
+
+### Input packing
+
+The graph contract is fixed by [20](20-onnx-export.md): inputs
+`states [B, featureLen] f32`, `cand_feats [M, moveFeatureLen] f32`,
+`cand_offsets [B+1] i64`; outputs `values [B, maxPlayers] f32`,
+`logits [M] f32`. Packing an `EvalRequest[]`:
+
+```
+B = reqs.length
+M = Σ reqs[i].numCands
+states     : Float32Array(B × featureLen)        — row i ← reqs[i].state
+candFeats  : Float32Array(M × moveFeatureLen)    — ragged concat of reqs[i].candFeats
+candOffsets: BigInt64Array(B + 1)                — prefix sums: [0, n0, n0+n1, …, M]
+
+feeds = {
+  states:       new ort.Tensor('float32', states, [B, featureLen]),
+  cand_feats:   new ort.Tensor('float32', candFeats, [M, moveFeatureLen]),
+  cand_offsets: new ort.Tensor('int64', candOffsets, [B + 1]),
+}
+```
+
+The three scratch buffers are owned by the evaluator instance, grown
+geometrically (never shrunk), and reused across calls. This is safe because
+each worker's PUCT awaits one `evaluate()` at a time; the evaluator asserts
+there is no concurrent in-flight call rather than defending against one.
+Every request must have `numCands ≥ 1` (decision points always have a legal
+move) — asserted, not tolerated.
+
+### Output unpacking and per-slice softmax
+
+`values` is sliced per row into `number[]` (length `maxPlayers`). Priors are
+computed per candidate slice — softmax stays outside the graph by design
+(ragged-segment softmax exports poorly):
+
+```
+for i in 0..B:
+  slice  = logits[off[i] .. off[i+1])
+  m      = max(slice)
+  e      = slice.map(x => exp(x − m))     // max-subtract: numerically stable
+  priors = e.map(x => x / Σe)
+```
+
+### Golden-batch parity harness
+
+[20](20-onnx-export.md)'s Python test writes a fixture: a tiny committed
+model (tens of thousands of params, ~100–200 KB — small enough to check in,
+unlike a real 2M-param net) plus `golden-batch.json` with raw inputs and
+expected `values`/`logits` at batch sizes {1, 7} with ragged candidate
+counts. The Node test
+(`agent/src/evaluators/__tests__/onnx.parity.test.ts`):
+
+1. builds `EvalRequest[]` from the fixture inputs,
+2. runs `createOnnxEvaluator` against the fixture model with a stub adapter
+   matching the fixture's spec,
+3. asserts `values` within 1e-4 of expected, and priors within 1e-4 of
+   softmax(expected logits) per slice.
+
+This guards the classic cross-runtime failure — input-packing bugs (row
+order, offset off-by-one, i64 vs i32) — not model quality. A second test
+spawns two `worker_threads` that each construct a session and run the golden
+batch, pinning the addon-under-workers behavior explicitly (see tradeoffs).
 
 ## Inputs
 
-- `model.onnx` + `spec.json`; `EvalRequest[]` from PUCT.
+- `model.onnx` + `spec.json`; `EvalRequest[]` from PUCT
+  ([13](13-puct-search.md)).
 
 ## Outputs
 
-- `OnnxEvaluator` usable anywhere an `Evaluator` is (self-play workers,
-  `nn:` arena policy in [22](22-arena-gating.md)).
+- `createOnnxEvaluator` usable anywhere an `Evaluator` is: self-play workers
+  ([15](15-selfplay-workers.md)) and the `nn:` arena policy
+  ([22](22-arena-gating.md)).
 
 ## How it runs / verification
 
-- `pnpm --dir agent test` — golden-batch parity: outputs match the fixture
-  written by [20](20-onnx-export.md)'s Python test within 1e-4 (guards
-  against input-packing bugs, the classic cross-runtime failure).
-- Micro-bench in [08](08-benchmarks.md): ms/evaluate at batch 1 and 16.
+- `pnpm --dir agent test` — golden-batch parity within 1e-4 (values and
+  priors); spec.json mismatch throws with both versions named; the
+  two-worker-threads smoke test passes.
+- Micro-bench in [08](08-benchmarks.md): ms/evaluate at batch 1 and 16, so
+  the "engine-bound, not NN-bound" claim is a number, not a hope.
+
+## Design notes & tradeoffs
+
+- **CPU-per-worker vs a GPU inference server.** At ~2M params a forward pass
+  is ~4 MFLOPs per position; one CPU core sustaining even a modest 5–20
+  GFLOP/s on small GEMMs gives ~0.2–1 ms/eval. PUCT does ≤ `sims` evals per
+  move, so NN time is ~40–200 ms of a 1–3 s move — the engine
+  (`completions()` + encode) dominates by 5–20×. A GPU server would add IPC
+  (each request ships ~60 KB of f32 state alone), cross-worker batching
+  queues, and a second process to babysit, all to accelerate the minority
+  term. It stays Stage 3 of [12](12-evaluator-interface.md): built only if
+  profiling shows NN-bound workers, behind the same interface.
+- **Native-dependency risk.** `onnxruntime-node` ships prebuilt binaries per
+  platform/arch; building from source is not a realistic fallback. Two
+  concrete exposures: (1) brand-new Node majors can lag prebuilt/ABI
+  support, so CI pins Node 24.x for anything touching the evaluator rather
+  than `node-version: latest` (see [24](24-smoke-e2e.md)); (2) the pnpm
+  build-script allowlist noted above. The version is pinned exactly in
+  `package.json`, matching the repo's existing convention.
+- **worker_threads.** N-API context-aware addons are expected to work in
+  workers, and current onnxruntime-node does, but this has broken before in
+  its history — hence the explicit two-worker test. If it regresses, the
+  fallback is a `child_process`-based pool; [15](15-selfplay-workers.md)'s
+  pool abstraction should not leak `worker_threads` specifics so that swap
+  stays cheap.
+- **Batch=1 now, in-worker batching later.** Stage 1 passes single-request
+  arrays (PUCT expands one leaf per simulation). Because the interface is
+  already `EvalRequest[] → Promise<EvalResult[]>` and PUCT already carries
+  virtual loss ([13](13-puct-search.md)), Stage-2 batching (collect leaves
+  from several concurrent simulations, evaluate as one batch) changes no
+  interface code — it is purely a scheduling change inside the worker. ORT
+  amortizes per-call overhead well under batching, so the win is real but
+  only matters once the engine share shrinks
+  (post-[07](07-engine-fast-paths.md)).

--- a/docs/trainer/21-onnx-evaluator.md
+++ b/docs/trainer/21-onnx-evaluator.md
@@ -1,0 +1,45 @@
+# 21 — ONNX evaluator in Node
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [12](12-evaluator-interface.md), [20](20-onnx-export.md) |
+| Milestone | M6 |
+
+## Goal
+
+Serve the trained net inside Node self-play and arena workers: an
+`Evaluator` implementation backed by `onnxruntime-node` on CPU.
+
+## Design
+
+- New dependency: `onnxruntime-node` (CPU execution provider).
+- `agent/src/evaluators/onnx.ts`: `OnnxEvaluator(modelPath)` — each
+  `worker_thread` owns its own `InferenceSession`; a reused scratch buffer
+  packs `EvalRequest[]` into the `states` / `cand_feats` / `cand_offsets`
+  graph inputs from [20](20-onnx-export.md); softmax is applied per candidate
+  slice on the way out; `id` = the model file's spec version + gen tag (lands
+  in JSONL `netId`).
+- Asserts `spec.json` versions against the adapter's featureSpec/actionSpec
+  at construction — a stale model fails loudly, not silently.
+- Why CPU is fine at first: at ~2M params a fused forward is ~0.1–0.5 ms,
+  the same order as one `completions()` call — search stays engine-bound.
+  If profiling ever shows NN-bound workers, Stage-2 in-worker batching (the
+  interface already takes request arrays) comes before any GPU server.
+
+## Inputs
+
+- `model.onnx` + `spec.json`; `EvalRequest[]` from PUCT.
+
+## Outputs
+
+- `OnnxEvaluator` usable anywhere an `Evaluator` is (self-play workers,
+  `nn:` arena policy in [22](22-arena-gating.md)).
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — golden-batch parity: outputs match the fixture
+  written by [20](20-onnx-export.md)'s Python test within 1e-4 (guards
+  against input-packing bugs, the classic cross-runtime failure).
+- Micro-bench in [08](08-benchmarks.md): ms/evaluate at batch 1 and 16.

--- a/docs/trainer/22-arena-gating.md
+++ b/docs/trainer/22-arena-gating.md
@@ -1,0 +1,52 @@
+# 22 — Arena gating & promotion
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [04](04-baselines-arena.md), [21](21-onnx-evaluator.md) |
+| Milestone | M6 |
+
+## Goal
+
+Only nets that demonstrably beat the current champion get to generate the
+next generation's data — the flywheel's ratchet.
+
+## Design
+
+- Extend the arena CLI's policy specs with
+  `nn:<onnx-path | best@runs/<id>>[:sims]`:
+
+```sh
+pnpm --dir agent arena 100 long nn:runs/r1/gen-003/model.onnx:200 nn:best@runs/r1:200
+pnpm --dir agent arena 50  long nn:best@runs/r1:400 mcts:400     # the yardstick
+```
+
+- `nn:` builds a PUCT policy with an `OnnxEvaluator`, **no Dirichlet noise**,
+  argmax move selection (τ→0) — evaluation, not exploration.
+- Gate procedure (invoked by the orchestrator, [23](23-orchestrator.md)):
+  candidate vs `best.json`'s champion, ≥100 games, seats alternated
+  (`runMatch` already does this), fixed seed schedule.
+  **Promote on win-rate ≥ 0.55**; on promotion, update `runs/<id>/best.json`
+  `{ gen, onnx, ckpt, arena }`. SPRT early stopping is a later nicety.
+- Gen-1 special case: the champion is pure UCT (`mcts:<sims>`) until the
+  first net is promoted.
+- Always also log (not gate on) candidate vs `mcts:400` — the fixed-strength
+  yardstick that shows absolute progress across the whole run; promoted-vs-
+  promoted only shows relative progress.
+
+## Inputs
+
+- Candidate `model.onnx`, `best.json`, gate params from `config.json`
+  (games, sims, threshold).
+
+## Outputs
+
+- `gen-NNN/arena.json` (full match record); updated `best.json` on
+  promotion; `STATE` → `gated`.
+
+## How it runs / verification
+
+- `pnpm --dir agent test` — spec parsing (`nn:`), promotion threshold logic,
+  best.json update atomicity (write-temp-rename).
+- Determinism: same seeds ⇒ same match outcome, so gates are auditable.

--- a/docs/trainer/22-arena-gating.md
+++ b/docs/trainer/22-arena-gating.md
@@ -90,6 +90,31 @@ The candidate-vs-`mcts:400` yardstick is always played and logged, never
 gated on: it is the fixed-strength ruler showing absolute progress across
 the whole run, whereas promoted-vs-promoted only shows relative progress.
 
+### Config panel and the solo bucket
+
+One net serves all configs (1–4 players × short/long × both countries), so
+the gate evaluates a **panel of config buckets** from `config.json`
+(`gate.panel`), not one config. Gating on all 16 buckets at ≥100 games each
+is a day of compute, so the panel is a representative subset (e.g.
+`2p-long-france`, `4p-short-ireland`, `1p-long-france`) with per-bucket game
+counts; ungated buckets are covered statistically by self-play sampling the
+full mix and by rotating one "guest" bucket through the panel across
+generations.
+
+- **2–4 player buckets**: head-to-head `runMatch` vs the champion exactly as
+  above (seat-alternated; for 3–4p the remaining seats are filled with
+  champion copies, and the candidate's mean rank-outcome is the score).
+- **Solo bucket**: there is no opponent — candidate and champion each play
+  the *same fixed seed set* and the comparison is **paired**: per seed,
+  candidate wins the pair if its final score is higher (success counting per
+  [09](09-game-adapter.md): the reported metric is the score>500 rate, also
+  logged per side). Pairing on identical seeds cancels board-setup variance,
+  which for N=50-ish solo games is the difference between signal and noise.
+- **Promotion rule**: weighted mean of per-bucket win rates ≥ `threshold`
+  (0.55) **and** no panel bucket below 0.45 — a net that trades 4p collapse
+  for 2p gains must not ratchet in. Per-bucket results all land in
+  `arena.json`.
+
 ### best.json atomic update
 
 On promotion, write `runs/<id>/best.json`:

--- a/docs/trainer/22-arena-gating.md
+++ b/docs/trainer/22-arena-gating.md
@@ -14,39 +14,165 @@ next generation's data — the flywheel's ratchet.
 
 ## Design
 
-- Extend the arena CLI's policy specs with
-  `nn:<onnx-path | best@runs/<id>>[:sims]`:
+### parsePolicy grammar extension
+
+Today `agent/src/cli/arena.ts` has a synchronous
+`parsePolicy(spec: string): Policy` handling `random | greedy | mcts[:sims]`,
+consumed positionally (`pnpm arena [games] [short|long] [policyA] [policyB]`).
+The extended grammar:
+
+```
+policy := "random" | "greedy" | "mcts"[":"sims] | "nn:" source [":"sims]
+source := <path to model.onnx> | "best@" <run dir>      e.g. best@runs/r1
+sims   := integer                                        (nn default: 200)
+```
+
+Parsing rules: strip the `nn:` prefix; if the final `:`-separated segment is
+all digits, it is `sims` and is split off (paths on this project never end in
+an all-digit segment, and we are on posix so no drive-letter colons); if the
+remainder starts with `best@`, read `<run>/best.json` and resolve its `onnx`
+field relative to the run dir — a missing `best.json` is an error at parse
+time, not a silent fallback.
+
+Two mechanical changes ripple from this:
+
+- `parsePolicy` becomes `async (spec) => Promise<Policy>` because
+  `createOnnxEvaluator` awaits `InferenceSession.create`; the CLI top-level
+  `await`s both policies before starting.
+- `Policy.pick` (`agent/src/policy.ts`) widens to
+  `(state, rng) => Move | undefined | Promise<Move | undefined>`, and
+  `playGame` / `runMatch` in `agent/src/arena.ts` become async and `await`
+  each pick. Existing sync policies are untouched (`await` on a non-promise
+  is a no-op); the arena CLI and self-play call sites gain an `await`.
+
+The `nn:` policy itself is [13](13-puct-search.md)'s `puctPolicy` with an
+`OnnxEvaluator`, **no Dirichlet noise**, argmax move selection (τ→0) —
+evaluation, not exploration. Its `name` is `nn(<gen-or-basename>,<sims>)` so
+match logs identify exactly what played.
+
+### Gate procedure
+
+Invoked by the orchestrator ([23](23-orchestrator.md)) as
+`gate(runDir, gen)`; also runnable by hand as a CLI:
+
+```
+candidate = <runDir>/gen-NNN/model.onnx           (must exist, spec-checked)
+champion  = best.json exists
+              ? nn:<best.json .onnx>:<gate.sims>
+              : mcts:<gate.sims>                   // gen-1 special case: pure UCT
+                                                   // is champion until first promotion
+result = runMatch(candidatePolicy, championPolicy, {
+  games: gate.games,                               // ≥ 100, must be even (assert)
+  cfg,                                             // from config.json
+  baseSeed: gate.baseSeed + gen * gate.games,      // fresh openings per gate,
+})                                                 // reproducible from config
+yardstick = runMatch(candidatePolicy, mcts400Policy, { games: gate.yardstick.games, … })
+write gen-NNN/arena.json  { candidate, champion, params, result, yardstick }
+if result.aWinRate >= gate.threshold (0.55): promote()
+advance STATE → gated either way
+```
+
+**Seat/seed schedule.** `runMatch` already alternates which policy takes
+seat 0 (`swap = g % 2 === 1`) and derives per-game determinism from
+`seed = baseSeed + g` with `mulberry32(seed * 7919 + 1)` — the gate reuses
+this unchanged. The per-generation `baseSeed` offset means no two gates
+replay the identical opening set (which would correlate outcomes across
+generations), while any gate is exactly reproducible from `config.json`.
+Even game counts are asserted so seats balance.
+
+**Parallelism.** 100 games at 200 sims is hours of single-threaded search
+(comparable to a self-play tranche), so gate games are distributed across
+the [15](15-selfplay-workers.md) worker pool by game index. The seed
+schedule is a pure function of `g`, so the result is identical at any worker
+count.
+
+The candidate-vs-`mcts:400` yardstick is always played and logged, never
+gated on: it is the fixed-strength ruler showing absolute progress across
+the whole run, whereas promoted-vs-promoted only shows relative progress.
+
+### best.json atomic update
+
+On promotion, write `runs/<id>/best.json`:
+
+```json
+{
+  "gen": 7,
+  "onnx": "gen-007/model.onnx",
+  "ckpt": "gen-007/ckpt/model.pt",
+  "arena": { "games": 100, "winRate": 0.58, "eloDiff": 56, "vsYardstick": 0.61 },
+  "promotedAt": "2026-07-01T04:12:33Z"
+}
+```
+
+Paths are run-relative so the run dir survives `rsync` to another machine
+([25](25-rocm-runbook.md)). The write is temp-file-then-`rename` on the same
+filesystem — atomic, so a crash mid-gate can never leave a torn champion.
+
+### Statistical notes — what 55% over 100 games means
+
+- The 95% binomial CI half-width at p̂ = 0.55 over 100 games is
+  1.96·√(0.55·0.45/100) ≈ **±9.8 percentage points** — the gate resolves
+  roughly "clearly better vs clearly not", nothing finer.
+- Under the null of an equal-strength candidate (p = 0.5), the chance of
+  scoring ≥ 55/100 is ~18% — a meaningful false-promotion rate per gate.
+- This is accepted deliberately: falsely promoting an *equal* net costs
+  almost nothing (its self-play data is as good as the old champion's), and
+  the ratchet is applied repeatedly, so drift toward weaker nets requires
+  repeatedly beating the gate from below — increasingly unlikely. Falsely
+  rejecting a slightly better net merely delays it one generation. The
+  `mcts:400` yardstick is the independent instrument that would expose
+  sustained regression.
+- SPRT (as chess-engine testing uses) reaches decisions on clearly
+  better/worse candidates in far fewer games, but adds sequential-stopping
+  machinery and interacts awkwardly with the fixed seed schedule and the
+  worker-pool dispatch. It stays a later nicety; the fixed-N gate is trivial
+  to audit.
+
+## Inputs
+
+- Candidate `model.onnx`, `best.json` (or its absence), gate params from
+  `config.json` (`games`, `sims`, `threshold`, `baseSeed`, yardstick spec).
+
+## Outputs
+
+- `gen-NNN/arena.json` (full match record, both matches); updated
+  `best.json` on promotion; `STATE` → `gated`.
+
+## How it runs / verification
 
 ```sh
 pnpm --dir agent arena 100 long nn:runs/r1/gen-003/model.onnx:200 nn:best@runs/r1:200
 pnpm --dir agent arena 50  long nn:best@runs/r1:400 mcts:400     # the yardstick
 ```
 
-- `nn:` builds a PUCT policy with an `OnnxEvaluator`, **no Dirichlet noise**,
-  argmax move selection (τ→0) — evaluation, not exploration.
-- Gate procedure (invoked by the orchestrator, [23](23-orchestrator.md)):
-  candidate vs `best.json`'s champion, ≥100 games, seats alternated
-  (`runMatch` already does this), fixed seed schedule.
-  **Promote on win-rate ≥ 0.55**; on promotion, update `runs/<id>/best.json`
-  `{ gen, onnx, ckpt, arena }`. SPRT early stopping is a later nicety.
-- Gen-1 special case: the champion is pure UCT (`mcts:<sims>`) until the
-  first net is promoted.
-- Always also log (not gate on) candidate vs `mcts:400` — the fixed-strength
-  yardstick that shows absolute progress across the whole run; promoted-vs-
-  promoted only shows relative progress.
+- `pnpm --dir agent test` — spec parsing (`nn:` path vs `best@` vs sims
+  suffix, error on missing best.json); promotion threshold logic including
+  draws-as-half; best.json update atomicity (write-temp-rename); async
+  `runMatch` still deterministic for sync policies.
+- Determinism: same config ⇒ same seeds ⇒ same match outcome, so every gate
+  in a run's history is auditable after the fact.
 
-## Inputs
+## Design notes & tradeoffs
 
-- Candidate `model.onnx`, `best.json`, gate params from `config.json`
-  (games, sims, threshold).
-
-## Outputs
-
-- `gen-NNN/arena.json` (full match record); updated `best.json` on
-  promotion; `STATE` → `gated`.
-
-## How it runs / verification
-
-- `pnpm --dir agent test` — spec parsing (`nn:`), promotion threshold logic,
-  best.json update atomicity (write-temp-rename).
-- Determinism: same seeds ⇒ same match outcome, so gates are auditable.
+- **Fixed-N 55% gate vs SPRT vs Elo threshold.** An Elo threshold is just a
+  win-rate threshold in different units (55% ≈ +35 Elo), so it adds nothing
+  at N=100. SPRT's real advantage — early stopping — matters when gates are
+  frequent and compute-precious; here one gate per 1–2 days of self-play is
+  a rounding error, and fixed-N keeps results reproducible and the code a
+  loop. Revisit if generation time drops 10×.
+- **Gating vs AlphaZero-style always-accept.** AlphaGo Zero gated at 55%
+  over 400 games; the final AlphaZero paper dropped gating and always used
+  the latest net, and KataGo largely follows suit — at their scale, data
+  volume and shuffling buffers smooth over a bad net. At *our* scale (500
+  games/gen, window 5), one collapsed value head generating a whole
+  generation of poisoned data is a real setback measured in days. Gating is
+  cheap insurance in the small-data regime; Leela Chess Zero's early history
+  (test runs derailed by regressions that gating would have caught) is the
+  cautionary tale.
+- **Evaluating with noise off and argmax.** The gate measures deployment
+  strength: no Dirichlet noise, τ→0. The known hazard is that two
+  deterministic players on a fixed opening replay the same game; here the
+  `START <seed>` opening randomization plus per-game seeds vary the games,
+  and seat alternation cancels first-mover bias. If arena games ever look
+  duplicated (identical command lists), the fix is a small τ for the first
+  few moves of arena games only — noted now so it is a knob, not a surprise.

--- a/docs/trainer/23-orchestrator.md
+++ b/docs/trainer/23-orchestrator.md
@@ -15,30 +15,116 @@ cleanly.
 
 ## Design
 
-- `agent/src/cli/loop.ts`, run as
-  `pnpm --dir agent loop --config runs/r1/config.json [--gens N]`.
-- Deliberately boring: a sequential driver that shells out
-  (`child_process`) to the four stage commands — each stage stays
-  independently runnable and debuggable; the orchestrator adds no logic of
-  its own beyond sequencing and bookkeeping.
-- `config.json` is the single source of truth: game cfg, sims, curation,
-  temperature, games/gen, window K, epochs, gate threshold, workers.
-- **Resume via `STATE` marker** per generation
-  (`selfplay → exported → trained → gated`): on start, find the first
-  incomplete stage of the latest generation and rerun it — every stage is
-  itself resumable/idempotent, so "resume = rerun the same command" holds
-  end-to-end.
-- Non-promotion path: keep the old champion, still advance to the next
-  generation (fresh data from the champion), flag the streak; ≥3 consecutive
-  failed gates halts the loop for a human look.
-- Prunes `shards/` of gated generations (JSONL stays).
-- Appends one summary line per generation to `runs/<id>/loop-log.jsonl`
-  (durations, games, loss, gate result, Elo vs yardstick).
+`agent/src/cli/loop.ts`, wired as a `"loop"` script in `agent/package.json`
+(alongside the existing `arena`/`selfplay` scripts, same
+`node --import tsx/esm` invocation):
+
+```sh
+pnpm --dir agent loop --config runs/r1/config.json [--gens N]
+```
+
+Deliberately boring: a sequential driver that shells out (`child_process`)
+to the stage commands. Each stage stays independently runnable and
+debuggable; the orchestrator adds no logic beyond sequencing, verification,
+and bookkeeping. `config.json` is the single source of truth (game cfg,
+sims, curation, temperature, games/gen, window K, epochs, gate params,
+workers); stage CLIs receive everything via `--run/--gen` plus explicit
+flags derived from it.
+
+### Stage state machine
+
+Per generation, `gen-NNN/STATE` holds the *last completed* stage:
+
+| STATE after | Stage command (spawned) | cwd | Done-condition verified before writing STATE |
+| --- | --- | --- | --- |
+| `selfplay` | `node --import tsx/esm src/cli/selfplay.ts --run <R> --gen N --games G --workers W [--net <best.onnx> --sims S]` | `agent/` | JSONL line count across `selfplay/worker-*.jsonl` ≥ G |
+| `exported` | `node --import tsx/esm src/cli/export.ts --run <R> --gen N` | `agent/` | every shard dir has all 7 `.npy` + `meta.json`; decision totals match JSONL |
+| `trained` | `uv run oel-train --run <R> --gen N --device auto --epochs E --window K` then `uv run oel-export-onnx --ckpt <R>/gen-NNN/ckpt/model.pt --out <R>/gen-NNN/model.onnx` | `trainer/` | `ckpt/model.pt`, `model.onnx`, `spec.json` all exist |
+| `gated` | `node --import tsx/esm src/cli/gate.ts --run <R> --gen N` | `agent/` | `arena.json` exists |
+
+Notes on the table:
+
+- `<R>` is the **absolute** run-dir path — children run with different cwds
+  (`agent/` vs `trainer/`), so relative paths are forbidden at this seam.
+- `--net` is passed iff `<R>/best.json` exists (gen-0 and pre-first-promotion
+  generations run the RolloutEvaluator, per [15](15-selfplay-workers.md)).
+- ONNX export is folded into the `trained` transition rather than getting its
+  own STATE value: it takes seconds, and "trained" meaning "ckpt **and**
+  servable model exist" keeps the 4-state machine of the
+  [README](README.md) layout intact.
+- The gate is a thin CLI wrapper (`gate.ts`) over [22](22-arena-gating.md)'s
+  procedure even though it lives in the same package — uniform
+  spawn/kill/resume semantics for all four stages beat saving one process
+  fork.
+
+Children are spawned with `stdio: 'inherit'` behind a line-prefixer
+(`[selfplay]`, `[train]`, …) so an overnight log reads chronologically, and
+awaited to exit; a nonzero exit fails the stage.
+
+### STATE file semantics
+
+- Content: a single token (`selfplay | exported | trained | gated`) plus
+  newline. Absent file = nothing completed for that generation.
+- Written **only by the orchestrator**, only after the done-condition above
+  is verified against real artifacts, via write-`STATE.tmp`-then-`rename`
+  (atomic; a crash between stage completion and marker write just means the
+  stage reruns, and every stage is idempotent/resumable by construction —
+  see [15](15-selfplay-workers.md)/[16](16-shard-exporter.md)/[19](19-training-loop.md)).
+  Keeping Python STATE-free means the marker logic exists in exactly one
+  place.
+
+### Resume-point selection
+
+```
+gen ← highest NNN with a gen-NNN/ dir (else 0)
+state ← read gen-NNN/STATE (absent ⇒ "none")
+if state == gated: gen ← gen + 1; state ← none
+run stages after `state` in order, then loop into gen+1
+```
+
+Because "resume = rerun the same stage command" holds for every stage,
+killing the loop anywhere — including mid-stage — loses at most partial
+work inside one stage.
+
+### Failure, retry, halt
+
+- Stage exits nonzero → retry once after 30 s (clears transient
+  OOM/filesystem hiccups); second failure halts the loop with a nonzero
+  exit, STATE untouched, so `loop` is safe to rerun after a fix.
+- **Halt conditions** (clean stop with a reason on stderr): 3 consecutive
+  failed gates (read back from `loop-log.jsonl`) — the net has stalled and a
+  human should look; free disk below a configured floor before starting
+  self-play; `--gens N` reached; SIGINT/SIGTERM (forwarded to the child,
+  then exit — the child's own resume story handles the rest).
+- Non-promotion is **not** failure: keep the old champion, advance to the
+  next generation (fresh data from the champion's self-play), record the
+  streak.
+
+### Bookkeeping
+
+- **Shard pruning**: after gen N is gated, delete `shards/` for generations
+  `< N − K + 1` (outside the training window — the window's shards must
+  survive for the next `oel-train`). JSONL is never pruned; if a needed
+  shard dir is missing at train time (pruned too eagerly, or an
+  encoder-version bump invalidated it), the orchestrator re-runs export for
+  that generation first — regeneration is the designed-in escape hatch of
+  [16](16-shard-exporter.md).
+- **`loop-log.jsonl`**: one line per generation, appended after gating:
+
+```jsonc
+{ "gen": 3, "startedAt": "…", "finishedAt": "…",
+  "durations": { "selfplay": 25100, "export": 310, "train": 940, "onnx": 12, "gate": 5200 },  // seconds
+  "games": 500, "decisions": 152340, "netId": "gen-003",
+  "loss": { "first": 4.81, "final": 3.12 },
+  "gate": { "games": 100, "winRate": 0.57, "eloDiff": 49, "promoted": true },
+  "yardstick": { "games": 100, "winRate": 0.44, "eloDiff": -42 },
+  "champion": "gen-003", "failedGateStreak": 0 }
+```
 
 ## Inputs
 
-- `runs/<id>/config.json`; the stage CLIs (`selfplay`, `export`, `uv run
-  oel-train`, `uv run oel-export-onnx`, `arena` gate).
+- `runs/<id>/config.json`; the stage CLIs (`selfplay`, `export`,
+  `uv run oel-train`, `uv run oel-export-onnx`, `gate`).
 
 ## Outputs
 
@@ -47,9 +133,40 @@ cleanly.
 
 ## How it runs / verification
 
-- Unit: STATE-machine transitions and resume-point selection
-  (`pnpm --dir agent test`).
+- Unit (`pnpm --dir agent test`): resume-point selection over synthetic run
+  dirs (every STATE value × present/absent artifacts); done-condition checks;
+  prune-set computation never touches the training window; STATE
+  write-temp-rename.
 - Integration: the smoke run ([24](24-smoke-e2e.md)) is this command with a
   tiny config.
 - Manual: kill it at each stage boundary and mid-stage; rerun; verify no
-  duplicated work and no corrupted markers.
+  duplicated work (JSONL line counts, shard counts) and no corrupted
+  markers.
+
+## Design notes & tradeoffs
+
+- **Shelling out vs in-process orchestration.** Three of five stage commands
+  are Node and could be imported and called directly, saving process spawns.
+  Shelling out wins anyway: crash isolation (a native-addon segfault in a
+  worker kills one stage, not the week-long loop), memory isolation (train
+  and selfplay never share a heap), identical invocations for "orchestrated"
+  and "run by hand while debugging", and the Python stages need
+  `child_process` regardless — one mechanism for five stages. The overhead
+  (a process spawn per stage per generation, milliseconds against hours) is
+  irrelevant.
+- **Node orchestrator vs bash vs Make.** Make's DAG model looks tempting
+  (STATE files are almost sentinel targets), but "count JSONL lines and
+  compare to config" or "read a failed-gate streak from a log" is painful in
+  Make, and bash grows unreadable exactly at the retry/verify/halt logic
+  that is this project's whole content. TypeScript in `agent/` gets the
+  existing test harness, typed config parsing shared with the stage CLIs,
+  and one language for all Node-side code. The loop body stays under a few
+  hundred lines either way.
+- **STATE files vs sqlite/manifest.** A run database would give queryable
+  history and transactional stage transitions, but introduces a schema, a
+  dependency, and a second source of truth that can disagree with the
+  filesystem. The filesystem *is* the state (artifacts + one marker file per
+  gen + append-only log), inspectable with `ls` and `cat`, rsync-able to the
+  GPU box or a rental with no migration step ([25](25-rocm-runbook.md)).
+  `loop-log.jsonl` covers the "queryable history" need well enough for one
+  machine and one run at a time.

--- a/docs/trainer/23-orchestrator.md
+++ b/docs/trainer/23-orchestrator.md
@@ -1,0 +1,55 @@
+# 23 — Generation orchestrator
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` |
+| Depends on | [15](15-selfplay-workers.md), [16](16-shard-exporter.md), [19](19-training-loop.md), [20](20-onnx-export.md), [22](22-arena-gating.md) |
+| Milestone | M6 |
+
+## Goal
+
+One command that runs generations unattended overnight: self-play → export →
+train → export-onnx → gate → (promote) → next generation. Dies and resumes
+cleanly.
+
+## Design
+
+- `agent/src/cli/loop.ts`, run as
+  `pnpm --dir agent loop --config runs/r1/config.json [--gens N]`.
+- Deliberately boring: a sequential driver that shells out
+  (`child_process`) to the four stage commands — each stage stays
+  independently runnable and debuggable; the orchestrator adds no logic of
+  its own beyond sequencing and bookkeeping.
+- `config.json` is the single source of truth: game cfg, sims, curation,
+  temperature, games/gen, window K, epochs, gate threshold, workers.
+- **Resume via `STATE` marker** per generation
+  (`selfplay → exported → trained → gated`): on start, find the first
+  incomplete stage of the latest generation and rerun it — every stage is
+  itself resumable/idempotent, so "resume = rerun the same command" holds
+  end-to-end.
+- Non-promotion path: keep the old champion, still advance to the next
+  generation (fresh data from the champion), flag the streak; ≥3 consecutive
+  failed gates halts the loop for a human look.
+- Prunes `shards/` of gated generations (JSONL stays).
+- Appends one summary line per generation to `runs/<id>/loop-log.jsonl`
+  (durations, games, loss, gate result, Elo vs yardstick).
+
+## Inputs
+
+- `runs/<id>/config.json`; the stage CLIs (`selfplay`, `export`, `uv run
+  oel-train`, `uv run oel-export-onnx`, `arena` gate).
+
+## Outputs
+
+- Fully populated `gen-NNN/` directories, an updated `best.json`, and
+  `loop-log.jsonl` — the run's audit trail.
+
+## How it runs / verification
+
+- Unit: STATE-machine transitions and resume-point selection
+  (`pnpm --dir agent test`).
+- Integration: the smoke run ([24](24-smoke-e2e.md)) is this command with a
+  tiny config.
+- Manual: kill it at each stage boundary and mid-stage; rerun; verify no
+  duplicated work and no corrupted markers.

--- a/docs/trainer/24-smoke-e2e.md
+++ b/docs/trainer/24-smoke-e2e.md
@@ -1,0 +1,48 @@
+# 24 — Smoke end-to-end run
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | repo (config + CI wiring) |
+| Depends on | [23](23-orchestrator.md) |
+| Milestone | M6 |
+
+## Goal
+
+Prove the whole loop closes — gen-0 self-play through training through a
+gated gen-1 — in minutes on any machine (laptop, CI, the trashcan), so
+pipeline regressions are caught before burning a GPU-day.
+
+## Design
+
+- `runs/smoke/config.json` (checked in): 2-player **short** game, 8
+  games/gen, 16 sims, curation `{maxPerLevel: 8, maxMoves: 32}`, 2 epochs,
+  window 1, gate of 6 games with threshold logged but not enforced, 2
+  workers, `--device cpu`.
+- Command: `pnpm --dir agent loop --config runs/smoke/config.json --gens 2`.
+- Assertions after the run (a small script, `pnpm --dir agent smoke`):
+  - `gen-000` used the RolloutEvaluator (netId `rollout`), `gen-001` used
+    `gen-000`'s ONNX;
+  - every `STATE` reached `gated`; `best.json` exists;
+  - overfit-style sanity: gen-000 training loss decreased monotonically-ish
+    (final < first);
+  - Node ONNX evaluator output matched the Python golden batch (from
+    [20](20-onnx-export.md)/[21](21-onnx-evaluator.md) fixtures).
+- CI: run on every PR touching `agent/`, `game/src/{control,encode}.ts`, or
+  `trainer/` (needs Python + uv in the workflow; cache the torch CPU wheel).
+
+## Inputs
+
+- The checked-in smoke config; no GPU, no network.
+
+## Outputs
+
+- A disposable `runs/smoke/` tree; pass/fail for CI.
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent loop --config runs/smoke/config.json --gens 2 && pnpm --dir agent smoke
+```
+
+Target wall-clock: < 10 minutes on a laptop CPU.

--- a/docs/trainer/24-smoke-e2e.md
+++ b/docs/trainer/24-smoke-e2e.md
@@ -15,29 +15,144 @@ pipeline regressions are caught before burning a GPU-day.
 
 ## Design
 
-- `runs/smoke/config.json` (checked in): 2-player **short** game, 8
-  games/gen, 16 sims, curation `{maxPerLevel: 8, maxMoves: 32}`, 2 epochs,
-  window 1, gate of 6 games with threshold logged but not enforced, 2
-  workers, `--device cpu`.
-- Command: `pnpm --dir agent loop --config runs/smoke/config.json --gens 2`.
-- Assertions after the run (a small script, `pnpm --dir agent smoke`):
-  - `gen-000` used the RolloutEvaluator (netId `rollout`), `gen-001` used
-    `gen-000`'s ONNX;
-  - every `STATE` reached `gated`; `best.json` exists;
-  - overfit-style sanity: gen-000 training loss decreased monotonically-ish
-    (final < first);
-  - Node ONNX evaluator output matched the Python golden batch (from
-    [20](20-onnx-export.md)/[21](21-onnx-evaluator.md) fixtures).
-- CI: run on every PR touching `agent/`, `game/src/{control,encode}.ts`, or
-  `trainer/` (needs Python + uv in the workflow; cache the torch CPU wheel).
+### The checked-in config
+
+`runs/smoke/config.json`, in full (same schema the real run uses,
+[26](26-first-run.md)):
+
+```json
+{
+  "run": "smoke",
+  "game": { "players": 2, "country": "france", "length": "short" },
+  "selfplay": {
+    "gamesPerGen": 8,
+    "workers": 2,
+    "sims": 16,
+    "cPuct": 1.5,
+    "dirichlet": { "epsilon": 0.25, "alpha": 0.5 },
+    "temperature": { "tau": 1.0, "moves": 8 },
+    "curation": { "maxPerLevel": 8, "maxMoves": 32 },
+    "gen0": { "evaluator": "rollout", "sims": 16, "rolloutDepth": 30 },
+    "baseSeed": 1000
+  },
+  "train": {
+    "device": "cpu",
+    "window": 1,
+    "epochs": 2,
+    "batchSize": 64,
+    "lr": 0.001,
+    "weightDecay": 0.0001,
+    "valueLossWeight": 1.0,
+    "seed": 7
+  },
+  "gate": {
+    "games": 6,
+    "sims": 16,
+    "threshold": 0.55,
+    "enforce": false,
+    "baseSeed": 9000,
+    "yardstick": null
+  }
+}
+```
+
+`"enforce": false` means the gate plays and logs but promotion happens
+regardless — 6 games of 16-sim search say nothing about strength, and the
+smoke run must exercise the promotion + `best.json` path deterministically.
+`"yardstick": null` skips the `mcts:400` match (pure runtime with no
+assertion value here). `train.seed` pins torch's RNG so the loss-decrease
+assertion below is reproducible.
+
+### Command and assertions
+
+```sh
+pnpm --dir agent loop --config runs/smoke/config.json --gens 2
+pnpm --dir agent smoke        # runs agent/src/cli/smoke.ts against runs/smoke/
+```
+
+The assertion script checks, in order (each failure names the file it
+inspected):
+
+1. `gen-000/STATE` and `gen-001/STATE` both read `gated`.
+2. Every gen-000 JSONL line has `netId: "rollout"`; every gen-001 line has
+   `netId: "gen-000"` — proving gen-1 actually played with gen-0's ONNX.
+3. JSONL line counts equal `gamesPerGen`; every game replays
+   (`v: 2`, decisions non-empty, visits sum to sims at each decision —
+   sampling a few games is enough).
+4. Shard `meta.json` decision totals equal the JSONL decision totals for
+   the same generation.
+5. `best.json` exists and points at `gen-001` artifacts that exist.
+6. Sanity, not strength: gen-000's `train-log.jsonl` final total loss <
+   first total loss (2 epochs on ~8 games with a fixed seed makes this
+   near-deterministic; see tradeoffs).
+7. The Node ONNX parity fixture test passed (already enforced by
+   `pnpm --dir agent test`, re-run here so the smoke job is self-contained).
+
+### CI wiring
+
+There is **no agent or trainer CI today** — `.github/workflows/` contains
+only `game.yml` (game tests on PRs touching `game/**`), `hourly.yml` (web
+cron), and `publish.yml` (npm release). This project adds the first
+workflow that installs the pnpm *workspace* (agent depends on
+`hathora-et-labora-game` via `workspace:`) and the first that installs
+Python. Sketch, following `game.yml`'s existing conventions
+(checkout@v7, pnpm/action-setup@v6, setup-node@v6, explicit pnpm-store
+cache):
+
+```yaml
+name: smoke
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [agent/**, trainer/**, game/src/**, runs/smoke/**, .github/workflows/smoke.yml]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with: { package_json_file: agent/package.json }
+      - uses: actions/setup-node@v6
+        with: { node-version: 24.x }          # pinned, NOT `latest` like game.yml:
+                                              # onnxruntime-node prebuilds lag new majors
+      # pnpm store cache: same 4 steps as game.yml, keyed on agent+game package.json
+      - run: pnpm install --no-frozen-lockfile          # repo root — workspace install
+      - uses: astral-sh/setup-uv@v7
+        with: { enable-cache: true, cache-dependency-glob: trainer/uv.lock }
+      - run: uv sync                                    # working-directory: trainer
+      - run: pnpm --dir agent loop --config runs/smoke/config.json --gens 2
+      - run: pnpm --dir agent smoke
+```
+
+Details that will bite if skipped:
+
+- **Torch CPU wheel caching**: `uv sync` with the default (CPU) extra pulls
+  a ~190 MB torch wheel; `setup-uv`'s cache keyed on `trainer/uv.lock` makes
+  that a one-time cost (~2–4 min cold, <30 s warm).
+- **onnxruntime-node postinstall** must be allowlisted in
+  `pnpm-workspace.yaml` (`onlyBuiltDependencies`) — see
+  [21](21-onnx-evaluator.md). The smoke job is the regression net for this.
+- Expected wall clock: setup ~2 min, `uv sync` warm <1 min, loop < 10 min,
+  assertions <1 min ⇒ **~12 min warm, ~16 cold**; `timeout-minutes: 30`
+  leaves headroom without letting a hang eat a runner for hours.
+
+### Deliberately NOT asserted
+
+- **Strength** of anything: gate win-rates, yardstick results, which side
+  won. 6 games at 16 sims are noise; asserting on them creates flaky CI.
+- Absolute loss values or loss *thresholds* — only first-vs-final ordering
+  under a fixed seed.
+- Timing (beyond the job timeout) — CI runners vary too much.
 
 ## Inputs
 
-- The checked-in smoke config; no GPU, no network.
+- The checked-in smoke config; no GPU, no network beyond package installs.
 
 ## Outputs
 
-- A disposable `runs/smoke/` tree; pass/fail for CI.
+- A disposable `runs/smoke/` tree (git-ignored except `config.json`);
+  pass/fail for CI.
 
 ## How it runs / verification
 
@@ -45,4 +160,35 @@ pipeline regressions are caught before burning a GPU-day.
 pnpm --dir agent loop --config runs/smoke/config.json --gens 2 && pnpm --dir agent smoke
 ```
 
-Target wall-clock: < 10 minutes on a laptop CPU.
+Target wall-clock: < 10 minutes on a laptop CPU. Also run manually after
+any change to the shard format, spec versions, or the ONNX graph contract —
+it is the only test that crosses all three language boundaries
+(TS engine → npy → torch → ONNX → onnxruntime-node) in one shot.
+
+## Design notes & tradeoffs
+
+- **Every PR vs nightly.** The paths filter already scopes the job to PRs
+  that touch the pipeline (`agent/`, `trainer/`, `game/src/`), so the
+  ~12-minute cost lands only where it can pay off; a repo where most PRs
+  touch `web/` never pays it. Nightly-only would be cheaper still, but this
+  pipeline's failure mode is "three-language integration rot discovered the
+  night you start a GPU run" — exactly the failure a per-PR gate exists to
+  prevent. If the job creeps past ~20 minutes, demote the loop to nightly
+  and keep unit + parity tests on PRs.
+- **Asserting loss decrease vs pipeline completion only.** Completion-only
+  is robust but would happily pass a trainer that reads shuffled targets and
+  learns nothing — the historical worst-case bug class here (silent
+  offset/perspective mixups). Loss decrease over 2 epochs on a tiny fixed
+  dataset with pinned seeds is the cheapest signal that gradients connect
+  data to loss, and it is near-deterministic in that regime. It can still
+  flake on a torch version bump changing kernel determinism; the agreed
+  response is to re-pin the seed/expectations in the same PR, never to
+  delete the assertion. Real learning verification lives in
+  [19](19-training-loop.md)'s overfit test and [26](26-first-run.md)'s
+  gates, not here.
+- **Why `gate.enforce: false` instead of a tiny real gate.** A real 55%
+  gate over 6 games is a coin flip that would randomly leave gen-1 either
+  promoted or not, making assertions 2 and 5 nondeterministic. Forcing
+  promotion keeps the smoke run a *pipeline* test with one deterministic
+  path through every branch that matters (including best.json writing);
+  gate *logic* correctness is unit-tested in [22](22-arena-gating.md).

--- a/docs/trainer/25-rocm-runbook.md
+++ b/docs/trainer/25-rocm-runbook.md
@@ -13,47 +13,148 @@ The RX 7800 XT (16 GB) box running Linux and training. Documented so it's
 reproducible after a reinstall, with the CUDA-rental path as a first-class
 alternate.
 
-## Runbook (to be executed and corrected in place)
+## What is known vs what must be verified on the box
 
-1. **OS**: Ubuntu 24.04 LTS, fresh install (the machine is being repurposed
-   from Windows).
-2. **ROCm 6.x** via AMD's apt repo; add user to `render`/`video` groups;
-   verify with `rocminfo` (agent should list `gfx1101`).
-3. **The unofficial-card override**: the 7800 XT is gfx1101; official ROCm
-   support targets gfx1100 (7900 series). Set for every training shell:
+| Claim | Confidence |
+| --- | --- |
+| RX 7800 XT is Navi 32 = `gfx1101`, 16 GB | known |
+| `gfx1101` is **not** on ROCm's official consumer support list (that's the 7900 series, `gfx1100`); the PRO W7700 (`gfx1101`) gained official support in later ROCm 6.x Radeon releases, so gfx1101 kernels exist in recent ROCm libs | known, but which stack versions ship them → **verify on the box** |
+| `HSA_OVERRIDE_GFX_VERSION=11.0.0` (run gfx1100 code objects on the gfx1101 card) is the long-standing community workaround and widely reported working for Navi 32 + PyTorch | known as a report; **verify on the box** — it is unsupported by AMD by definition |
+| PyTorch ROCm wheels compile for a fixed arch list; whether the current wheel includes native `gfx1101` objects (making the override unnecessary) | **verify on the box** — try without the override first |
+| Ubuntu 24.04 (noble) is a supported ROCm 6.x OS (added mid-6.1.x era); exact point-release ↔ kernel pairing | pairing itself known; current matrix → **verify at install time** at rocm.docs.amd.com |
+| torch ROCm wheel index URL shape: `https://download.pytorch.org/whl/rocm<X.Y>` | known shape; the exact `<X.Y>` that exists for the pinned torch version → **verify** on pytorch.org's install matrix |
+| ROCm torch masquerades as `cuda` (`torch.cuda.is_available()`, `--device auto` in [17](17-trainer-scaffold.md) resolves it) | known |
+
+## Runbook (execute top to bottom; correct this doc in place)
+
+1. **OS.** Ubuntu 24.04 LTS Desktop, fresh install (the machine is being
+   repurposed from Windows), stock kernel. Note the kernel version
+   (`uname -r`) in this doc once installed — ROCm's dkms module is
+   kernel-sensitive.
+2. **ROCm 6.x** via the `amdgpu-install` bootstrap (verify the latest 6.x
+   point release and exact URL against the ROCm install docs first):
+
+   ```sh
+   wget https://repo.radeon.com/amdgpu-install/<6.x.y>/ubuntu/noble/amdgpu-install_<...>_all.deb
+   sudo apt install ./amdgpu-install_*.deb
+   sudo amdgpu-install --usecase=rocm
+   sudo usermod -aG render,video $USER
+   # reboot, then:
+   rocminfo | grep -E 'gfx|Marketing'        # expect an agent reporting gfx1101
+   rocm-smi                                   # temps/VRAM visible
+   ```
+
+   Record the installed version: `apt show rocm-libs | grep Version`.
+3. **Torch.** `cd trainer && uv sync --extra rocm`. The `rocm` extra in
+   `pyproject.toml` pins torch against the ROCm wheel index:
+
+   ```toml
+   [[tool.uv.index]]
+   name = "pytorch-rocm"
+   url = "https://download.pytorch.org/whl/rocm6.X"   # verify: must match an index
+   explicit = true                                     # that exists for the pinned torch
+   ```
+
+4. **First contact — without the override**:
+
+   ```sh
+   uv run python -c "import torch; print(torch.__version__, torch.cuda.is_available(), torch.cuda.get_device_name(0) if torch.cuda.is_available() else '-')"
+   uv run oel-check-gpu     # device name, VRAM, matmul benchmark
+   ```
+
+   If the wheel carries native gfx1101 objects, this just works — record
+   that here and skip step 5.
+5. **The unofficial-card override.** On `torch.cuda.is_available() == False`
+   or `HIP error: invalid device function` at the first kernel launch:
+
    ```sh
    export HSA_OVERRIDE_GFX_VERSION=11.0.0
    ```
-   (and `PYTORCH_ROCM_ARCH=gfx1101` only if compiling extensions — we don't.)
-4. **uv + torch**: `cd trainer && uv sync --extra rocm` (pulls torch from the
-   ROCm wheel index). ROCm torch reports as `cuda` — `--device auto` in the
-   trainer resolves it; nothing else changes.
-5. **Verify**: `uv run oel-check-gpu` — device name, VRAM, and a matmul
-   benchmark; then the overfit test on GPU
-   (`uv run pytest -k overfit --device auto`).
-6. **Known failure modes**: kernel/driver mismatch after `apt upgrade`
-   (pin dkms), GPU hang on first-gen ROCm+RDNA3 with hostile batch sizes
-   (drop batch, upgrade ROCm), `HSA_OVERRIDE` forgotten (torch sees no
-   device — the check script tests for this and says so).
 
-## Cloud alternate (≤ $50 bring-up budget)
+   Set it for every training shell (a `trainer/.envrc` or a line in the
+   orchestrator's train-stage environment — not a global profile, so its
+   presence stays visible). `PYTORCH_ROCM_ARCH=gfx1101` matters only when
+   compiling extensions, which we don't.
+6. **Prove learning on GPU.** The overfit test from
+   [19](19-training-loop.md): `uv run pytest -k overfit` with
+   `--device auto` — loss to ~0 on 10 games. This exercises real
+   forward/backward kernels, not just a matmul.
+7. **Burn-in.** One real training epoch on smoke-run shards
+   ([24](24-smoke-e2e.md)) while watching `watch -n1 rocm-smi` — confirm GPU
+   utilization, VRAM well under 16 GB, temperatures sane, and no resets in
+   `sudo dmesg | grep -i amdgpu` afterwards.
+8. **Freeze the good state.** `sudo apt-mark hold` the amdgpu-dkms/rocm
+   packages (a routine `apt upgrade` breaking the kernel/driver pairing is
+   the top known failure mode), and record versions + any overrides in this
+   doc.
 
-- Any CUDA box (RunPod/Lambda, e.g. a 4090 at ~$0.4–0.7/hr ⇒ ~70–100 hrs of
-  budget — far more than needed to prove learning).
-- `rsync` the run dir (JSONL + shards or just JSONL + re-export), then:
-  `uv sync --extra cu12 && uv run oel-train --run … --gen N`.
-- Identical code path; checkpoints/ONNX rsync back.
+### Known failure modes
+
+- **Kernel/driver mismatch after `apt upgrade`** — dkms rebuild fails or the
+  GPU vanishes. Prevention: step 8's holds; recovery: reinstall the pinned
+  amdgpu-dkms against the running kernel.
+- **`HSA_OVERRIDE` forgotten** — torch sees no device or dies at first
+  kernel. `oel-check-gpu` explicitly tests for this and prints the fix.
+- **GPU hang under hostile batch shapes** (RDNA3 + early ROCm 6.x reports):
+  training stalls, `dmesg` shows ring timeouts. Response ladder: reduce
+  batch size; update ROCm point release; as a last resort the CPU fallback
+  below. Our model (~2M params) is tiny; this is unlikely but documented.
+
+## Fallback ladder (in order, cheapest first)
+
+1. **Override tweaks / ROCm point release change** — most Navi 32 reports
+   land here and succeed.
+2. **CPU training.** At ~2M params and ~750k-sample windows this is
+   genuinely viable: minutes-per-epoch territory, and self-play — not
+   training — is the pipeline's bottleneck ([README](README.md)). The first
+   generations can run `--device cpu` while the GPU is debugged; nothing
+   downstream changes.
+3. **Cloud CUDA rental (≤ $50 budget).** Any CUDA box (RunPod/Lambda; a 4090
+   at ~$0.4–0.7/hr ⇒ 70–100 hrs of budget — far more than needed to prove
+   learning). `rsync` the run dir (JSONL alone suffices; re-export shards
+   there), then `uv sync --extra cu12 && uv run oel-train --run … --gen N`.
+   Identical code path; checkpoints/ONNX rsync back. This is why
+   [17](17-trainer-scaffold.md) keeps plain-PyTorch and per-index extras.
 
 ## Inputs
 
-- The physical machine; `trainer/` from [17](17-trainer-scaffold.md).
+- The physical machine; `trainer/` from [17](17-trainer-scaffold.md);
+  smoke-run shards for burn-in.
 
 ## Outputs
 
 - A machine that passes `oel-check-gpu` and the GPU overfit test; this
-  document updated with anything that differed in practice.
+  document updated with the actual versions, whether the override was
+  needed, and anything that differed in practice.
 
 ## How it runs / verification
 
-- `uv run oel-check-gpu` clean; one real training epoch on smoke-run shards
-  completes with GPU utilization visible in `rocm-smi`.
+- `uv run oel-check-gpu` clean; `uv run pytest -k overfit` on GPU; one real
+  training epoch with GPU utilization visible in `rocm-smi` and a clean
+  `dmesg`.
+
+## Design notes & tradeoffs
+
+- **Bare-metal Ubuntu vs WSL2 vs dual-boot.** ROCm-on-WSL2 exists but
+  supports a narrower GPU list (flagship consumer cards), adds a
+  virtualization layer to an already-unofficial card, and Windows would
+  keep taxing the machine. Dual-boot preserves Windows at the cost of every
+  reboot being a context switch on a box meant to run unattended for weeks.
+  The machine is being dedicated to this; bare metal removes the two least
+  debuggable layers. The self-play workers are pure Node and portable, so
+  nothing else cares about the OS choice.
+- **ROCm version pinning vs tracking latest.** Latest point releases carry
+  the RDNA3 fixes we may need (arguing for newness at *install* time), but
+  a working driver + kernel + wheel triple on an unofficial card is
+  precious and easy to silently break (arguing for freezing afterwards).
+  Policy: install the newest 6.x at bring-up, then hold everything (step 8)
+  and only move all three components together, deliberately, re-running
+  steps 4–7 as the acceptance test.
+- **The unofficial-card risk and its blast radius.** The worst realistic
+  case — gfx1101 never runs reliably — is confined to the *train* stage:
+  JSONL, shards, checkpoints, and ONNX are all device-agnostic, and the
+  evaluator serves on CPU ([21](21-onnx-evaluator.md)). The fallback ladder
+  turns "GPU doesn't work" into "training costs ≤ $50 or some CPU-minutes
+  per generation", not a project risk. This containment is a direct payoff
+  of the plain-PyTorch, no-custom-kernels decision in the
+  [README](README.md)'s locked stack.

--- a/docs/trainer/25-rocm-runbook.md
+++ b/docs/trainer/25-rocm-runbook.md
@@ -1,0 +1,59 @@
+# 25 — ROCm hardware bring-up
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `trainer/` (scripts + this runbook) |
+| Depends on | [17](17-trainer-scaffold.md) |
+| Milestone | M7 |
+
+## Goal
+
+The RX 7800 XT (16 GB) box running Linux and training. Documented so it's
+reproducible after a reinstall, with the CUDA-rental path as a first-class
+alternate.
+
+## Runbook (to be executed and corrected in place)
+
+1. **OS**: Ubuntu 24.04 LTS, fresh install (the machine is being repurposed
+   from Windows).
+2. **ROCm 6.x** via AMD's apt repo; add user to `render`/`video` groups;
+   verify with `rocminfo` (agent should list `gfx1101`).
+3. **The unofficial-card override**: the 7800 XT is gfx1101; official ROCm
+   support targets gfx1100 (7900 series). Set for every training shell:
+   ```sh
+   export HSA_OVERRIDE_GFX_VERSION=11.0.0
+   ```
+   (and `PYTORCH_ROCM_ARCH=gfx1101` only if compiling extensions — we don't.)
+4. **uv + torch**: `cd trainer && uv sync --extra rocm` (pulls torch from the
+   ROCm wheel index). ROCm torch reports as `cuda` — `--device auto` in the
+   trainer resolves it; nothing else changes.
+5. **Verify**: `uv run oel-check-gpu` — device name, VRAM, and a matmul
+   benchmark; then the overfit test on GPU
+   (`uv run pytest -k overfit --device auto`).
+6. **Known failure modes**: kernel/driver mismatch after `apt upgrade`
+   (pin dkms), GPU hang on first-gen ROCm+RDNA3 with hostile batch sizes
+   (drop batch, upgrade ROCm), `HSA_OVERRIDE` forgotten (torch sees no
+   device — the check script tests for this and says so).
+
+## Cloud alternate (≤ $50 bring-up budget)
+
+- Any CUDA box (RunPod/Lambda, e.g. a 4090 at ~$0.4–0.7/hr ⇒ ~70–100 hrs of
+  budget — far more than needed to prove learning).
+- `rsync` the run dir (JSONL + shards or just JSONL + re-export), then:
+  `uv sync --extra cu12 && uv run oel-train --run … --gen N`.
+- Identical code path; checkpoints/ONNX rsync back.
+
+## Inputs
+
+- The physical machine; `trainer/` from [17](17-trainer-scaffold.md).
+
+## Outputs
+
+- A machine that passes `oel-check-gpu` and the GPU overfit test; this
+  document updated with anything that differed in practice.
+
+## How it runs / verification
+
+- `uv run oel-check-gpu` clean; one real training epoch on smoke-run shards
+  completes with GPU utilization visible in `rocm-smi`.

--- a/docs/trainer/26-first-run.md
+++ b/docs/trainer/26-first-run.md
@@ -10,7 +10,9 @@
 ## Goal
 
 The AlphaZero "it works" moment: a promoted generation that beats pure UCT
-at equal simulations, on the 2-player · long · France config.
+at equal simulations — brought up on 2-player · long · France, then widened
+to the full config matrix (1–4 players × short/long × both countries, solo
+success = score > 500; see "Widening to the full config mix" below).
 
 ## Starting configuration
 
@@ -140,6 +142,45 @@ widen `window` to 7–8 first (more diverse outcomes), then consider net
 scale (below). If *policy* loss plateaus **and** gates stall for 3+
 generations (the [23](23-orchestrator.md) halt), that is the real "look at
 everything" signal.
+
+## Widening to the full config mix
+
+The bring-up run above is deliberately single-config (2p·long·France — one
+bucket, one yardstick, fewest moving parts while pipeline bugs are still
+live). The target state is **all 16 configs** (1–4 players × short/long ×
+Ireland/France) served by the one config-conditioned net; the encoder
+already carries players/length/country one-hots, so this is a config change,
+not a code change. As soon as criteria 1–2 below hold on the bring-up run,
+start `runs/all-configs-v1` by widening `game` to a weighted mix, e.g.:
+
+```jsonc
+"game": { "mix": [
+  { "cfg": { "players": 2, "country": "france",  "length": "long"  }, "weight": 4 },
+  { "cfg": { "players": 2, "country": "ireland", "length": "long"  }, "weight": 2 },
+  { "cfg": { "players": 1, "country": "france",  "length": "long"  }, "weight": 2 },
+  { "cfg": { "players": 3, "country": "france",  "length": "long"  }, "weight": 2 },
+  { "cfg": { "players": 4, "country": "france",  "length": "long"  }, "weight": 2 },
+  { "cfg": { "players": 2, "country": "france",  "length": "short" }, "weight": 2 }
+  // …remaining combinations at weight 1
+]},
+"gate": { "panel": [
+  { "bucket": "2p-long-france",  "games": 100 },
+  { "bucket": "4p-short-ireland","games": 60 },
+  { "bucket": "1p-long-france",  "games": 50 }   // paired-seed, score>500 rate
+], "threshold": 0.55, "bucketFloor": 0.45 }
+```
+
+Self-play assigns each game's cfg by deterministic weighted round-robin over
+the mix ([15](15-selfplay-workers.md)); JSONL/shards are config-heterogeneous
+by design (every game line carries its `cfg`, every state row carries the
+config one-hots). **Solo success = final score > 500**: search and training
+use the `σ((score−500)/100)` value mapping from [09](09-game-adapter.md),
+and the journal tracks the solo bucket's score>500 rate alongside per-bucket
+gate results ([22](22-arena-gating.md)). Warm-start the all-configs run from
+the bring-up run's best checkpoint — the config planes were constant during
+bring-up, so the net treats new configs as unfamiliar inputs, not
+contradictory ones; expect a few generations before the 3–4p and solo
+buckets catch up.
 
 ## Success criteria
 

--- a/docs/trainer/26-first-run.md
+++ b/docs/trainer/26-first-run.md
@@ -1,0 +1,58 @@
+# 26 — First real training run
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | ops (a run dir + observations) |
+| Depends on | [24](24-smoke-e2e.md), [25](25-rocm-runbook.md) |
+| Milestone | M7 |
+
+## Goal
+
+The AlphaZero "it works" moment: a promoted generation that beats pure UCT
+at equal simulations, on the 2-player · long · France config.
+
+## Design
+
+- `runs/2p-long-france-v1/config.json` starting point:
+  - gen-0: 500 games, pure UCT at ~400 sims (RolloutEvaluator), curation
+    `{maxPerLevel: 24, maxMoves: 64}`;
+  - gen-1+: PUCT at 200 sims with the current net, Dirichlet ε 0.25 / α 0.5,
+    τ = 1 for 30 moves;
+  - train: window 5, 2 epochs/gen, AdamW, cosine LR;
+  - gate: 100 games at 200 sims, promote ≥ 0.55; always log vs `mcts:400`.
+- Expected wall-clock (to be corrected by [08](08-benchmarks.md) numbers):
+  ~1–3 s/move at 200 sims ⇒ roughly 500 games/day on 12 workers — a
+  generation every 1–2 days initially. If that's too slow, pull the levers in
+  README order (curation caps, sims schedule, in-worker batching) before any
+  new infrastructure.
+- Track per generation, in `loop-log.jsonl` and a small markdown journal in
+  the run dir: gate result, win-rate vs `mcts:400`, policy top-1 agreement,
+  value calibration.
+
+## Success criteria
+
+1. Gen-1 net's PUCT ≥ pure UCT at equal sims (sanity: the net learned
+   *something* from gen-0 data).
+2. Within a handful of generations, a promoted net **beats `mcts:400`
+   decisively at 200 sims** — search doing less work and winning more.
+3. The loop survives a week unattended (crashes resume, gates ratchet).
+
+## Inputs
+
+- Everything: the full pipeline (23/24) on the ROCm box (25).
+
+## Outputs
+
+- `runs/2p-long-france-v1/` with a promoted `best.json` — the first policy
+  artifact eligible for real-time play against humans (deployment is a
+  follow-on project, see README "Later").
+- Updated benchmark/throughput numbers and journal feeding the next planning
+  round.
+
+## How it runs / verification
+
+```sh
+pnpm --dir agent loop --config runs/2p-long-france-v1/config.json
+pnpm --dir agent arena 100 long nn:best@runs/2p-long-france-v1:200 mcts:400
+```

--- a/docs/trainer/26-first-run.md
+++ b/docs/trainer/26-first-run.md
@@ -12,23 +12,134 @@
 The AlphaZero "it works" moment: a promoted generation that beats pure UCT
 at equal simulations, on the 2-player · long · France config.
 
-## Design
+## Starting configuration
 
-- `runs/2p-long-france-v1/config.json` starting point:
-  - gen-0: 500 games, pure UCT at ~400 sims (RolloutEvaluator), curation
-    `{maxPerLevel: 24, maxMoves: 64}`;
-  - gen-1+: PUCT at 200 sims with the current net, Dirichlet ε 0.25 / α 0.5,
-    τ = 1 for 30 moves;
-  - train: window 5, 2 epochs/gen, AdamW, cosine LR;
-  - gate: 100 games at 200 sims, promote ≥ 0.55; always log vs `mcts:400`.
-- Expected wall-clock (to be corrected by [08](08-benchmarks.md) numbers):
-  ~1–3 s/move at 200 sims ⇒ roughly 500 games/day on 12 workers — a
-  generation every 1–2 days initially. If that's too slow, pull the levers in
-  README order (curation caps, sims schedule, in-worker batching) before any
-  new infrastructure.
-- Track per generation, in `loop-log.jsonl` and a small markdown journal in
-  the run dir: gate result, win-rate vs `mcts:400`, policy top-1 agreement,
-  value calibration.
+`runs/2p-long-france-v1/config.json`, in full (schema shared with
+[24](24-smoke-e2e.md)'s smoke config):
+
+```json
+{
+  "run": "2p-long-france-v1",
+  "game": { "players": 2, "country": "france", "length": "long" },
+  "selfplay": {
+    "gamesPerGen": 500,
+    "workers": 12,
+    "sims": 200,
+    "cPuct": 1.5,
+    "dirichlet": { "epsilon": 0.25, "alpha": 0.5 },
+    "temperature": { "tau": 1.0, "moves": 30 },
+    "curation": { "maxPerLevel": 24, "maxMoves": 64 },
+    "gen0": { "evaluator": "rollout", "sims": 400, "rolloutDepth": 60 },
+    "baseSeed": 100000
+  },
+  "train": {
+    "device": "auto",
+    "window": 5,
+    "epochs": 2,
+    "batchSize": 256,
+    "lr": 0.0002,
+    "lrSchedule": "cosine",
+    "weightDecay": 0.0001,
+    "valueLossWeight": 1.0,
+    "seed": 42
+  },
+  "gate": {
+    "games": 100,
+    "sims": 200,
+    "threshold": 0.55,
+    "enforce": true,
+    "baseSeed": 900000,
+    "yardstick": { "policy": "mcts:400", "games": 100 }
+  }
+}
+```
+
+Rationale for the non-obvious values: `dirichlet.alpha` 0.5 ≈ 10/⟨branching
+18⟩ per [13](13-puct-search.md); `gen0.sims` 400 because gen-0 data quality
+sets the ceiling for gen-1 and is paid only once; `tempMoves` 30 covers the
+settlement-and-early-building phase where opening diversity matters.
+
+## Expected generation timeline
+
+Derived from the [README](README.md) assumption of 1–3 s/move at 200 sims
+(midpoint 2 s), ~300 decisions/game, 12 workers — **to be corrected by
+[08](08-benchmarks.md) numbers before trusting any of it**:
+
+| Stage | Assumption | Estimate (range) |
+| --- | --- | --- |
+| gen-0 self-play, 500 games @ 400-sim UCT | 2–4 s/move, 150k moves ÷ 12 | ~10 h (7–14 h) |
+| gen-N self-play, 500 games @ 200 sims | 1–3 s/move, 150k moves ÷ 12 | ~7 h (3.5–10.5 h) |
+| export | ~1–2 ms/decision × ~150k | ~5 min |
+| train (window 5 ≈ 750k samples × 2 epochs, batch 256 ≈ 6k steps) | 10–30 ms/step GPU | ~5 min (CPU fallback: ~30–60 min) |
+| ONNX export | — | < 1 min |
+| gate 100 games + yardstick 100 games @ 200 sims, pooled | ~60k moves ÷ 12 | ~3 h (2–5 h) |
+| **Total per generation** | | **~10–15 h ⇒ ~1 generation/day** |
+
+So the week-one plan is: gen-0 overnight, then roughly one gated generation
+per day. Five generations ≈ one week — which is why decision point B exists.
+
+## Monitoring checklist and journal
+
+Each morning, from `loop-log.jsonl` plus a 5-minute look:
+
+- [ ] Loop still alive; no `failedGateStreak` growth; disk headroom OK.
+- [ ] Gate result and yardstick win-rate vs `mcts:400` (the absolute ruler).
+- [ ] `finishedRate` ≈ 1.0 and avg steps stable in self-play (a legality or
+      resign-path bug shows here first).
+- [ ] Train log: policy loss ↓ across generations; policy top-1 agreement
+      with `chosen` ↑; value calibration buckets roughly monotone.
+- [ ] Skim 2–3 games' command lists for obvious pathology (move loops,
+      degenerate all-commit endings).
+
+Journal (`runs/2p-long-france-v1/journal.md`), one entry per generation:
+
+```markdown
+## gen-003 — 2026-07-09
+- durations: selfplay 6.8h · train 4m · gate+yardstick 3.1h
+- gate: 61/100 vs gen-002 → PROMOTED   | yardstick: 44/100 vs mcts:400 (-42 Elo)
+- losses: policy 3.41→3.12 · value 0.221→0.209 · top-1 agreement 38%
+- eyeball: openings diversifying; still overvalues early Peat
+- changes made: none
+- next: watch value calibration bucket 0.7–0.9 (overconfident)
+```
+
+The "changes made" line is the discipline: one knob per generation, recorded.
+
+## Decision points
+
+**A. Gen-1 fails the sanity gate** (NN-PUCT at 200 sims loses to the pure
+UCT champion). Diagnostic ladder, in order — do not tune hyperparameters
+first:
+
+1. Plumbing: golden-batch parity test still green ([21](21-onnx-evaluator.md))?
+   `netId` in gen-1 JSONL actually `gen-000`?
+2. Data: gen-0 `finishedRate`, outcome balance (≈50/50 by seat), decisions
+   per game in the expected 250–350 band.
+3. Learning: did the [19](19-training-loop.md) overfit test pass on *this*
+   box? Is policy top-1 agreement meaningfully above chance (≳ 25% vs the
+   ~5% of uniform-over-18)? If not, the net learned nothing — inspect
+   shards, not the LR.
+4. Only then tune: +2 epochs, or halve LR, retrain gen-1 from the same
+   shards (cheap — no new self-play needed) and re-gate.
+5. If two retrains fail: generate 500 more gen-0 games (data volume is the
+   most likely ceiling) before touching architecture.
+
+**B. Throughput too low** (< ~300 games/day sustained, i.e. > ~36 h/gen):
+pull the README levers in order — verify `completions()` fast path is
+actually engaged ([07](07-engine-fast-paths.md)), lower curation caps
+(`maxMoves` 64 → 48), then a sims schedule (e.g. 200 → 120 after move 60,
+where branching collapses), then Stage-2 in-worker batching
+([12](12-evaluator-interface.md)). Only after all four: consider fewer
+games/gen (see tradeoffs). Never silently drop `gate.games`.
+
+**C. Value loss plateaus** while policy loss still falls: expected, not
+alarming — value MSE bottoms out at the outcome variance of near-even
+positions. Check *calibration* (predicted-vs-actual by bucket) instead of
+raw MSE. Act only if calibration is bad or gates stall alongside it:
+widen `window` to 7–8 first (more diverse outcomes), then consider net
+scale (below). If *policy* loss plateaus **and** gates stall for 3+
+generations (the [23](23-orchestrator.md) halt), that is the real "look at
+everything" signal.
 
 ## Success criteria
 
@@ -40,15 +151,16 @@ at equal simulations, on the 2-player · long · France config.
 
 ## Inputs
 
-- Everything: the full pipeline (23/24) on the ROCm box (25).
+- Everything: the full pipeline ([23](23-orchestrator.md),
+  [24](24-smoke-e2e.md)) on the ROCm box ([25](25-rocm-runbook.md)).
 
 ## Outputs
 
 - `runs/2p-long-france-v1/` with a promoted `best.json` — the first policy
   artifact eligible for real-time play against humans (deployment is a
-  follow-on project, see README "Later").
-- Updated benchmark/throughput numbers and journal feeding the next planning
-  round.
+  follow-on project, see [README](README.md) "Later").
+- Corrected timing table above, journal, and benchmark numbers feeding the
+  next planning round.
 
 ## How it runs / verification
 
@@ -56,3 +168,36 @@ at equal simulations, on the 2-player · long · France config.
 pnpm --dir agent loop --config runs/2p-long-france-v1/config.json
 pnpm --dir agent arena 100 long nn:best@runs/2p-long-france-v1:200 mcts:400
 ```
+
+## Design notes & tradeoffs
+
+- **500 games/gen vs more.** More games per generation means better policy
+  targets and less overfitting per net, but at ~1 gen/day, 2,000 games/gen
+  would mean one *feedback cycle* every 4 days — and early on, feedback
+  cycles (finding pipeline and data bugs) are worth more than data quality.
+  500 games × window 5 still trains each net on ~2,500 games. Scale
+  games/gen up only after the loop is demonstrably learning (criteria 1–2)
+  and throughput levers are exhausted.
+- **200 sims vs 400 for NN self-play.** Halving sims halves generation time;
+  AlphaZero-style training tolerates it because the net supplies prior
+  quality that raw UCT lacks — 200 NN-guided sims should quickly exceed 400
+  blind ones (that is literally success criterion 2). Gen-0 gets 400 because
+  there is no net to compensate, and it is a one-time cost. If gen-1 gating
+  is marginal, raising gen-1's sims is the *last* lever, not the first —
+  data volume and training fixes come cheaper.
+- **Window 5.** Window 1 forgets too fast at 500 games (each net sees only
+  its predecessor's biases); a very long window trains on stale, weaker
+  play. K=5 ≈ 2,500 games ≈ 750k decisions is enough for a 2M-param net
+  without letting gen-1 data haunt gen-9. Widen toward 7–8 if value
+  calibration is poor (decision C); shrink toward 3 if the yardstick curve
+  shows the net dragging old mistakes forward after big jumps.
+- **When to scale the net.** Signals that ~2M params is the binding
+  constraint, all of which must hold: training loss floors *above* the
+  overfit-test regime (underfitting, not data noise), policy top-1
+  agreement saturated across 2–3 generations, gates stalling, and the
+  throughput budget shows headroom (a bigger net raises the 0.2–1 ms/eval
+  in [21](21-onnx-evaluator.md), where the math says ~4× params is
+  absorbable while engine-bound). Scale depth before width, re-run the
+  overfit and parity tests, and note that a net change invalidates nothing
+  durable — JSONL survives, shards re-export, and `best.json` keeps
+  gating the new architecture against the old champion honestly.

--- a/docs/trainer/27-realtime-deployment.md
+++ b/docs/trainer/27-realtime-deployment.md
@@ -72,20 +72,20 @@ humans watch each command land live.
 Two layers, because realtime alone is not reliable enough to stake a human's
 game on:
 
-1. **Supabase Realtime subscription** per seated game on the broadcast topic
+1. **Supabase Realtime subscription** per seated game on broadcast topic
    `instance:<id>` (the trigger in
    `supabase/migrations/20250222000341_realtime_instance_broadcasts.sql`
    already publishes every update). A broadcast is a *wake-up*, never trusted
-   as state: on wake, fetch + replay + check `activePlayerIndex` color against
-   the bot's entrant colors.
+   as state: on wake, fetch + replay + check the active color against the
+   bot's entrant colors.
 2. **Slow poll** (default 30 s) over the same seated-games query — catches
-   dropped websockets, and is also how the bot discovers *new* games it was
-   just invited to (there is no broadcast for `entrant` inserts).
+   dropped websockets, and discovers *new* games the bot was just invited to
+   (there is no broadcast for `entrant` inserts).
 
 A single scheduler serializes work per game (one in-flight decision per
-`instance_id`) and caps global search concurrency at 1 in v1 — several games
-in flight simply queue, which keeps CPU and latency predictable. One seat per
-game; a wake for a game where it is not the bot's turn is a no-op.
+`instance_id`) and caps global search concurrency at 1 in v1 — concurrent
+games simply queue, keeping CPU and latency predictable. One seat per game;
+a wake when it is not the bot's turn is a no-op.
 
 ### Time-bounded search
 
@@ -110,13 +110,13 @@ Every fallback is tagged in the move log; a healthy deploy shows zero.
 
 ### Model management
 
-`BOT_MODEL=best@runs/<id>` reuses [22](22-arena-gating.md)'s `best@` resolution:
-read `best.json`, resolve `onnx` run-relative (an rsync'd copy of the run dir
-works — paths are run-relative by design). The daemon polls `best.json`'s
-mtime (~60 s); on change it constructs a fresh evaluator (spec assertion
-included), swaps it **between** moves only, and keeps the old one if the new
-load fails. `spec.netId` (e.g. `gen-007`) is logged with every move — "which
-net played this" is auditable per move, matching JSONL provenance in
+`BOT_MODEL=best@runs/<id>` reuses [22](22-arena-gating.md)'s `best@`
+resolution: read `best.json`, resolve `onnx` run-relative (an rsync'd copy of
+the run dir works — paths are run-relative by design). The daemon polls
+`best.json`'s mtime (~60 s); on change it constructs a fresh evaluator (spec
+assertion included), swaps it **between** moves only, and keeps the old one
+if the new load fails. `spec.netId` (e.g. `gen-007`) is logged with every
+move — "which net played this" stays auditable, matching JSONL provenance in
 [14](14-selfplay-v2.md).
 
 ### Human-experience knobs

--- a/docs/trainer/27-realtime-deployment.md
+++ b/docs/trainer/27-realtime-deployment.md
@@ -1,0 +1,222 @@
+# 27 — Real-time deployment (bot daemon)
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `bot/` (new top-level workspace package) |
+| Depends on | [21](21-onnx-evaluator.md), [22](22-arena-gating.md), web/MCP server ([design](../mcp-server-design.md), shipped) |
+| Milestone | M8 |
+
+## Goal
+
+The end goal of the whole trainer: humans on kennerspiel.com play against the
+promoted net in real time. A small always-on daemon holds seats like any other
+player, notices when it is its turn, runs a **wall-clock-budgeted** PUCT search
+with the current champion, and appends its move through the same CAS write
+path the web and MCP server use.
+
+## Design
+
+### Where inference runs: a daemon, not serverless
+
+A new top-level `bot/` package — not `agent/`, not `web/`. `agent/` stays
+deployment-blind (no Supabase dependency, no daemon loop); `web/` stays
+inference-free (`onnxruntime-node` must never enter the Vercel bundle, per
+[21](21-onnx-evaluator.md)'s "`game/` and `web/` never see it"). `bot/`
+depends on both worlds: it imports the OeL adapter ([09](09-game-adapter.md)),
+`puct` ([13](13-puct-search.md)) and `createOnnxEvaluator` ([21](21-onnx-evaluator.md))
+from `agent/`, plus `@supabase/supabase-js` for the game store.
+
+It runs as one long-lived Node process on an always-on box (the Linux training
+machine or the trashcan Mac Pro — both have `onnxruntime-node` prebuilds).
+Alternatives rejected:
+
+- **Inference in the Next.js API on Vercel** — `onnxruntime-node` is a large
+  native addon squeezed against serverless bundle limits; cold starts re-create
+  the `InferenceSession` per invocation; execution caps (the MCP route already
+  runs `maxDuration = 60`; cheaper tiers cap far lower) sit uncomfortably close
+  to multi-second searches; no persistent process for hot-reload, per-game
+  queues, or a warm session.
+- **Supabase edge function** — Deno runtime: no `onnxruntime-node` at all,
+  only WASM ORT at a large slowdown, plus tight CPU-time limits that a
+  3–5 s search blows through. Fine for webhooks, wrong for search.
+
+### Game I/O: direct Postgres, same CAS append
+
+The bot is a first-class player exactly as the MCP design specifies: its own
+Supabase auth user (`BOT_PROFILE_ID`), seated via ordinary `entrant` rows —
+humans invite it from the web lobby. I/O per turn:
+
+- **Read**: `select commands from instance` for seated games (join through
+  `entrant`), then adapter replay — the bot must replay locally to search
+  anyway, so the raw command list is the natural wire format (the MCP
+  `get_game` summary is prose-shaped for LLMs, useless to PUCT).
+- **Write**: the existing `append_command(p_instance_id, p_expected_count,
+  p_command)` CAS RPC
+  (`supabase/migrations/20260612070000_create_append_command_function.sql`).
+  CAS on command count makes retries idempotent: a duplicate attempt after a
+  crash or blip returns zero rows instead of double-appending; the bot
+  re-reads, re-replays, re-decides. Before writing, the bot re-runs the same
+  seat/turn/legality pipeline `make_move` enforces
+  (`web/src/mcp/tools/makeMove.ts`) — cheap, the replayed state is in hand.
+- v1 uses the service-role key on the box, the same trust level the Vercel
+  project already holds; the MCP-HTTP alternative is weighed in tradeoffs.
+
+Multi-command turns (actions then `COMMIT`) fall out naturally: after each
+successful append, replay again; if the bot's seat is still active, search
+again. The existing broadcast trigger fires on every `instance` UPDATE, so
+humans watch each command land live.
+
+### Turn detection
+
+Two layers, because realtime alone is not reliable enough to stake a human's
+game on:
+
+1. **Supabase Realtime subscription** per seated game on the broadcast topic
+   `instance:<id>` (the trigger in
+   `supabase/migrations/20250222000341_realtime_instance_broadcasts.sql`
+   already publishes every update). A broadcast is a *wake-up*, never trusted
+   as state: on wake, fetch + replay + check `activePlayerIndex` color against
+   the bot's entrant colors.
+2. **Slow poll** (default 30 s) over the same seated-games query — catches
+   dropped websockets, and is also how the bot discovers *new* games it was
+   just invited to (there is no broadcast for `entrant` inserts).
+
+A single scheduler serializes work per game (one in-flight decision per
+`instance_id`) and caps global search concurrency at 1 in v1 — several games
+in flight simply queue, which keeps CPU and latency predictable. One seat per
+game; a wake for a game where it is not the bot's turn is a no-op.
+
+### Time-bounded search
+
+`puct()` gains a `budgetMs` option beside `sims` (small additive change in
+`agent/src/mcts/puct.ts`): the sim loop stops when **either** `sims` is
+reached **or** `elapsed ≥ budgetMs`, subject to a `minSims` floor so a GC
+pause cannot reduce a move to noise. Arena/self-play pass no budget and are
+bit-identical to before. Play settings mirror the gate ([22](22-arena-gating.md)):
+**no Dirichlet noise, τ→0 argmax** — deployment strength, not exploration.
+The single-candidate short-circuit from [13](13-puct-search.md) already makes
+forced moves instant.
+
+Degradation ladder — the bot must never stall a human's game:
+
+1. `OnnxEvaluator` with the current champion (normal case).
+2. Net missing or `spec.json` mismatch at load ([21](21-onnx-evaluator.md)'s
+   assertion): log loudly, play **greedy 1-ply** over `adapter.heuristic`.
+3. Evaluator failure mid-search: retry the move once, then fall back to the
+   rollout policy (`mcts:` at low sims), then greedy.
+
+Every fallback is tagged in the move log; a healthy deploy shows zero.
+
+### Model management
+
+`BOT_MODEL=best@runs/<id>` reuses [22](22-arena-gating.md)'s `best@` resolution:
+read `best.json`, resolve `onnx` run-relative (an rsync'd copy of the run dir
+works — paths are run-relative by design). The daemon polls `best.json`'s
+mtime (~60 s); on change it constructs a fresh evaluator (spec assertion
+included), swaps it **between** moves only, and keeps the old one if the new
+load fails. `spec.netId` (e.g. `gen-007`) is logged with every move — "which
+net played this" is auditable per move, matching JSONL provenance in
+[14](14-selfplay-v2.md).
+
+### Human-experience knobs
+
+Per-config difficulty levels map to search effort:
+
+```
+casual: { budgetMs: 1000, minSims:  50 }    tournament: { budgetMs: 5000, minSims: 400 }
+plus optional openingTemperature (τ > 0 for the first N plies) for variety
+```
+
+`minDelayMs` (default ~1500) pads instant replies (forced moves, cache hits)
+so the bot doesn't feel like a vending machine. Resign/mercy rules are out of
+scope for v1 — Ora et Labora ends by structure, not by resignation.
+
+### Ops
+
+- **Supervision**: a systemd unit (`bot/deploy/kennerspiel-bot.service`,
+  `Restart=always`); pm2 works identically if preferred.
+- **Stateless by construction**: all game state is the Postgres command list;
+  a crash-restart re-derives everything, and CAS means a move half-attempted
+  before the crash either landed or didn't — no repair step.
+- **Structured log**, one JSON line per move: `{ ts, instanceId, step,
+  moveKey, netId, value, sims, elapsedMs, budgetMs, forced, fallback }`.
+- **Health endpoint** on localhost (`/healthz`): last poll time, realtime
+  connection state, seated-game count, current `netId`, queue depth.
+
+## Implementation plan
+
+1. `bot/package.json` + workspace entry in `pnpm-workspace.yaml`; deps:
+   `agent` (workspace), `@supabase/supabase-js`; `bot/src/config.ts` (env +
+   difficulty table).
+2. `agent/src/mcts/puct.ts`: add `budgetMs`/`minSims` to options (tested:
+   budget respected, `minSims` floor, no behavior change when unset).
+3. `bot/src/db.ts` — service client, `listSeatedGames()`, `fetchCommands()`,
+   `appendCommand()` (CAS + zero-rows handling).
+4. `bot/src/turns.ts` — realtime subscriptions + slow poll, per-game queue.
+5. `bot/src/model.ts` — `best.json` watcher, evaluator swap, netId.
+6. `bot/src/play.ts` — replay → seat/turn checks → budgeted `puct` → ladder →
+   pacing → append; the move-log line lives here.
+7. `bot/src/main.ts` (daemon wiring) + `bot/src/health.ts`.
+8. `bot/src/__tests__/` — CAS-conflict retry, ladder selection, budget/pacing
+   math, hot-reload swap (all against a stub client + fixture games).
+9. `bot/deploy/kennerspiel-bot.service`; runbook notes in this doc's How-it-runs.
+
+## Inputs
+
+- `runs/<id>/best.json` + champion `model.onnx`/`spec.json` ([22](22-arena-gating.md)).
+- Supabase: `instance`/`entrant` tables, `append_command` RPC, realtime
+  broadcasts; env: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`,
+  `BOT_PROFILE_ID`, `BOT_MODEL`.
+
+## Outputs
+
+- Moves appended to live games (rendered by the existing web UI in realtime);
+  per-move JSONL log with netId provenance; `/healthz`.
+
+## How it runs / verification
+
+```sh
+pnpm --dir bot start                                   # daemon (env-configured)
+pnpm --dir bot start --dry-run --fixture game.jsonl    # decide, print, never write
+pnpm --dir bot test
+```
+
+- **Dry-run** replays a fixture command list and prints the chosen move +
+  stats — no network, safe anywhere.
+- **Staging**: seat two bot profiles in one real game (branch deploy + real
+  Supabase); the daemon plays itself through the production write path to
+  completion.
+- **Latency assertion**: over a staged game, p95 `elapsedMs ≤ budgetMs + 500`
+  and every move ≥ `minDelayMs` — checked from the move log by a test script.
+- **Acceptance**: one full game vs a human via the web UI, with the move log
+  showing budgeted searches, zero fallbacks, and the expected `netId`.
+
+## Design notes & tradeoffs
+
+- **Daemon vs Vercel vs edge function.** Chosen: daemon. Serverless buys
+  autoscaling the bot doesn't need and charges for it in cold-started
+  sessions, execution caps, and native-addon friction; the edge function
+  can't run ORT natively at all. The daemon's one real cost — a box to keep
+  alive — is already paid by the trainer ([25](25-rocm-runbook.md)).
+- **Direct DB vs the MCP HTTP tools.** The MCP path would reuse `make_move`'s
+  validation and need only the narrow bearer token instead of the service-role
+  key — genuinely better auth hygiene. But its read surface is LLM-prose
+  (summaries, completion trees), not the command lists the adapter needs, and
+  `wait_for_my_turn` is itself a ≤55 s serverless poll — a daemon on Realtime
+  is strictly better placed. Chosen: direct DB for v1, duplicating ~30 lines
+  of seat/turn checks; improve auth later by making the bot a real authed
+  user under RLS (the MCP design's own noted upgrade), not by routing search
+  through HTTP.
+- **Polling vs Realtime.** Either alone is wrong: pure polling at human-game
+  cadence means dead air after every human move; pure Realtime silently
+  wedges on dropped websockets. Broadcast-as-wake-up + slow-poll-as-truth
+  costs ~20 lines and removes both failure modes.
+- **Time budget vs fixed sims.** Fixed sims made arena results reproducible;
+  a human opponent cares about wall clock. Budget + `minSims` floor bounds
+  the worst case in both directions; logging sims-reached preserves the
+  strength signal fixed-sims used to give.
+- **Hot-reload vs restart-to-upgrade.** Restart is simpler and systemd makes
+  it cheap — but it drops in-flight queue state and turns every promotion
+  into an ops action. The watcher is ~30 lines, swaps only between moves,
+  fails closed to the old net; kept. Restart stays the manual escape hatch.

--- a/docs/trainer/28-second-game-onboarding.md
+++ b/docs/trainer/28-second-game-onboarding.md
@@ -1,0 +1,219 @@
+# 28 — Second-game onboarding
+
+| | |
+| --- | --- |
+| Status | planned |
+| Package | `agent/` + the new game's engine package |
+| Depends on | [09](09-game-adapter.md)–[22](22-arena-gating.md) |
+| Milestone | M9 (new) |
+
+## Goal
+
+Plug a second heavy-euro game (another Uwe-style engine — think Agricola,
+Caverna, Glass Road) into the trainer by implementing exactly one adapter and
+two encoders, reusing search/self-play/export/training/gating byte-for-byte.
+This doc is the concrete checklist: what the new engine must provide, what
+the adapter must satisfy, and the acceptance gates that prove it — with the
+gotchas OeL already taught us attached to each step.
+
+## Design
+
+### Engine prerequisites (hard requirements, engine-side)
+
+The new game's engine package must provide, before any adapter work starts:
+
+- **A pure reducer over serializable state** — `(state, command) → state`,
+  no hidden mutability, state round-trips through JSON. JSONL replay, the
+  exporter's incremental cursor ([16](16-shard-exporter.md)), and golden
+  tests all assume replayability.
+- **A legal-move oracle** — either token-completion style like OeL's
+  `control()`/`completions()` (partial command → next-token candidates) or a
+  direct full-move enumerator. The adapter absorbs either shape;
+  completion-style is nicer for human UIs but is *not* required for training.
+- **Determinism after a seeded start** — given the opening commands (OeL's
+  `CONFIG`/`START` analog, seed included), the game is a pure function of its
+  seed: card draws and tile flips derive from seeded state, never from
+  `Math.random` inside the reducer.
+- **Per-player scoring, callable mid-game and terminal** — the rollout
+  cutoff and gen-0 self-play evaluate *non-terminal* states
+  ([09](09-game-adapter.md)'s `outcome` contract, [12](12-evaluator-interface.md)'s
+  `RolloutEvaluator`).
+- **A terminal predicate** and correct **player-to-move at every state** —
+  including any interrupt/response sub-turns. OeL's `WORK_CONTRACT`
+  interrupts were the bug magnet here; per-node `playerToMove` is what makes
+  PUCT's per-player backup correct ([13](13-puct-search.md)).
+
+Not required (OeL luxuries the core never sees): interrupt semantics, a
+neutral player, a rondel, a landscape grid, or a completion-token grammar.
+Required contracts regardless of genre: `outcome()` returns per-player values
+in `[0,1]` **with a defined mid-game meaning** (score rank for comparative
+games); non-comparative/solo modes need an explicit squash — follow the solo
+σ-mapping precedent from [09](09-game-adapter.md) (`σ((score − target)/scale)`,
+thresholds in adapter config, the binary rate stays the reported metric).
+
+### The adapter checklist (`GameAdapter<TState, TMove, TCfg>` from [09](09-game-adapter.md))
+
+Implement `agent/src/game/<game>.ts` item by item, each with its OeL lesson:
+
+- `name`, `initial(cfg, seed)` — replay the opening; a bad opening throws.
+- `apply` — reducer + throw→`undefined`; never partially mutates.
+- `isTerminal` / `playerToMove` / `numPlayers` — trivial delegations, but
+  `playerToMove` must be right during sub-turns (see above).
+- `outcome` — per-player `[0,1]`, defined mid-game; map solo/co-op modes
+  through a σ-squash as in [09](09-game-adapter.md).
+- `legalMoves(state, caps)` — **canonical + deduped, no exceptions.** Before
+  writing any code, audit the new engine's move emission for OeL's k²
+  joined-token equivalent ([10](10-move-canonicalization.md)): anywhere
+  enumeration emits multiple encodings of one reducer-identical move splits
+  policy mass and wastes curation budget. Write the game's `canonicalize` +
+  in-DFS seen-set first; prove it with the never-merge-distinct-states
+  property over a state corpus.
+- `moveKey(move)` — canonical serialization that **round-trips**
+  (`parseMoveKey(moveKey(m))` reapplies identically) and contains **no
+  whitespace inside a token**, so join-with-space/`split(' ')` is unambiguous.
+  This key is the JSONL v2 and shard identity
+  ([14](14-selfplay-v2.md)/[16](16-shard-exporter.md)).
+- `sampleMove(state, rng)` — **cheap**: a random completion walk or
+  equivalent, never full enumeration. Rollouts call it in the inner loop;
+  enumerate-then-pick silently multiplies gen-0 cost by the branching factor.
+- `heuristic?` — optional; only needed for a greedy baseline.
+- `featureSpec` + `encodeState`, `actionSpec` + `encodeMove` — below.
+
+### State encoder guidelines (the new game's `encode.ts`)
+
+Follow [01](01-state-encoder.md)'s shape, not its contents:
+
+- **Egocentric rotation**: mover → slot 0, relative turn order preserved;
+  frame player one-hots emitted in rotated slot space.
+- **Fixed-capacity categorical vocabs, append-only ordering** — 01's
+  stability rule. Trained weights are keyed by id position; reordering is
+  silent corruption. Pin specific ids in tests.
+- **Anchored spatial grids** if the game has player boards (Agricola/Caverna
+  farms): fix logical origin to a constant output row/col so bookkeeping
+  offsets don't shift learned spatial features.
+- **Reserve capacity on day one** for every expansion axis the game is known
+  to have (decks, expansion buildings, player counts) — OeL's
+  country-capacity lesson from [07](07-engine-fast-paths.md): reserving slots
+  while no trained weights exist is free; growing a vocab later invalidates
+  every checkpoint.
+- **Emit `featureSpec`** with `featureLen`, `version`, block offsets, grid
+  geometry, `categorical` entries, and every vocab list. The Python side is
+  data-driven ([18](18-model.md)): the **same OelNet architecture family**
+  applies by changing `spec.json` only — grid dims, channel counts, scalar
+  widths, and vocab capacities are all spec-driven. The one case needing
+  actual `model.py` code: a game with **no spatial board** makes the conv
+  tower optional (spec declares zero grids; the trunk consumes scalars
+  only) — a small, guarded change, not a fork.
+
+### ActionSpec / move encoder guidelines ([11](11-action-encoder.md) generalized)
+
+Decompose each canonical move into fixed-length blocks:
+
+- command **one-hot** (append-only command vocab);
+- categorical ids (cards, buildings, animals) **sharing the state-side
+  embedding vocabs** — same id space as the corresponding state channel so
+  one `nn.Embedding` serves both towers;
+- placement **one-hots** aligned to the state grid's anchored coordinates;
+- combinatorial payments/conversions as **summed resource-count vectors** —
+  this is what made OeL's 1,600+ payment variants learnable;
+- a few scalars (`numParams`, flags for tokens the count-sum erases — OeL's
+  `usesJoker` precedent).
+
+Acceptance rule for feature collisions: two distinct canonical moves may
+share an encoding **only if they are state-equivalent** (applying both yields
+deep-equal states) — the pilgrimageSite precedent from
+[11](11-action-encoder.md). Audit every multi-param command for ordering
+information the summed bag would lose; add a discriminating scalar wherever
+the audit finds real loss. Encoders never throw on unknown tokens.
+
+### Reused with zero changes — the payoff
+
+Explicitly: `puct.ts` ([13](13-puct-search.md)), `Evaluator`/`RolloutEvaluator`
+([12](12-evaluator-interface.md)), self-play v2 + the worker pool
+([14](14-selfplay-v2.md)/[15](15-selfplay-workers.md)), the npy exporter
+(parameterized by the specs, [16](16-shard-exporter.md)), the trainer's
+data/model/train/export-onnx stack (spec-driven,
+[17](17-trainer-scaffold.md)–[20](20-onnx-export.md)), `OnnxEvaluator`
+([21](21-onnx-evaluator.md)), arena + gating ([22](22-arena-gating.md)), the
+orchestrator ([23](23-orchestrator.md)), and the smoke harness
+([24](24-smoke-e2e.md)). If any of these needs a game-conditional branch,
+that is an adapter-contract bug, not an onboarding task.
+
+### Run-directory / config implications
+
+- `config.json` gains a `gameId` (adapter selector); CLIs and orchestrator
+  resolve the adapter from it, defaulting to `"oel"` so existing runs parse
+  unchanged.
+- **Runs never mix games** (unlike game *configs*, which one run mixes
+  freely per [15](15-selfplay-workers.md)) — feature/action specs differ, so
+  shards and checkpoints are incompatible across games by construction; the
+  exporter and trainer assert `gameId` + spec versions in `meta.json`.
+- **Model checkpoints are per-game.** No transfer learning in v1;
+  warm-starting one game's net from another's trunk is a future experiment,
+  noted and deliberately unbudgeted.
+
+## Implementation plan
+
+1. Engine prerequisites audit (checklist above) — file engine issues first.
+2. `canonicalize`/`moveKey` for the new game, with the duplicate-emission
+   audit and property tests ([10](10-move-canonicalization.md)'s method).
+3. The adapter, delegating to the engine's own internal modules
+   ([09](09-game-adapter.md)'s delegation pattern).
+4. `encode.ts` + `featureSpec` in the game package; `encodeMove` +
+   `actionSpec` in the adapter package.
+5. `gameId` plumbing in config/CLIs/orchestrator.
+6. The acceptance ladder below, in order.
+
+## Inputs
+
+- The new game's engine package (reducer, oracle, scoring, terminal).
+- The frozen contracts: `GameAdapter`, `ActionSpec`, `FeatureSpec`,
+  JSONL v2, shard layout, `spec.json`.
+
+## Outputs
+
+- `agent/src/game/<game>.ts` (+ its `<game>Moves.ts`/`<game>Action.ts`),
+  the game package's `encode.ts`/`featureSpec`, `gameId` in config, and a
+  checked-in `runs/smoke-<game>/config.json`.
+
+## How it runs / verification (each gate blocks the next)
+
+1. **Adapter unit suite** — every enumerated move applies; canonical-dedupe
+   property (never merges distinct applied states) over a state corpus;
+   `moveKey` round-trip; seeded determinism (same seed ⇒ same game).
+2. **Golden-game regression** — full command lists for random-vs-random and
+   tiny-sims self-play pinned per seed.
+3. **Benchmark run** — [08](08-benchmarks.md)'s harness pointed at the new
+   adapter; publish branching distribution (raw vs deduped) and per-op costs
+   like OeL's, since throughput assumptions do not transfer between games.
+4. **Tiny smoke loop** — [24](24-smoke-e2e.md)'s config with the new
+   `gameId`, `--gens 2`, closing selfplay→export→train→gate end-to-end in
+   minutes.
+5. **Real run** — [26](26-first-run.md)'s playbook: one bring-up config
+   first, promoted net beats pure UCT at equal sims.
+
+## Design notes & tradeoffs
+
+- **One adapter package per game vs a `games/` dir in `agent/`.** A separate
+  package per game keeps engine deps isolated but adds workspace ceremony per
+  game; a `games/<id>/` directory inside `agent/` matches how `game/oel.ts`
+  already lives and keeps the adapter registry a static map. Chosen: `games/`
+  dir in `agent/`, one engine dependency per subdir; revisit if adapters grow
+  their own release cadence.
+- **Sharing the erection-embedding trick across games.** The *pattern* (state
+  and action towers share one categorical vocab) transfers; the *vocabs* do
+  not — ids are game-local, and pretending an Agricola card id and an OeL
+  building id share a space would poison both. Each game ships its own
+  vocab + capacity in its own spec.
+- **Demand token-completion oracles vs accept direct enumerators.** The
+  adapter absorbs either: completion-style gives cheap `sampleMove` walks and
+  a two-click human UI for free, but forcing it onto an engine that naturally
+  enumerates whole moves buys nothing for training. Require only the oracle's
+  *output* contract; recommend completion-style when the game will also be
+  played by humans through the web/MCP seam.
+- **Per-game model vs multi-game model.** v1 is strictly per-game: the net
+  conditions on *config within a game* (the config one-hots in the shared
+  block), not across games — a shared multi-game trunk is a research project
+  with different specs, vocabs, and value semantics per game, and nothing in
+  the current loop needs it. Per-game checkpoints keep gating and promotion
+  exactly as [22](22-arena-gating.md)/[23](23-orchestrator.md) define them.

--- a/docs/trainer/README.md
+++ b/docs/trainer/README.md
@@ -22,7 +22,10 @@ self-contained; their **Status** column below reflects reality.
 | Stack | Node self-play (TS engine) · PyTorch training · ONNX for Node inference |
 | Hardware | One machine: RX 7800 XT 16 GB on bare-metal Ubuntu + ROCm (`gfx1101`, HSA override). Plain PyTorch so a ≤$50 CUDA rental or CPU works identically — see [25](25-rocm-runbook.md) |
 | Core interface | Game-agnostic `GameAdapter` — see [09](09-game-adapter.md) |
-| First config | 2-player · long · France |
+| Configs in scope | **All 16**: 1–4 players × short/long × Ireland/France, one config-conditioned net (the config one-hots are already in the encoder's shared block). Self-play samples a weighted config mix; gating evaluates a per-bucket panel — see [14](14-selfplay-v2.md)/[22](22-arena-gating.md) |
+| Solo value target | Success = **final score > 500**. Value/search target = `σ((score − 500)/100)` (0.5 exactly at 500, monotone in score); the binary >500 rate is the reported metric — see [09](09-game-adapter.md) |
+| Future countries | More countries will be added later: the encoder's country one-hot gets reserved capacity now, while no trained weights exist — see [07](07-engine-fast-paths.md) |
+| Bring-up config | 2-player · long · France first (matches the strategy guide), then widen to the full mix — see [26](26-first-run.md) |
 | Durable data | JSONL of games (commands + per-decision candidates/visits); tensors regenerated per training run |
 
 ## The generation loop
@@ -135,7 +138,7 @@ graph LR
 | M4 — Search v2 | 12–15 | PUCT-with-uniform-priors ≈ UCT strength at equal sims; JSONL v2 round-trips |
 | M5 — Training pipeline | 16–20 | Overfit test on 10 games; Node↔Python shard round-trip bit-exact; torch↔ONNX parity |
 | M6 — Closed loop | 21–24 | `pnpm loop --config tiny.json --gens 2` finishes end-to-end in minutes |
-| M7 — Real run | 25, 26 | A promoted generation beats pure UCT at equal sims |
+| M7 — Real run | 25, 26 | A promoted generation beats pure UCT at equal sims (2–4p buckets) and beats pure UCT's score>500 rate in solo |
 
 ## Run directory layout (shared vocabulary)
 
@@ -165,5 +168,7 @@ building more infrastructure — that is what 08 exists for.
   [`docs/mcp-server-design.md`](../mcp-server-design.md)).
 - Second game onboarding: implement `GameAdapter` + `ActionSpec` for the new
   game; search/selfplay/exporter/trainer are reused unchanged.
-- 3–4 player configs: value head is already a per-player vector; no
-  architecture change.
+- Additional countries: append the country to the reserved config slot and
+  the new buildings to the append-only erection vocab (both capacity-reserved
+  — [01](01-state-encoder.md)/[07](07-engine-fast-paths.md)); re-export
+  shards and keep training — no architecture change.

--- a/docs/trainer/README.md
+++ b/docs/trainer/README.md
@@ -1,0 +1,169 @@
+# Offline AlphaZero Trainer — Master Plan
+
+An offline job that iterates **self-play → training → gating** on a single
+machine, producing a policy+value network strong enough for real-time play
+against humans. Ora et Labora (2-player, long, France) is the baseline game;
+the core is game-agnostic so similar games can plug in later.
+
+This index links one design doc per project. Each project doc states how it
+runs, what it consumes, and what it produces. Projects already implemented in
+the repo are included as specs (phrased forward-looking) so the plan is
+self-contained; their **Status** column below reflects reality.
+
+> Supersedes [`docs/mcts-self-play-plan.md`](../mcts-self-play-plan.md), whose
+> Phases 1–3 correspond to projects 01–06 here.
+
+## Locked decisions
+
+| Decision | Choice |
+| --- | --- |
+| Model | **Full AlphaZero**: policy + value heads from the start, PUCT with priors |
+| Policy scheme | **Move-scoring over enumerated candidates** (not flat action space, not token-factorized) — see [11](11-action-encoder.md) |
+| Stack | Node self-play (TS engine) · PyTorch training · ONNX for Node inference |
+| Hardware | One machine: RX 7800 XT 16 GB on bare-metal Ubuntu + ROCm (`gfx1101`, HSA override). Plain PyTorch so a ≤$50 CUDA rental or CPU works identically — see [25](25-rocm-runbook.md) |
+| Core interface | Game-agnostic `GameAdapter` — see [09](09-game-adapter.md) |
+| First config | 2-player · long · France |
+| Durable data | JSONL of games (commands + per-decision candidates/visits); tensors regenerated per training run |
+
+## The generation loop
+
+```
+        ┌──────────────────────────────────────────────────────────┐
+        ▼                                                          │
+  selfplay (Node workers, PUCT + net_k)  ──►  gen-N/*.jsonl        │
+  export  (Node, replay + encode)        ──►  gen-N/shards/*.npy   │
+  train   (Python, GPU)                  ──►  ckpt + model.onnx    │
+  arena   (Node, net_new vs best)        ──►  promote? ────────────┘
+```
+
+Gen-0 uses pure-UCT rollouts (no net) to bootstrap. `mcts:400` stays in the
+arena forever as the fixed-strength yardstick; the "it works" moment is
+NN-guided PUCT beating pure UCT at equal simulations.
+
+## Projects
+
+| # | Project | Package | Depends on | Milestone | Status |
+| --- | --- | --- | --- | --- | --- |
+| [01](01-state-encoder.md) | State encoder (egocentric tensor) | `game/` | — | — | ✅ done |
+| [02](02-engine-adapter.md) | Engine adapter | `agent/` | — | — | ✅ done |
+| [03](03-move-enumeration.md) | Move enumeration & sampling | `agent/` | 02 | — | ✅ done |
+| [04](04-baselines-arena.md) | Baseline policies & arena | `agent/` | 02, 03 | — | ✅ done |
+| [05](05-uct-search.md) | Pure UCT search | `agent/` | 02, 03 | — | ✅ done |
+| [06](06-selfplay-v1.md) | Self-play generator v1 | `agent/` | 04, 05 | — | ✅ done |
+| [07](07-engine-fast-paths.md) | Engine fast paths | `game/` | 01 | M1 | planned |
+| [08](08-benchmarks.md) | Benchmark harness | `agent/` | 03, 07 | M1 | planned |
+| [09](09-game-adapter.md) | GameAdapter interface | `agent/` | 02–06 | M2 | planned |
+| [10](10-move-canonicalization.md) | Move canonicalization | `agent/` | 03, 07 | M2 | planned |
+| [11](11-action-encoder.md) | ActionSpec & move encoder | `agent/` | 07, 10 | M3 | planned |
+| [12](12-evaluator-interface.md) | Evaluator interface | `agent/` | 09 | M4 | planned |
+| [13](13-puct-search.md) | PUCT search | `agent/` | 09, 12 | M4 | planned |
+| [14](14-selfplay-v2.md) | Self-play v2 (JSONL v2) | `agent/` | 10, 13 | M4 | planned |
+| [15](15-selfplay-workers.md) | Worker-pool self-play CLI | `agent/` | 14 | M4 | planned |
+| [16](16-shard-exporter.md) | Tensor shard exporter | `agent/` | 07, 11, 14 | M5 | planned |
+| [17](17-trainer-scaffold.md) | Trainer scaffold (Python/uv) | `trainer/` | 16 | M5 | planned |
+| [18](18-model.md) | Network architecture | `trainer/` | 17 | M5 | planned |
+| [19](19-training-loop.md) | Training loop | `trainer/` | 18 | M5 | planned |
+| [20](20-onnx-export.md) | ONNX export & parity | `trainer/` | 18 | M5 | planned |
+| [21](21-onnx-evaluator.md) | ONNX evaluator in Node | `agent/` | 12, 20 | M6 | planned |
+| [22](22-arena-gating.md) | Arena gating & promotion | `agent/` | 04, 21 | M6 | planned |
+| [23](23-orchestrator.md) | Generation orchestrator | `agent/` | 15, 16, 19, 20, 22 | M6 | planned |
+| [24](24-smoke-e2e.md) | Smoke end-to-end run | repo | 23 | M6 | planned |
+| [25](25-rocm-runbook.md) | ROCm hardware bring-up | `trainer/` | 17 | M7 | planned |
+| [26](26-first-run.md) | First real training run | ops | 24, 25 | M7 | planned |
+
+## Dependency graph
+
+```mermaid
+graph LR
+  subgraph done
+    P01[01 state encoder]
+    P02[02 engine adapter]
+    P03[03 move enumeration]
+    P04[04 baselines+arena]
+    P05[05 UCT search]
+    P06[06 selfplay v1]
+  end
+  P02 --> P03 --> P04
+  P03 --> P05
+  P02 --> P04
+  P02 --> P05
+  P04 --> P06
+  P05 --> P06
+  P01 --> P07[07 engine fast paths]
+  P03 --> P08[08 benchmarks]
+  P07 --> P08
+  P06 --> P09[09 GameAdapter]
+  P03 --> P10[10 canonicalization]
+  P07 --> P10
+  P07 --> P11[11 action encoder]
+  P10 --> P11
+  P09 --> P12[12 evaluator iface]
+  P09 --> P13[13 PUCT]
+  P12 --> P13
+  P10 --> P14[14 selfplay v2]
+  P13 --> P14
+  P14 --> P15[15 workers CLI]
+  P07 --> P16[16 shard exporter]
+  P11 --> P16
+  P14 --> P16
+  P16 --> P17[17 trainer scaffold]
+  P17 --> P18[18 model]
+  P18 --> P19[19 training loop]
+  P18 --> P20[20 ONNX export]
+  P12 --> P21[21 ONNX evaluator]
+  P20 --> P21
+  P04 --> P22[22 arena gating]
+  P21 --> P22
+  P15 --> P23[23 orchestrator]
+  P16 --> P23
+  P19 --> P23
+  P20 --> P23
+  P22 --> P23
+  P23 --> P24[24 smoke e2e]
+  P17 --> P25[25 ROCm runbook]
+  P24 --> P26[26 first run]
+  P25 --> P26
+```
+
+## Milestones (each ships as one or a few PRs)
+
+| Milestone | Projects | Exit criterion |
+| --- | --- | --- |
+| M1 — Engine fast paths | 07, 08 | `completions()` ≡ `control().completion` parity; benchmark numbers pinned |
+| M2 — Game-agnostic core | 09, 10 | Existing agent tests green through the adapter; canonical dedupe proven |
+| M3 — Action encoding | 11 | Every enumerated move over fixture states encodes NaN-free |
+| M4 — Search v2 | 12–15 | PUCT-with-uniform-priors ≈ UCT strength at equal sims; JSONL v2 round-trips |
+| M5 — Training pipeline | 16–20 | Overfit test on 10 games; Node↔Python shard round-trip bit-exact; torch↔ONNX parity |
+| M6 — Closed loop | 21–24 | `pnpm loop --config tiny.json --gens 2` finishes end-to-end in minutes |
+| M7 — Real run | 25, 26 | A promoted generation beats pure UCT at equal sims |
+
+## Run directory layout (shared vocabulary)
+
+```
+runs/<run-id>/
+  config.json            # game cfg + search + selfplay + train + gate params
+  best.json              # current champion { gen, onnx, ckpt, arena }
+  gen-NNN/
+    STATE                # selfplay | exported | trained | gated  (resume marker)
+    selfplay/worker-*.jsonl
+    shards/shard-*/      # .npy tensors (regenerable; pruned after gating)
+    ckpt/model.pt
+    model.onnx  spec.json
+    arena.json  train-log.jsonl
+```
+
+## Primary risk
+
+Self-play throughput (~1–3 s/move at 200 sims ⇒ ~500 games/day on 12
+workers). Levers, in order: `completions()` fast path (07), curation caps,
+sims scheduling, in-worker batching (12), completion caching. Measure before
+building more infrastructure — that is what 08 exists for.
+
+## Later (out of scope here)
+
+- Real-time deployment behind the web/MCP `make_move` seam (see
+  [`docs/mcp-server-design.md`](../mcp-server-design.md)).
+- Second game onboarding: implement `GameAdapter` + `ActionSpec` for the new
+  game; search/selfplay/exporter/trainer are reused unchanged.
+- 3–4 player configs: value head is already a per-player vector; no
+  architecture change.

--- a/docs/trainer/schemas.md
+++ b/docs/trainer/schemas.md
@@ -1,0 +1,390 @@
+# Schemas — canonical cross-project data contracts
+
+Every file format and tensor interface that crosses a project boundary in the
+offline-AlphaZero trainer, in one place. **When two project docs disagree
+about a shape, this doc wins.** Each contract: who writes / who reads / what
+version-bumps it, a typed definition, then validator invariants.
+
+Corrections canonicalized here (see "Change procedure" for how to evolve):
+`moveFeatureLen` is **91** (doc 11; doc 16's "≈90" and doc 20's `[131, 90]`
+example are stale); the Dirichlet config key is **`alphaScale`** (docs 13/14;
+the `"alpha": 0.5` in docs 24/26 example configs should read
+`"alphaScale": 10`); `STATE` is written **only by the orchestrator** (doc 23;
+stage docs saying "STATE → x" mean "the orchestrator advances STATE after me").
+
+---
+
+## 1. `runs/<id>/config.json` — run configuration
+
+Written once by a human when a run is created; read by the orchestrator
+(doc 23) and every stage CLI (defaults for flags; CLI overrides win). It has
+no version field — it is per-run, and the trainer records a `config_hash` in
+checkpoints so a silent mid-run edit is caught at resume. Changing it
+mid-run is allowed only for values not yet consumed (practically: start a new
+run dir instead).
+
+```ts
+type GameCfg = { players: 1|2|3|4; country: 'france'|'ireland'; length: 'short'|'long' }
+// NOTE: no `colors` here — the adapter defaults seat colors. The JSONL `cfg`
+// field (§2) records the full GameConfig including colors.
+
+type RunConfig = {
+  run: string                                    // run id, must equal the dir name
+  game: GameCfg                                  // single-config run …
+      | { mix: { cfg: GameCfg; weight: number }[] } // … or weighted mix (doc 26)
+  selfplay: {
+    gamesPerGen: number                          // JSONL-line target per generation
+    workers: number                              // worker_threads pool size
+    sims: number                                 // PUCT simulations per decision
+    cPuct: number                                // default 1.5
+    dirichlet: { epsilon: number; alphaScale: number } // ε=0.25, alphaScale=10; α = alphaScale/rootCandidateCount
+    temperature: { tau: number; moves: number }  // τ=1 sampling for first `moves` decisions, then argmax
+    curation: { maxPerLevel: number; maxMoves: number } // enumeration caps (distinct canonical moves)
+    gen0: { evaluator: 'rollout'; sims: number; rolloutDepth: number } // used until first promotion
+    baseSeed: number                             // game seed = baseSeed + gameIndex (default gen * 1_000_000)
+  }
+  solo: { target: number; scale: number }        // value mapping σ((score − target)/scale); defaults { target: 500, scale: 100 }
+  train: {
+    device: 'auto'|'cpu'|'cuda'
+    window: number                               // K generations of shards (doc 19: 5)
+    epochs: number                               // effective epochs → step budget ceil(E·rows/batch)
+    batchSize: number                            // decisions per batch (256)
+    lr: number
+    lrSchedule?: 'cosine'                        // default cosine w/ 200-step linear warmup
+    weightDecay: number                          // AdamW decoupled (1e-4)
+    valueLossWeight: number                      // λ in L = L_policy + λ·L_value (1.0)
+    seed: number                                 // torch/numpy/python RNG
+  }
+  gate:                                          // scalar shorthand (single-config runs) …
+    { games: number; sims: number; threshold: number      // even games ≥ … ; 0.55
+      enforce: boolean                                    // false ⇒ play, log, promote regardless (smoke)
+      baseSeed: number                                    // gate seeds = baseSeed + gen*games + g
+      yardstick: { policy: string; games: number } | null } // e.g. { policy: 'mcts:400', games: 100 }
+  | // … or the panel form (config-mix runs, doc 26)
+    { panel: { bucket: string; games: number }[]          // bucket = '<P>p-<length>-<country>'
+      threshold: number; bucketFloor: number              // 0.55 weighted mean AND every bucket ≥ 0.45
+      sims: number; enforce: boolean; baseSeed: number
+      yardstick?: { policy: string; games: number } | null }
+}
+```
+
+Invariants:
+- `run` equals the run directory basename.
+- mix weights are positive; cfg→game assignment is deterministic weighted
+  round-robin over `gameIndex` (doc 15) — the (seed, cfg) corpus is a pure
+  function of this file plus the target count.
+- `gate.games` (and each panel bucket's games for 2–4p) is even (seat balance).
+- `dirichlet.epsilon ∈ [0,1]`; `temperature.tau > 0`; `threshold ∈ (0.5, 1]`;
+  `bucketFloor < threshold`.
+- `solo.scale > 0`; the 1p bucket's gate is paired-by-seed score comparison,
+  reported metric = score>500 rate (docs 09/22).
+
+## 2. JSONL v2 — self-play game line
+
+One JSON object per line, one line per completed game. Written by self-play
+workers (`gen-NNN/selfplay/worker-K.jsonl`, one `appendFileSync` per game);
+read by the shard exporter (doc 16), the resume scanner (doc 15), and the
+smoke assertions (doc 24). **This is the durable archive** — everything else
+regenerates from it. Schema changes bump the `v` field (currently `2`).
+
+```ts
+type SelfPlayGameV2 = {
+  v: 2                          // first field — cheap to sniff
+  gameId: string                // "g" + seed; stable across resumes
+  cfg: GameConfig               // { players, country, length, colors } — full, incl. colors
+  seed: number                  // opening seed AND rng derivation: mulberry32(seed*7919+3)
+  netId: string                 // evaluator.id: "rollout" | "gen-NNN"
+  search: { sims: number; cPuct: number
+            dirichlet: { epsilon: number; alphaScale: number } | null
+            tempMoves: number
+            curation: { maxPerLevel: number; maxMoves: number } }
+  commands: string[][]          // whole game incl. CONFIG/START opening — replayable
+  decisions: Decision[]
+  outcome: number[]             // per-player [0,1], seat-indexed; solo: σ((score−target)/scale)
+  finished: boolean             // reached GameStatusEnum.FINISHED
+  steps: number                 // decisions taken
+}
+
+type Decision = {
+  step: number                  // index into commands; replay commands[0..step) ⇒ the state
+  perspective: number           // playerToMove at the decision (encoder slot 0)
+  candidates: string[]          // FULL canonical moveKey list, order = adapter.legalMoves
+  visits: number[]              // aligned; zeros included; sums to search.sims
+  q: number[]                   // aligned mover-Q from PUCT, rounded to 4 dp
+  chosen: number                // index into candidates; commands[step] ≡ candidates[chosen].split(' ')
+  forced?: true                 // present-and-true only for single-candidate short-circuits (visits = [sims])
+}
+```
+
+**moveKey grammar** (doc 10): canonical move tokens joined by a single
+space. Tokens contain no whitespace; coordinate tokens are single integers
+(possibly negative) — joined `"col row"` engine tokens are truncated to their
+leading integer during canonicalization. Round-trip is exact:
+`moveKey(m).split(' ')` ≡ the canonical token array.
+
+Invariants:
+- Line parses as JSON with `v === 2` (truncated last line ⇒ crash artifact:
+  truncate and regenerate that seed).
+- Replaying `commands` reproduces `outcome`, `finished`, `steps`.
+- Per decision: `visits.length === q.length === candidates.length`;
+  `Σ visits === search.sims`; `0 ≤ chosen < candidates.length`;
+  replaying `commands[0..step)` yields a state whose `legalMoves` (same caps)
+  equals `candidates`.
+- Seeds are unique across all `worker-*.jsonl` of a generation.
+
+## 3. Shard directory — `gen-NNN/shards/shard-XXXXX/`
+
+Written by the Node exporter (doc 16), read by the Python `ShardDataset`
+(doc 17). **Disposable**: a pure function of (JSONL, featureSpec, actionSpec);
+regenerated per training run, pruned once outside the training window. An
+encoder change bumps `featureSpecVersion` (move encoder: `actionSpecVersion`)
+and simply requires re-export. Shards hold 4,096 decisions (last shard
+partial); dirs are built in `.tmp-*` and atomically renamed, `meta.json`
+written last.
+
+Dimensions: `moveFeatureLen = 91` (doc 11). `featureLen = featureSpec.featureLen`
+from `game/src/encode.ts` — **14,670** for the current encoder;
+**14,676** once project 07's `COUNTRY_CAPACITY = 8` lands (+6 in the shared
+block, featureSpecVersion bump). Never hardcode it downstream; assert it.
+
+| File | Shape | dtype | Contents |
+| --- | --- | --- | --- |
+| `states.npy` | `[N, featureLen]` | `<f2` | egocentric encoding, slot 0 = perspective |
+| `values.npy` | `[N, 4]` | `<f4` | outcome rotated: `values[s] = s < P ? outcome[(perspective+s) % P] : 0` |
+| `value_mask.npy` | `[N, 4]` | `\|u1` | `1` for slots `< numPlayers`, else `0` |
+| `cand_feats.npy` | `[M, 91]` | `<f2` | ragged concat of per-decision candidate encodings, JSONL order |
+| `cand_offsets.npy` | `[N+1]` | `<i8` | prefix sums into M; `offsets[0] = 0`, `offsets[N] = M` |
+| `policy.npy` | `[M]` | `<f4` | `visits[i] / Σ visits` per decision slice |
+| `chosen.npy` | `[N]` | `<i4` | slice-local index of the played move |
+
+`meta.json`:
+
+```jsonc
+{ "featureSpecVersion": 1, "actionSpecVersion": 1,
+  "featureLen": 14670, "moveFeatureLen": 91,
+  "rows": 4096, "cands": 73912, "games": 17,
+  "netId": "gen-003", "exporterGitSha": "…" }
+```
+
+**.npy v1.0 header rule** (the Node writer, `agent/src/npy.ts`): magic
+`\x93NUMPY` (6 B) · version `\x01\x00` · `HEADER_LEN` uint16 LE · ASCII
+Python-dict literal `{'descr': '<f2', 'fortran_order': False, 'shape': (4096, 14670), }`
+space-padded so `10 + HEADER_LEN` is a multiple of 64, ending in `\n`; then
+raw little-endian C-order bytes. Allowed dtypes: `<f2 <f4 <i4 <i8 |u1`.
+
+Invariants:
+- All seven `.npy` + `meta.json` present, or the dir name starts `.tmp-` (dead).
+- `offsets` strictly increasing (every decision has ≥ 1 candidate);
+  `offsets[N] === M === cands`; `rows === N`.
+- Every policy slice sums to 1 ± 1e-6; `chosen[i] < offsets[i+1] − offsets[i]`.
+- `values[i][0] === outcome[perspective]` (rotation invariant); masked slots are 0.
+- No NaN/Inf in `states`/`cand_feats` (f16 payloads bit-exact vs the Node
+  golden fixture).
+- All shard metas in a training window agree on both spec versions and both
+  lengths — with each other, with `spec.json`, and with a resumed ckpt (doc 17).
+
+## 4. `spec.json` — model interface descriptor
+
+Written by `oel-export-onnx` (doc 20) next to `model.onnx`; read by
+`OnnxEvaluator` construction (doc 21, asserted against the adapter's specs)
+and the trainer's version guard. Regenerated on every export; any field that
+changes reflects a version bump upstream (featureSpec / actionSpec / graph
+interface), never an in-place edit.
+
+```jsonc
+{ "featureSpecVersion": 1,        // adapter.featureSpec.version at export
+  "actionSpecVersion": 1,         // adapter.actionSpec.version
+  "featureLen": 14670,
+  "moveFeatureLen": 91,
+  "maxPlayers": 4,
+  "graphInterfaceVersion": 1,     // §5 contract version
+  "opset": 18,
+  "netId": "gen-007",             // lands in JSONL netId via Evaluator.id
+  "ckpt": "gen-007/ckpt/model.pt" // source checkpoint, run-relative
+}
+```
+
+Invariants: every field present; `featureLen`/`moveFeatureLen` match the
+adapter constants; consumers abort naming both sides on any mismatch
+("model built against featureSpec v3, adapter is v4").
+
+## 5. ONNX graph interface (`model.onnx`)
+
+Produced by the export wrapper (doc 20), consumed by `onnxruntime-node`
+inside `OnnxEvaluator` (doc 21) and by the Python parity test. Changing
+inputs/outputs/semantics bumps `graphInterfaceVersion` in `spec.json`.
+
+| Tensor | Direction | Shape | dtype | Notes |
+| --- | --- | --- | --- | --- |
+| `states` | in | `[B, featureLen]` | f32 | dynamic axis 0 = `B` |
+| `cand_feats` | in | `[M, moveFeatureLen]` | f32 | ragged concat; dynamic axis 0 = `M` |
+| `cand_offsets` | in | `[B+1]` | i64 | prefix sums; `[0] = 0`, `[B] = M` |
+| `values` | out | `[B, maxPlayers]` | f32 | **post-sigmoid**, egocentric slot order |
+| `logits` | out | `[M]` | f32 | **raw, pre-softmax** |
+
+Invariants:
+- Softmax is applied **outside** the graph, per candidate slice, max-subtracted
+  (doc 21) — the graph never normalizes over segments.
+- Precondition: every decision has ≥ 1 candidate ⇒ offsets strictly
+  increasing (asserted at export and by the evaluator, not tolerated).
+- Opset 18, f32 weights; graph contains no `Loop`/`If` nodes (structural check).
+- torch ↔ onnxruntime max |Δ| ≤ 1e-4 on values and logits across B ∈ {1,7,64},
+  including a 1-candidate decision.
+
+## 6. `gen-NNN/parity/golden.json` — parity fixture
+
+Written by `trainer/tests/test_onnx.py` (doc 20) from a real shard, with
+**torch** outputs as expected values; replayed by the Node parity test
+(doc 21) against the same `model.onnx` — proving Node-packing ≡ torch
+transitively. Its own `v` bumps with the fixture format; `specVersions`
+mirror `spec.json`. (The committed tiny-model test fixture in `agent/` uses
+this same schema.)
+
+```jsonc
+{ "v": 1, "specVersions": { "feature": 1, "action": 1 }, "opset": 18,
+  "tolerance": 1e-4,
+  "cases": [ { "B": 7, "M": 131,
+    "inputs":   { "states":       { "shape": [7, 14670], "dtype": "f32", "b64": "…" },
+                  "cand_feats":   { "shape": [131, 91],  "dtype": "f32", "b64": "…" },
+                  "cand_offsets": { "shape": [8],        "dtype": "i64", "b64": "…" } },
+    "expected": { "values": { "shape": [7, 4], "dtype": "f32", "b64": "…" },
+                  "logits": { "shape": [131],  "dtype": "f32", "b64": "…" } } } ] }
+```
+
+Invariants: `b64` decodes to exactly `∏shape × dtype-size` little-endian
+bytes; shapes are mutually consistent (`offsets` length `B+1`, last element
+`M`); at least one case with `B = 1` and one with a 1-candidate decision.
+
+## 7. `runs/<id>/best.json` — current champion
+
+Written only by the gate on promotion (doc 22), temp-file-then-`rename`
+(atomic — a crash mid-gate never leaves a torn champion). Read by self-play
+(`--net` resolution), the gate itself (champion policy, warm-start source),
+and `parsePolicy`'s `best@<run>` form. Absent file = no promotion yet
+(gen-0/rollout era). No version field; the shape rides on this doc.
+
+```jsonc
+{ "gen": 7,
+  "onnx": "gen-007/model.onnx",       // run-relative — the run dir must survive rsync
+  "ckpt": "gen-007/ckpt/model.pt",    // run-relative
+  "arena": { "games": 100, "winRate": 0.58, "eloDiff": 56, "vsYardstick": 0.61 },
+  "promotedAt": "2026-07-01T04:12:33Z" }
+```
+
+Invariants: both paths run-relative (never absolute) and existing;
+`winRate ≥ gate.threshold` unless `enforce: false`; `promotedAt` ISO-8601 UTC.
+
+## 8. `gen-NNN/arena.json` — gate record
+
+Written by `gate.ts` after both matches (doc 22), win or lose; read by the
+orchestrator (done-condition, loop-log fields) and humans auditing a run.
+One per generation; existence is the `gated` done-condition.
+
+```jsonc
+{ "gen": 7,
+  "candidate": "gen-007/model.onnx",
+  "champion": "gen-006/model.onnx",        // or "mcts:<sims>" before first promotion
+  "params": { "sims": 200, "threshold": 0.55, "bucketFloor": 0.45,
+              "baseSeed": 900000, "enforce": true },
+  "buckets": [                              // one entry per panel bucket (scalar gate ⇒ one bucket)
+    { "bucket": "2p-long-france", "games": 100, "winRate": 0.58, "eloDiff": 56 },
+    { "bucket": "1p-long-france", "games": 50, "winRate": 0.60,  // paired-by-seed
+      "scoreOver500Rate": { "candidate": 0.42, "champion": 0.36 } } ],
+  "result": { "winRate": 0.58, "promoted": true },   // weighted mean; promoted = mean ≥ threshold AND every bucket ≥ bucketFloor
+  "yardstick": { "policy": "mcts:400", "games": 100, "winRate": 0.44, "eloDiff": -42 } // or null
+}
+```
+
+Invariants: per-bucket seeds derive from `baseSeed + gen * games + g`
+(reproducible from `config.json` alone); 2–4p bucket games even
+(seat-alternated); solo buckets paired on identical seed sets; `promoted`
+consistent with `threshold`/`bucketFloor` (or `enforce: false` noted);
+yardstick always played and logged when configured, never gated on.
+
+## 9. `gen-NNN/STATE` — stage marker
+
+A single token + newline naming the **last completed** stage. Written
+**only by the orchestrator** (doc 23) — stage CLIs never touch it — after
+verifying the stage's done-condition against real artifacts, via
+`STATE.tmp` + `rename`. Absent file = nothing completed for that generation.
+Token set (append here if the state machine ever grows):
+
+```
+selfplay | exported | trained | gated
+```
+
+Invariants: file content ∈ token set; the named stage's artifacts actually
+exist (JSONL count ≥ gamesPerGen / complete shards matching JSONL totals /
+`ckpt/model.pt` + `model.onnx` + `spec.json` / `arena.json`); `trained`
+means ckpt **and** servable ONNX (export is folded into that transition).
+
+## 10. `loop-log.jsonl` and `gen-NNN/train-log.jsonl`
+
+**`runs/<id>/loop-log.jsonl`** — appended by the orchestrator, one line per
+generation after gating (doc 23). Read by the halt logic (failed-gate
+streak) and humans/journals. Schema rides on this doc.
+
+```jsonc
+{ "gen": 3, "startedAt": "…", "finishedAt": "…",
+  "durations": { "selfplay": 25100, "export": 310, "train": 940, "onnx": 12, "gate": 5200 }, // seconds
+  "games": 500, "decisions": 152340, "netId": "gen-003",
+  "loss": { "first": 4.81, "final": 3.12 },
+  "gate": { "games": 100, "winRate": 0.57, "eloDiff": 49, "promoted": true },
+  "yardstick": { "games": 100, "winRate": 0.44, "eloDiff": -42 },   // or null
+  "champion": "gen-003", "failedGateStreak": 0 }
+```
+
+**`gen-NNN/train-log.jsonl`** — written by `oel-train` (doc 19): one
+`"type": "step"` line every 50 steps plus one `"type": "summary"` at the end.
+
+```jsonc
+{ "type": "step", "ts": "2026-07-01T12:00:00Z", "gen": 3, "step": 1250,
+  "lr": 4.1e-4, "loss": 2.31, "policy_loss": 1.98, "value_loss": 0.33,
+  "top1_agree": 0.44, "policy_entropy": 2.1,
+  "value_mae": 0.31, "grad_norm": 0.8, "rows_seen": 320000 }
+{ "type": "summary", "gen": 3, "steps": 5860, "wall_s": 1410,
+  "final": { "loss": 1.71, "top1_agree": 0.58 },
+  "value_calibration": [[0.05, 0.11], [0.15, 0.18]] }   // [pred-bucket, actual mean]
+```
+
+Invariants: both append-only JSONL; step lines contiguous in `step` across a
+resume; exactly one summary line per completed training invocation;
+`loss === policy_loss + valueLossWeight · value_loss` per step line.
+
+## 11. Version-compatibility matrix
+
+Every mismatch **aborts loudly, naming both sides** — never warn-and-continue;
+silently crossing an encoder change is the worst bug class in this pipeline.
+JSONL survives every bump: **re-export is the escape hatch.**
+
+| Version field | Declared by | Guards the pair(s) | On mismatch |
+| --- | --- | --- | --- |
+| `featureSpecVersion` | adapter `featureSpec.version` (`game/src/encode.ts` via doc 09) | state encoder ↔ shard `meta.json` ↔ ckpt `spec` ↔ `spec.json` ↔ OnnxEvaluator | abort; re-export shards from JSONL, retrain or warm-start, re-export ONNX |
+| `actionSpecVersion` | adapter `actionSpec.version` (doc 11) | move encoder ↔ shard `meta.json` ↔ ckpt `spec` ↔ `spec.json` ↔ OnnxEvaluator | same as above |
+| `graphInterfaceVersion` | `spec.json` (doc 20) | exported ONNX graph ↔ OnnxEvaluator packing/unpacking code | abort at evaluator construction; re-export ONNX from the same ckpt after updating the consumer |
+| JSONL `v` | each game line (doc 14) | self-play writer ↔ shard exporter (and resume scanner, smoke checks) | abort export naming the file/line; migrate or regenerate self-play |
+
+Aligned non-version constants asserted alongside: `featureLen` and
+`moveFeatureLen` (shards ↔ spec.json ↔ ckpt ↔ adapter), `maxPlayers = 4`,
+`opset = 18`, golden.json `specVersions` ↔ `spec.json`.
+
+## Change procedure
+
+1. **State encoder change** (e.g. project 07's `COUNTRY_CAPACITY = 8`,
+   14,670 → 14,676): bump `featureSpec.version` in the same commit as the
+   layout change. Then, in order: re-export shards for the training window
+   (JSONL untouched), retrain or warm-start (the version guard rejects old
+   ckpts/shards), `oel-export-onnx` (new `spec.json`), re-generate
+   `golden.json`, run the smoke loop (doc 24) before any GPU run.
+2. **Move encoder / ActionSpec change**: bump `actionSpec.version`; same
+   re-export → retrain → re-export-ONNX → parity sequence.
+3. **ONNX graph I/O change**: update exporter and OnnxEvaluator together,
+   bump `graphInterfaceVersion`, regenerate `golden.json`; no shard or JSONL
+   work needed.
+4. **JSONL schema change**: bump `v`, teach the exporter (and resume scanner)
+   the new version — support reading the old `v` for one transition window or
+   accept regenerating self-play. Never mutate existing lines.
+5. **This doc**: any contract edit lands here first (or in the same PR),
+   with the owning project doc updated to match. Downstream order is always
+   the same: JSONL → shards → ckpt → ONNX/spec.json → evaluator — regenerate
+   left-to-right from the first invalidated artifact.


### PR DESCRIPTION
## What

A project-based design for the offline AlphaZero trainer under `docs/trainer/`: one big-picture index plus **26 deeply elaborated project docs**, each with a concrete implementation plan (exact signatures, algorithms, file formats, edge cases), a verification plan, and an explicit **Design notes & tradeoffs** section weighing the alternatives considered.

- **`docs/trainer/README.md`** — locked decisions, the generation loop, a dependency graph over all projects, milestones with exit criteria, run-directory layout, and the primary risk (self-play throughput).
- **Scope: all 16 configs** — 1–4 players × short/long × Ireland/France, served by one config-conditioned net (the encoder already carries config one-hots). Self-play samples a weighted config mix; gating evaluates a per-bucket panel. **Solo success = final score > 500**: search/training use a `σ((score−500)/100)` value mapping (the engine's raw-score solo outcome violates the [0,1] value contract), and the binary >500 rate is the reported metric. The encoder reserves country capacity now — while no trained weights exist — so future countries never change tensor shapes.
- `01`–`06` spec the already-shipped work (encoder, engine adapter, enumeration, baselines/arena, UCT, self-play v1), corrected against the code and with known flaws called out (O(steps²) prefixes, expanded-edges-only visit targets, deterministic-prefix curation bias).
- `07`–`15` get search training-ready: engine fast paths (`completions()`, `scores()`, `encodeInto` — every `control()` call today pays for a frame-flow walk and full scoring the search never reads), benchmark harness, game-agnostic `GameAdapter`, move canonicalization (the engine emits k² duplicate placement commands per k-row column, splitting policy mass), the 91-float move encoder that makes 1,600-variant payment tails learnable as 22 resource counts, the async `Evaluator` seam, PUCT (Dirichlet via Marsaglia–Tsang off the seeded RNG, virtual loss, complete visit support), JSONL v2, and the worker-pool CLI with a deterministic seed/config dispenser.
- `16`–`20` are the Node→Python pipeline: byte-level `.npy` shard writer with RNE f16 conversion, uv-managed trainer (three-way torch extras: cpu/rocm/cu12), a ~1.53M-param net (shared conv trunk over the four player grids, segment-softmax policy head, masked per-seat sigmoid value head) with full parameter arithmetic, exact loss/schedule/checkpoint/resume semantics, and ONNX export at opset 18 with a torch↔ORT↔Node golden-batch parity chain.
- `21`–`26` close the loop: `onnxruntime-node` evaluator (including the `pnpm-workspace.yaml` `onlyBuiltDependencies` gotcha), config-panel arena gating with honest statistics (±9.8pp CI at N=100) and paired-seed solo comparison, the resumable four-stage orchestrator, a CI-able smoke run (~12 min; first workflow to install the pnpm workspace + Python), the ROCm bring-up runbook for the RX 7800 XT (gfx1101, known-vs-verify table, HSA override, fallback ladder to CPU/cloud ≤$50), and the first real run with a full starting config, timing model (~1 generation/day), and decision trees for the three likely failure modes.
- `docs/mcts-self-play-plan.md` is banner-marked superseded (kept for history).

## Why

Sets the reviewed design for the offline self-play → train → gate loop that will produce a policy for real-time human-vs-computer play, structured so each project is independently buildable and verifiable, and so future Ora-et-Labora-like games plug into the same core via `GameAdapter`/`ActionSpec`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Cw5qiAmYZH5Ve6bByKfTA