### PR TITLE
docs(trainer): schemas reference, consistency pass, realtime-bot and second-game projects

### DIFF
--- a/docs/trainer/01-state-encoder.md
+++ b/docs/trainer/01-state-encoder.md
@@ -35,14 +35,16 @@ than throwing.
 ### Layout
 
 `FEATURE_LEN = MAX_PLAYERS(4) × PLAYER_BLOCK(3,455) + FRAME(549) + SHARED(301)
-= 14,670` floats (~57 KB dense f32, ~29 KB f16).
+= 14,670` floats (~57 KB dense f32, ~29 KB f16). ([07](07-engine-fast-paths.md)
+reserves `COUNTRY_CAPACITY = 8` for the country one-hot, growing SHARED to 307
+and `FEATURE_LEN` to 14,676; pipeline docs downstream of 07 quote that number.)
 
 | Block | Size | Contents |
 | --- | --- | --- |
 | Player scalars | 35 | 22 resource counts, wonders, 4 clergy buckets `[lb_unplaced, lb_placed, prior_unplaced, prior_placed]`, 8-bit in-hand settlement-type mask |
 | Player grid | 38×9×10 = 3,420 | per tile: 6 land one-hots, 1 categorical erection-id channel, 3 clergy flags `[laybrother, prior, opponent-owned]` |
 | Frame | 549 | round (raw), settlementRound one-hot (7), current/active player one-hots over *rotated slots* (4+4), 4 booleans, bonusActions command bitmask (14), nextUse one-hot (3), usable + unusable building masks (256+256) |
-| Shared | 301 | rondel deltas (9) and yields (9), still-available buildings mask (256), plot + district prices (9+9, zero-padded), wonders remaining, config one-hots: players (4), length (2), country (2) |
+| Shared | 301 | rondel deltas (9) and yields (9), still-available buildings mask (256), plot + district prices (9+9, zero-padded), wonders remaining, config one-hots: players (4), length (2), country (2 today; reserved to 8 by [07](07-engine-fast-paths.md)) |
 
 Empty player slots (games with <4 players) are zero blocks.
 

--- a/docs/trainer/05-uct-search.md
+++ b/docs/trainer/05-uct-search.md
@@ -103,7 +103,10 @@ drop are invisible to search), and no virtual loss (single-threaded only).
   maxⁿ (paranoid opponents are not modeled), the standard multiplayer-MCTS
   compromise.
 - **UCB1 with `c = 1.4`.** `√2 ≈ 1.414` is the textbook constant for rewards
-  in `[0,1]`, which the rank-based `outcome()` guarantees by construction —
+  in `[0,1]`, which the rank-based `outcome()` guarantees by construction for
+  2–4 players (solo's raw-score `outcome()` violates that scale and is
+  remapped to `σ((score − 500)/100)` by the adapter —
+  [09](09-game-adapter.md)) —
   the constant and the value scale were chosen together. Not tuned further:
   this searcher's job is to be a *stable* yardstick; PUCT (13) is where
   exploration tuning effort goes.

--- a/docs/trainer/16-shard-exporter.md
+++ b/docs/trainer/16-shard-exporter.md
@@ -20,13 +20,15 @@ strands data (re-export is a replay away).
 
 ### Dimensions (recomputed from `game/src/encode.ts`)
 
-`FEATURE_LEN = 14,670`: 4 player blocks of 3,455 (35 scalars — 22 resources +
-1 wonders + 4 clergy buckets + 8 settlement types — plus a 38×9×10 grid =
-3,420) + frame 549 + shared 301. Block offsets: players at
-`[0, 3455, 6910, 10365]`, frame at 13,820, shared at 14,369. One f16 state row
-is 29,340 bytes (~28.7 KiB). `moveFeatureLen ≈ 90` per
-[11](11-action-encoder.md) (14 command + 1 erection id + 9 col + 38 row + 22
-resources + ~6 scalars).
+`FEATURE_LEN = 14,670` today: 4 player blocks of 3,455 (35 scalars — 22
+resources + 1 wonders + 4 clergy buckets + 8 settlement types — plus a
+38×9×10 grid = 3,420) + frame 549 + shared 301. Block offsets: players at
+`[0, 3455, 6910, 10365]`, frame at 13,820, shared at 14,369. Once
+[07](07-engine-fast-paths.md) reserves `COUNTRY_CAPACITY = 8`, shared grows
+to 307 and `featureLen` to 14,676 — the exporter always writes whatever
+`featureSpec.featureLen` says, never a literal. One f16 state row is
+~28.7 KiB. `moveFeatureLen = 91` per [11](11-action-encoder.md) (14 command +
+1 erection id + 9 col + 38 row + 4 buy-side + 22 resources + 3 scalars).
 
 ### Shard directory layout
 
@@ -34,15 +36,15 @@ Shards of 4,096 decisions, zero-padded sequence names:
 
 ```
 gen-NNN/shards/shard-00042/
-  states.npy        [N, 14670]           <f2   (~28.7 KiB/row)
+  states.npy        [N, featureLen]      <f2   (~28.7 KiB/row)
   values.npy        [N, maxPlayers=4]    <f4   (outcome rotated: slot0 = perspective)
   value_mask.npy    [N, 4]               |u1   (live seats)
   cand_feats.npy    [M, moveFeatureLen]  <f2   (ragged concat)
   cand_offsets.npy  [N+1]                <i8   (prefix sums into M; offsets[0]=0)
   policy.npy        [M]                  <f4   (visit fractions, sum to 1 per slice)
   chosen.npy        [N]                  <i4   (index into the decision's slice)
-  meta.json         { featureSpecVersion, actionSpecVersion, featureLen: 14670,
-                      moveFeatureLen, rows, cands, games, netId, exporterGitSha }
+  meta.json         { featureSpecVersion, actionSpecVersion, featureLen,
+                      moveFeatureLen: 91, rows, cands, games, netId, exporterGitSha }
 ```
 
 Sizing at first-config scale: ~250–350 decisions/game × 500–2,000 games/gen →

--- a/docs/trainer/19-training-loop.md
+++ b/docs/trainer/19-training-loop.md
@@ -86,7 +86,7 @@ agreement should climb from ~1/branching, entropy should fall from
 { "model": state_dict, "optimizer": state_dict, "sched_step": int,
   "global_step": int, "rows_seen": int,
   "spec": { "featureSpecVersion": …, "actionSpecVersion": …,
-            "featureLen": 14670, "moveFeatureLen": … },
+            "featureLen": …,     "moveFeatureLen": 91 },   // from spec.json, never hardcoded
   "window": { "gens": [0,1,2,3], "shards": 512, "rows": 2_100_000 },
   "rng": { "torch": …, "numpy": …, "python": … },
   "config_hash": "…", "torch_version": "2.5.1" }

--- a/docs/trainer/20-onnx-export.md
+++ b/docs/trainer/20-onnx-export.md
@@ -22,7 +22,7 @@ uv run oel-export-onnx --ckpt gen-NNN/ckpt/model.pt --out gen-NNN/model.onnx
 
 ### Graph interface (fixed contract with [21](21-onnx-evaluator.md))
 
-- inputs: `states [B, 14670] f32` · `cand_feats [M, moveFeatureLen] f32` ·
+- inputs: `states [B, featureLen] f32` · `cand_feats [M, moveFeatureLen] f32` ·
   `cand_offsets [B+1] i64` (prefix sums, `offsets[0] = 0`, `offsets[B] = M`)
 - outputs: `values [B, maxPlayers] f32` (post-sigmoid) · `logits [M] f32`
   (raw, pre-softmax)
@@ -100,7 +100,7 @@ without a re-export.
 ### `spec.json` + golden-batch fixture (shared with [21](21-onnx-evaluator.md))
 
 `spec.json` is written next to the model: featureSpec + actionSpec versions,
-`featureLen: 14670`, `moveFeatureLen`, `maxPlayers: 4`, graph interface
+`featureLen` (from `featureSpec`), `moveFeatureLen: 91`, `maxPlayers: 4`, graph interface
 version, opset, and source ckpt path — every consumer asserts it before
 inference.
 
@@ -113,7 +113,7 @@ the Node parity test in [21](21-onnx-evaluator.md) replays against the same
   "tolerance": 1e-4,
   "cases": [ { "B": 7, "M": 131,
     "inputs":   { "states":       { "shape": [7, 14670], "dtype": "f32", "b64": "…" },
-                  "cand_feats":   { "shape": [131, 90],  "dtype": "f32", "b64": "…" },
+                  "cand_feats":   { "shape": [131, 91],  "dtype": "f32", "b64": "…" },
                   "cand_offsets": { "shape": [8],        "dtype": "i64", "b64": "…" } },
     "expected": { "values": { "shape": [7, 4], "dtype": "f32", "b64": "…" },
                   "logits": { "shape": [131],  "dtype": "f32", "b64": "…" } } } ] }

--- a/docs/trainer/24-smoke-e2e.md
+++ b/docs/trainer/24-smoke-e2e.md
@@ -29,7 +29,7 @@ pipeline regressions are caught before burning a GPU-day.
     "workers": 2,
     "sims": 16,
     "cPuct": 1.5,
-    "dirichlet": { "epsilon": 0.25, "alpha": 0.5 },
+    "dirichlet": { "epsilon": 0.25, "alphaScale": 10 },
     "temperature": { "tau": 1.0, "moves": 8 },
     "curation": { "maxPerLevel": 8, "maxMoves": 32 },
     "gen0": { "evaluator": "rollout", "sims": 16, "rolloutDepth": 30 },

--- a/docs/trainer/26-first-run.md
+++ b/docs/trainer/26-first-run.md
@@ -28,7 +28,7 @@ success = score > 500; see "Widening to the full config mix" below).
     "workers": 12,
     "sims": 200,
     "cPuct": 1.5,
-    "dirichlet": { "epsilon": 0.25, "alpha": 0.5 },
+    "dirichlet": { "epsilon": 0.25, "alphaScale": 10 },
     "temperature": { "tau": 1.0, "moves": 30 },
     "curation": { "maxPerLevel": 24, "maxMoves": 64 },
     "gen0": { "evaluator": "rollout", "sims": 400, "rolloutDepth": 60 },
@@ -56,8 +56,8 @@ success = score > 500; see "Widening to the full config mix" below).
 }
 ```
 
-Rationale for the non-obvious values: `dirichlet.alpha` 0.5 ≈ 10/⟨branching
-18⟩ per [13](13-puct-search.md); `gen0.sims` 400 because gen-0 data quality
+Rationale for the non-obvious values: `dirichlet.alphaScale` 10 yields
+α ≈ 10/⟨branching 18⟩ ≈ 0.55 per [13](13-puct-search.md); `gen0.sims` 400 because gen-0 data quality
 sets the ceiling for gen-1 and is paid only once; `tempMoves` 30 covers the
 settlement-and-early-building phase where opening diversity matters.
 

--- a/docs/trainer/27-realtime-deployment.md
+++ b/docs/trainer/27-realtime-deployment.md
@@ -23,13 +23,13 @@ A new top-level `bot/` package — not `agent/`, not `web/`. `agent/` stays
 deployment-blind (no Supabase dependency, no daemon loop); `web/` stays
 inference-free (`onnxruntime-node` must never enter the Vercel bundle, per
 [21](21-onnx-evaluator.md)'s "`game/` and `web/` never see it"). `bot/`
-depends on both worlds: it imports the OeL adapter ([09](09-game-adapter.md)),
-`puct` ([13](13-puct-search.md)) and `createOnnxEvaluator` ([21](21-onnx-evaluator.md))
-from `agent/`, plus `@supabase/supabase-js` for the game store.
+bridges both: it imports the OeL adapter ([09](09-game-adapter.md)), `puct`
+([13](13-puct-search.md)) and `createOnnxEvaluator`
+([21](21-onnx-evaluator.md)) from `agent/`, plus `@supabase/supabase-js`.
 
-It runs as one long-lived Node process on an always-on box (the Linux training
-machine or the trashcan Mac Pro — both have `onnxruntime-node` prebuilds).
-Alternatives rejected:
+It runs as one long-lived Node process on an always-on box (the Linux
+training machine or the trashcan Mac Pro — both have `onnxruntime-node`
+prebuilds). Alternatives rejected:
 
 - **Inference in the Next.js API on Vercel** — `onnxruntime-node` is a large
   native addon squeezed against serverless bundle limits; cold starts re-create
@@ -146,11 +146,10 @@ scope for v1 — Ora et Labora ends by structure, not by resignation.
 
 ## Implementation plan
 
-1. `bot/package.json` + workspace entry in `pnpm-workspace.yaml`; deps:
-   `agent` (workspace), `@supabase/supabase-js`; `bot/src/config.ts` (env +
-   difficulty table).
-2. `agent/src/mcts/puct.ts`: add `budgetMs`/`minSims` to options (tested:
-   budget respected, `minSims` floor, no behavior change when unset).
+1. `bot/package.json` + workspace entry in `pnpm-workspace.yaml` (deps:
+   workspace `agent`, `@supabase/supabase-js`); `bot/src/config.ts`.
+2. `agent/src/mcts/puct.ts`: add `budgetMs`/`minSims` options (tested: budget
+   respected, floor holds, bit-identical when unset).
 3. `bot/src/db.ts` — service client, `listSeatedGames()`, `fetchCommands()`,
    `appendCommand()` (CAS + zero-rows handling).
 4. `bot/src/turns.ts` — realtime subscriptions + slow poll, per-game queue.
@@ -159,8 +158,8 @@ scope for v1 — Ora et Labora ends by structure, not by resignation.
    pacing → append; the move-log line lives here.
 7. `bot/src/main.ts` (daemon wiring) + `bot/src/health.ts`.
 8. `bot/src/__tests__/` — CAS-conflict retry, ladder selection, budget/pacing
-   math, hot-reload swap (all against a stub client + fixture games).
-9. `bot/deploy/kennerspiel-bot.service`; runbook notes in this doc's How-it-runs.
+   math, hot-reload swap (stub client + fixture games).
+9. `bot/deploy/kennerspiel-bot.service`.
 
 ## Inputs
 
@@ -184,11 +183,10 @@ pnpm --dir bot test
 
 - **Dry-run** replays a fixture command list and prints the chosen move +
   stats — no network, safe anywhere.
-- **Staging**: seat two bot profiles in one real game (branch deploy + real
-  Supabase); the daemon plays itself through the production write path to
-  completion.
+- **Staging**: seat two bot profiles in one real game; the daemon plays
+  itself to completion through the production write path.
 - **Latency assertion**: over a staged game, p95 `elapsedMs ≤ budgetMs + 500`
-  and every move ≥ `minDelayMs` — checked from the move log by a test script.
+  and every move ≥ `minDelayMs`, checked from the move log by a script.
 - **Acceptance**: one full game vs a human via the web UI, with the move log
   showing budgeted searches, zero fallbacks, and the expected `netId`.
 

--- a/docs/trainer/README.md
+++ b/docs/trainer/README.md
@@ -8,7 +8,11 @@ the core is game-agnostic so similar games can plug in later.
 This index links one design doc per project. Each project doc states how it
 runs, what it consumes, and what it produces. Projects already implemented in
 the repo are included as specs (phrased forward-looking) so the plan is
-self-contained; their **Status** column below reflects reality.
+self-contained; their **Status** column below reflects reality. Every
+cross-project data contract (config.json, JSONL v2, shards, spec.json, the
+ONNX graph interface, best.json, STATE, logs) is pinned in
+[**schemas.md**](schemas.md) — when two project docs disagree about a shape,
+schemas.md wins.
 
 > Supersedes [`docs/mcts-self-play-plan.md`](../mcts-self-play-plan.md), whose
 > Phases 1–3 correspond to projects 01–06 here.
@@ -73,6 +77,11 @@ NN-guided PUCT beating pure UCT at equal simulations.
 | [24](24-smoke-e2e.md) | Smoke end-to-end run | repo | 23 | M6 | planned |
 | [25](25-rocm-runbook.md) | ROCm hardware bring-up | `trainer/` | 17 | M7 | planned |
 | [26](26-first-run.md) | First real training run | ops | 24, 25 | M7 | planned |
+| [27](27-realtime-deployment.md) | Real-time deployment (bot daemon) | `bot/` | 13, 21, 22, 26 | M8 | planned |
+| [28](28-second-game-onboarding.md) | Second-game onboarding | `agent/` + new engine | 09–24 | M9 | planned |
+
+Reference (not a project): [schemas.md](schemas.md) — canonical data
+contracts shared across projects.
 
 ## Dependency graph
 
@@ -126,6 +135,12 @@ graph LR
   P17 --> P25[25 ROCm runbook]
   P24 --> P26[26 first run]
   P25 --> P26
+  P13 --> P27[27 realtime bot]
+  P21 --> P27
+  P22 --> P27
+  P26 --> P27
+  P09 --> P28[28 second game]
+  P24 --> P28
 ```
 
 ## Milestones (each ships as one or a few PRs)
@@ -139,6 +154,8 @@ graph LR
 | M5 — Training pipeline | 16–20 | Overfit test on 10 games; Node↔Python shard round-trip bit-exact; torch↔ONNX parity |
 | M6 — Closed loop | 21–24 | `pnpm loop --config tiny.json --gens 2` finishes end-to-end in minutes |
 | M7 — Real run | 25, 26 | A promoted generation beats pure UCT at equal sims (2–4p buckets) and beats pure UCT's score>500 rate in solo |
+| M8 — Play humans | 27 | The bot daemon completes a full game vs a human through the web UI within its time budget |
+| M9 — Second game | 28 | A new game's adapter passes the acceptance ladder and closes a tiny smoke loop end-to-end |
 
 ## Run directory layout (shared vocabulary)
 
@@ -164,10 +181,6 @@ building more infrastructure — that is what 08 exists for.
 
 ## Later (out of scope here)
 
-- Real-time deployment behind the web/MCP `make_move` seam (see
-  [`docs/mcp-server-design.md`](../mcp-server-design.md)).
-- Second game onboarding: implement `GameAdapter` + `ActionSpec` for the new
-  game; search/selfplay/exporter/trainer are reused unchanged.
 - Additional countries: append the country to the reserved config slot and
   the new buildings to the append-only erection vocab (both capacity-reserved
   — [01](01-state-encoder.md)/[07](07-engine-fast-paths.md)); re-export


### PR DESCRIPTION
## What

Follow-up iteration on the trainer plan merged in #1867:

- **`docs/trainer/schemas.md`** (new) — the single canonical reference for every cross-project data contract: `config.json` (single-config and weighted-mix `game` forms, scalar and panel `gate` forms, the `solo` value-mapping anchors), the JSONL v2 game line with the `moveKey` grammar, the seven-file shard directory + `meta.json` + the `.npy` header rules the Node writer emits, `spec.json`, the ONNX graph interface, `golden.json`, `best.json`, `arena.json`, the `STATE` marker, both log schemas, a version-compatibility matrix (which version field guards which producer/consumer pair and what happens on mismatch), and a change procedure. When two project docs disagree about a shape, schemas.md wins.
- **`27-realtime-deployment.md`** (new project, M8) — the end goal: an always-on bot daemon (new `bot/` workspace package) that plays seated games against humans through the existing Supabase/MCP write path, with wall-clock-budgeted PUCT (no noise, τ→0), champion hot-reload from `best.json`, a graceful degradation ladder (net → greedy-value → rollout MCTS) so a human's game never stalls, and systemd ops. Justifies daemon-on-own-box over Vercel serverless and Supabase edge functions.
- **`28-second-game-onboarding.md`** (new project, M9) — the concrete checklist for plugging the next Uwe-style game into the trainer: engine prerequisites, the adapter items with OeL's hard-won gotchas attached (canonicalization duplicates, [0,1] outcome contract, capacity reservation), what is reused with zero changes, and the gated acceptance ladder ending in a smoke loop.
- **Consistency pass** across the doc set: `moveFeatureLen` standardized to 91 (doc 11 is the source of truth), hardcoded `featureLen` literals replaced with spec-driven references (14,670 today, 14,676 once project 07 reserves country capacity), the Dirichlet config key unified to `alphaScale`, and the solo σ((score−500)/100) value mapping propagated into docs 01/05.
- **README** — schemas link, projects 27/28 in the table and dependency graph, M8/M9 milestones with exit criteria.

## Why

Continues the iteration requested on the plan: pin the contracts implementers will code against, cover the two stated end goals (playing humans in real time, adding more games) as first-class projects, and remove the contradictions left by parallel doc authoring.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Cw5qiAmYZH5Ve6bByKfTA

---
_Generated by [Claude Code](https://claude.ai/code/session_017Cw5qiAmYZH5Ve6bByKfTA)_