### PR TITLE
feat(game): engine fast paths — completions/scores/encodeInto + reserved country capacity

### DIFF
--- a/docs/trainer/07-engine-fast-paths.md
+++ b/docs/trainer/07-engine-fast-paths.md
@@ -2,7 +2,7 @@
 
 | | |
 | --- | --- |
-| Status | planned |
+| Status | ✅ done |
 | Package | `game/` |
 | Depends on | [01](01-state-encoder.md) |
 | Milestone | M1 |

--- a/docs/trainer/README.md
+++ b/docs/trainer/README.md
@@ -57,7 +57,7 @@ NN-guided PUCT beating pure UCT at equal simulations.
 | [04](04-baselines-arena.md) | Baseline policies & arena | `agent/` | 02, 03 | — | ✅ done |
 | [05](05-uct-search.md) | Pure UCT search | `agent/` | 02, 03 | — | ✅ done |
 | [06](06-selfplay-v1.md) | Self-play generator v1 | `agent/` | 04, 05 | — | ✅ done |
-| [07](07-engine-fast-paths.md) | Engine fast paths | `game/` | 01 | M1 | planned |
+| [07](07-engine-fast-paths.md) | Engine fast paths | `game/` | 01 | M1 | ✅ done |
 | [08](08-benchmarks.md) | Benchmark harness | `agent/` | 03, 07 | M1 | planned |
 | [09](09-game-adapter.md) | GameAdapter interface | `agent/` | 02–06 | M2 | planned |
 | [10](10-move-canonicalization.md) | Move canonicalization | `agent/` | 03, 07 | M2 | planned |

--- a/docs/trainer/schemas.md
+++ b/docs/trainer/schemas.md
@@ -143,9 +143,9 @@ partial); dirs are built in `.tmp-*` and atomically renamed, `meta.json`
 written last.
 
 Dimensions: `moveFeatureLen = 91` (doc 11). `featureLen = featureSpec.featureLen`
-from `game/src/encode.ts` — **14,670** for the current encoder;
-**14,676** once project 07's `COUNTRY_CAPACITY = 8` lands (+6 in the shared
-block, featureSpecVersion bump). Never hardcode it downstream; assert it.
+from `game/src/encode.ts` — **14,676** as of project 07's `COUNTRY_CAPACITY = 8`
+(`featureSpec.version = 2`; the pre-07 layout was **14,670** / v1, +6 in the
+shared block on the bump). Never hardcode it downstream; assert it.
 
 | File | Shape | dtype | Contents |
 | --- | --- | --- | --- |

--- a/game/package.json
+++ b/game/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.21.2",
+  "version": "0.22.0",
   "name": "hathora-et-labora-game",
   "type": "module",
   "sideEffects": false,

--- a/game/src/__tests__/fastPaths.test.ts
+++ b/game/src/__tests__/fastPaths.test.ts
@@ -1,0 +1,683 @@
+import { describe, it, expect } from '../testHelpers'
+import { control, completions, scores, encode, encodeInto, erectionId, FEATURE_LEN, featureSpec } from '..'
+import { reducer } from '../reducer'
+import { initialState } from '../state'
+import { BuildingEnum, GameState, GameStatusEnum, SettlementEnum } from '../types'
+
+// ===========================================================================
+// Project 07 — engine fast paths. control() is now defined in terms of
+// completions() + scores(), and encode() in terms of encodeInto(); these
+// tests pin that the fast paths stay byte-for-byte identical to control()/
+// encode() over real replayed games, and that erectionId's Map matches the
+// old indexOf chain exactly. See docs/trainer/07-engine-fast-paths.md.
+// ===========================================================================
+
+// --- Reference erectionId: the pre-07 indexOf implementation, inlined, so the
+// table test compares the Map against exactly what it replaced. ---
+const BUILDINGS = Object.values(BuildingEnum) as BuildingEnum[]
+const SETTLEMENTS = Object.values(SettlementEnum) as SettlementEnum[]
+const genericBuildingKey = (b: string): string => {
+  const m = /^L([RGBW])([123])$/.exec(b)
+  if (m) return ['', 'ClayMound', 'FarmYard', 'CloisterOffice'][Number(m[2])]
+  return b
+}
+const settlementTypeKey = (s: string): string => {
+  const m = /^S[RGBW]([1-8])$/.exec(s)
+  return `Settlement${m ? m[1] : s}`
+}
+const dedupeInOrder = (keys: string[]): string[] => keys.filter((k, i) => keys.indexOf(k) === i)
+const OLD_GENERIC = dedupeInOrder(BUILDINGS.map(genericBuildingKey))
+const OLD_SETTLEMENT_TYPES = dedupeInOrder(SETTLEMENTS.map(settlementTypeKey))
+const OLD_SETTLEMENT_SET = new Set<string>(SETTLEMENTS)
+const oldErectionId = (e: string): number => {
+  if (OLD_SETTLEMENT_SET.has(e)) return OLD_GENERIC.length + OLD_SETTLEMENT_TYPES.indexOf(settlementTypeKey(e)) + 1
+  return OLD_GENERIC.indexOf(genericBuildingKey(e)) + 1
+}
+
+// --- Fixtures --------------------------------------------------------------
+// A full 4-player France/long game (mainline of game21872.test.ts): CONFIG +
+// START through the final COMMIT into FINISHED. Auto-lifted from that fixture.
+const game4pCommands: string[][] = [
+  ['CONFIG', '4', 'france', 'long'],
+  ['START', 'R', 'G', 'B', 'W'],
+  ['USE', 'LR3'],
+  ['BUY_DISTRICT', '2', 'PLAINS'],
+  ['COMMIT'],
+  ['USE', 'LG3', 'Jo'],
+  ['COMMIT'],
+  ['FELL_TREES', '2', '0'],
+  ['COMMIT'],
+  ['USE', 'LW1'],
+  ['COMMIT'],
+  ['BUILD', 'G01', '3', '1'],
+  ['COMMIT'],
+  ['BUILD', 'F09', '3', '1'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'Sh'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '0'],
+  ['COMMIT'],
+  ['FELL_TREES', '1', '0'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'Gn'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '0', 'Jo'],
+  ['COMMIT'],
+  ['USE', 'LB1'],
+  ['COMMIT'],
+  ['BUILD', 'G02', '3', '1'],
+  ['USE', 'G02', 'ClPnGn', 'Pn'],
+  ['BUY_DISTRICT', '-1', 'PLAINS'],
+  ['COMMIT'],
+  ['USE', 'LR1', 'Jo'],
+  ['COMMIT'],
+  ['BUILD', 'G12', '0', '0'],
+  ['COMMIT'],
+  ['USE', 'LB3'],
+  ['BUY_DISTRICT', '-1', 'HILLS'],
+  ['COMMIT'],
+  ['USE', 'LW2', 'Gn'],
+  ['COMMIT'],
+  ['FELL_TREES', '2', '0'],
+  ['COMMIT'],
+  ['USE', 'G12', 'PtPtShShShSh'],
+  ['COMMIT'],
+  ['BUILD', 'F04', '3', '-1'],
+  ['COMMIT'],
+  ['BUILD', 'G13', '1', '0'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['BUILD', 'F05', '2', '0'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '1'],
+  ['COMMIT'],
+  ['USE', 'LB2', 'Sh'],
+  ['COMMIT'],
+  ['USE', 'G13', 'PnPn'],
+  ['COMMIT'],
+  ['USE', 'LR1'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG3', 'Jo'],
+  ['BUY_DISTRICT', '2', 'PLAINS'],
+  ['COMMIT'],
+  ['USE', 'LB3'],
+  ['BUY_PLOT', '-1', 'MOUNTAIN'],
+  ['COMMIT'],
+  ['USE', 'LW2', 'Gn'],
+  ['COMMIT'],
+  ['FELL_TREES', '1', '1'],
+  ['COMMIT'],
+  ['BUILD', 'F08', '1', '2'],
+  ['USE', 'F08', 'ClGpPtGn'],
+  ['BUY_PLOT', '0', 'MOUNTAIN'],
+  ['COMMIT'],
+  ['SETTLE', 'SB3', '3', '0', 'ShShShSh'],
+  ['COMMIT'],
+  ['SETTLE', 'SW1', '2', '-1', 'WoGn'],
+  ['COMMIT'],
+  ['SETTLE', 'SR2', '3', '0', 'ShGnPtWo'],
+  ['COMMIT'],
+  ['SETTLE', 'SG1', '2', '2', 'GpPt'],
+  ['COMMIT'],
+  ['USE', 'LB1'],
+  ['COMMIT'],
+  ['BUILD', 'F15', '1', '-1'],
+  ['USE', 'F15', 'Pn'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'F15', 'Pn'],
+  ['COMMIT'],
+  ['USE', 'LG2', 'Sh'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['BUILD', 'G16', '3', '1'],
+  ['WITH_PRIOR'],
+  ['USE', 'G16'],
+  ['COMMIT'],
+  ['USE', 'G02', 'SwGnWo', 'Pn'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '0'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'JoGn'],
+  ['COMMIT'],
+  ['USE', 'G16'],
+  ['COMMIT'],
+  ['FELL_TREES', '2', '0'],
+  ['COMMIT'],
+  ['BUILD', 'G07', '1', '2'],
+  ['USE', 'G07', 'PtPtPtPt'],
+  ['COMMIT'],
+  ['USE', 'LG3'],
+  ['COMMIT'],
+  ['USE', 'LB2', 'Gn'],
+  ['COMMIT'],
+  ['USE', 'G13', 'PnPn'],
+  ['COMMIT'],
+  ['BUILD', 'F14', '4', '2'],
+  ['COMMIT'],
+  ['SETTLE', 'SG5', '4', '2', 'BrShPt'],
+  ['COMMIT'],
+  ['SETTLE', 'SB5', '2', '0', 'PtShShSh'],
+  ['COMMIT'],
+  ['SETTLE', 'SW5', '4', '-1', 'WoShBr'],
+  ['COMMIT'],
+  ['SETTLE', 'SR5', '3', '2', 'WoBrGnGn'],
+  ['COMMIT'],
+  ['BUILD', 'G22', '6', '0'],
+  ['USE', 'G22', 'Jo'],
+  ['COMMIT'],
+  ['WITH_PRIOR'],
+  ['USE', 'F04', 'GnGnGnGnGnGn'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['BUILD', 'F21', '2', '0'],
+  ['USE', 'F21', 'GpGpWn'],
+  ['BUY_PLOT', '-2', 'MOUNTAIN'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'F21', 'GpGpGpWn'],
+  ['COMMIT'],
+  ['FELL_TREES', '0', '2'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'F05', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'F05', 'FlFlFlFlFlFlPtPtBrBr'],
+  ['COMMIT'],
+  ['CONVERT', 'GnGn'],
+  ['BUY_DISTRICT', '-2', 'PLAINS'],
+  ['BUILD', 'F20', '2', '-2'],
+  ['USE', 'F20', 'PnWn'],
+  ['COMMIT'],
+  ['BUY_PLOT', '0', 'COAST'],
+  ['USE', 'LR2', 'Sh'],
+  ['COMMIT'],
+  ['USE', 'LG1'],
+  ['COMMIT'],
+  ['BUY_PLOT', '1', 'MOUNTAIN'],
+  ['WORK_CONTRACT', 'G12', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'G12', 'BrBrBrPnPtPtSwSw'],
+  ['COMMIT'],
+  ['USE', 'G13', 'PnPn'],
+  ['COMMIT'],
+  ['CONVERT', 'Ni'],
+  ['WORK_CONTRACT', 'G22', 'PnPn'],
+  ['USE', 'G22', 'Jo'],
+  ['COMMIT'],
+  ['BUILD', 'F24', '3', '2'],
+  ['COMMIT'],
+  ['BUILD', 'F17', '5', '1'],
+  ['WITH_PRIOR'],
+  ['USE', 'F17', 'PnBo'],
+  ['COMMIT'],
+  ['USE', 'F15', 'Pn'],
+  ['COMMIT'],
+  ['USE', 'LR2', 'Gn'],
+  ['COMMIT'],
+  ['BUY_DISTRICT', '3', 'HILLS'],
+  ['CUT_PEAT', '0', '3'],
+  ['COMMIT'],
+  ['FELL_TREES', '2', '-1'],
+  ['COMMIT'],
+  ['BUILD', 'F25', '3', '-1'],
+  ['COMMIT'],
+  ['BUILD', 'F11', '-1', '0'],
+  ['USE', 'F11'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG3'],
+  ['COMMIT'],
+  ['BUILD', 'G18', '5', '2'],
+  ['COMMIT'],
+  ['CONVERT', 'Ni'],
+  ['WORK_CONTRACT', 'G22', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'G22', 'Jo'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'F04', 'Wn'],
+  ['USE', 'F04', 'GnGnGnGnGn'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['BUILD', 'F23', '5', '1'],
+  ['USE', 'F23', 'Pn'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '-1'],
+  ['COMMIT'],
+  ['USE', 'G02', 'ClPnFl', 'Wo'],
+  ['COMMIT'],
+  ['USE', 'F05', 'FlFlFlFlFlFlFlCoSwBrBr'],
+  ['BUY_PLOT', '0', 'MOUNTAIN'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'Sh'],
+  ['COMMIT'],
+  ['USE', 'G16'],
+  ['COMMIT'],
+  ['SETTLE', 'SW2', '3', '0', 'WoPtBr'],
+  ['COMMIT'],
+  ['SETTLE', 'SR4', '-1', '1', 'CoBrBrSh'],
+  ['COMMIT'],
+  ['SETTLE', 'SG3', '0', '2', 'PnPnPnPnPnSh'],
+  ['COMMIT'],
+  ['SETTLE', 'SB6', '5', '0', 'PtPtPtMt'],
+  ['COMMIT'],
+  ['BUILD', 'F31', '4', '-2'],
+  ['USE', 'F31'],
+  ['COMMIT'],
+  ['USE', 'LR1'],
+  ['BUY_PLOT', '2', 'COAST'],
+  ['COMMIT'],
+  ['USE', 'G22'],
+  ['COMMIT'],
+  ['USE', 'G18', 'ClClClSnPtPt'],
+  ['COMMIT'],
+  ['USE', 'F21', 'GpGpGpGpGpGpGpGpGpWn'],
+  ['COMMIT'],
+  ['BUILD', 'G19', '1', '1'],
+  ['USE', 'G19', 'ShShShShSwSwSwSw'],
+  ['COMMIT'],
+  ['CONVERT', 'GnGn'],
+  ['BUILD', 'F30', '4', '3'],
+  ['USE', 'F30', 'Po'],
+  ['COMMIT'],
+  ['USE', 'G16'],
+  ['COMMIT'],
+  ['BUY_PLOT', '0', 'MOUNTAIN'],
+  ['BUILD', 'F32', '5', '1'],
+  ['USE', 'F32', 'Pn'],
+  ['FELL_TREES', '0', '-2'],
+  ['CUT_PEAT', '0', '0', 'Jo'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'F30', 'Po'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'Gn'],
+  ['COMMIT'],
+  ['USE', 'LB2', 'Sh'],
+  ['COMMIT'],
+  ['USE', 'G02', 'ClWoFl', 'Sh'],
+  ['COMMIT'],
+  ['BUILD', 'G26', '-1', '3'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'G07', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'G07', 'PtPtPtPtPtPtPtPt'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['SETTLE', 'SB7', '2', '-1', 'ShShShShShShBrPtWoWoWoWoWoSwSwSwSw'],
+  ['COMMIT'],
+  ['SETTLE', 'SW3', '3', '-2', 'ShShShFl'],
+  ['COMMIT'],
+  ['SETTLE', 'SR7', '0', '0', 'MtMtMtCoCoCo'],
+  ['COMMIT'],
+  ['SETTLE', 'SG2', '3', '3', 'GpGpGpCo'],
+  ['COMMIT'],
+  ['USE', 'LB3'],
+  ['COMMIT'],
+  ['BUILD', 'F40', '5', '0'],
+  ['COMMIT'],
+  ['BUILD', 'F29', '6', '0'],
+  ['USE', 'F29'],
+  ['COMMIT'],
+  ['BUY_PLOT', '2', 'MOUNTAIN'],
+  ['BUILD', 'F38', '0', '3'],
+  ['USE', 'F38', '1', '3', '2', '3', '1', '1', '1', '0'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '1'],
+  ['COMMIT'],
+  ['USE', 'G13', 'PnPn'],
+  ['COMMIT'],
+  ['USE', 'F14'],
+  ['COMMIT'],
+  ['BUILD', 'F36', '2', '3'],
+  ['COMMIT'],
+  ['FELL_TREES', '1', '-1'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'LG2', 'Wn'],
+  ['USE', 'LG2', 'ShJo'],
+  ['COMMIT'],
+  ['USE', 'F11'],
+  ['COMMIT'],
+  ['USE', 'F08', 'WoSnPnGp'],
+  ['COMMIT'],
+  ['BUILD', 'G39', '5', '-1'],
+  ['USE', 'G39', 'PtPtPt'],
+  ['COMMIT'],
+  ['BUILD', 'G28', '6', '-2'],
+  ['USE', 'G28'],
+  ['SETTLE', 'SW6', '5', '-2', 'ShShFlPtPtPt'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'G28'],
+  ['SETTLE', 'SR3', '2', '2', 'MtGpGp'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'G19', 'PnPn'],
+  ['CONVERT', 'GnGnGnGnGnGn'],
+  ['USE', 'G19', 'SwSwSwSwSwSwShShShShShSh'],
+  ['COMMIT'],
+  ['USE', 'LB1'],
+  ['COMMIT'],
+  ['USE', 'F40'],
+  ['USE', 'F27', 'Wn'],
+  ['USE', 'F08', 'WoClSwSh'],
+  ['COMMIT'],
+  ['CUT_PEAT', '0', '1'],
+  ['BUY_DISTRICT', '3', 'PLAINS'],
+  ['COMMIT'],
+  ['USE', 'F09'],
+  ['USE', 'LG2', 'Sh'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'F36', 'PnPn'],
+  ['USE', 'F36', 'Or', 'Po'],
+  ['COMMIT'],
+  ['USE', 'F15', 'Pn'],
+  ['COMMIT'],
+  ['USE', 'G01'],
+  ['USE', 'G28'],
+  ['SETTLE', 'SR6', '2', '3', 'PtPtPtBrGpGp'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'F17', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['CONVERT', 'Ni'],
+  ['USE', 'F17', 'PnPnPnBo'],
+  ['COMMIT'],
+  ['CONVERT', 'Gn'],
+  ['BUILD', 'F35', '1', '-1'],
+  ['WITH_PRIOR'],
+  ['USE', 'F35', 'PnPnPnPnPn'],
+  ['COMMIT'],
+  ['USE', 'F40'],
+  ['USE', 'F33', 'PtWoMt'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'F24', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'F24', 'BrBrWnWn'],
+  ['COMMIT'],
+  ['WORK_CONTRACT', 'G28', 'PnPn'],
+  ['WITH_LAYBROTHER'],
+  ['USE', 'G28'],
+  ['SETTLE', 'SG6', '1', '3', 'MtCoCo'],
+  ['COMMIT'],
+  ['USE', 'G18', 'ClClClPtWo'],
+  ['COMMIT'],
+  ['USE', 'G13', 'PnPn'],
+  ['COMMIT'],
+  ['USE', 'G26', 'WoWo'],
+  ['COMMIT'],
+  ['USE', 'G28'],
+  ['SETTLE', 'SG8', '5', '2', 'MtMtMtMtMtMtCo'],
+  ['COMMIT'],
+  ['USE', 'F40'],
+  ['USE', 'G34', 'BoPoOrRq'],
+  ['COMMIT'],
+  ['USE', 'F25', 'WoClSnSwPnGnShFlGpMtWnBrBo'],
+  ['COMMIT'],
+  ['SETTLE', 'SR1', '4', '3', 'GpPt'],
+  ['COMMIT'],
+  ['SETTLE', 'SG7', '5', '3', 'ShShShShShBrGpPnCoCoCo'],
+  ['COMMIT'],
+  ['SETTLE', 'SB2', '4', '-1', 'PtWoPnPnPn'],
+  ['COMMIT'],
+  ['SETTLE', 'SW8', '5', '-1', 'ShShShFlGpBrMtMtMtMtWoWoWo'],
+  ['COMMIT'],
+]
+
+// A solo (1-player) France/long game — exercises scores()'s slice(0, players)
+// (a neutral player sits past config.players) and 1p completion arms. Lifted
+// verbatim from control-solo.test.ts.
+const soloCommands: string[][] = `
+CONFIG 1 france long
+START R B
+CUT_PEAT 0 0
+COMMIT
+FELL_TREES 1 0
+COMMIT
+USE LR1
+COMMIT
+BUILD G07 0 0
+USE G07 PtPt
+COMMIT
+USE LR3
+COMMIT
+BUILD G01 3 1
+COMMIT
+USE LR2 Gn
+CONVERT GnGn
+COMMIT
+BUILD G06 1 0
+USE G06 CoCoCo
+COMMIT
+BUY_DISTRICT 2 PLAINS
+BUILD F09 3 2
+COMMIT
+USE LR1
+COMMIT
+FELL_TREES 0 2
+COMMIT
+CUT_PEAT 0 1
+COMMIT
+USE G07 PtPtPtPtPtPt
+COMMIT
+USE G06 CoCoCo
+BUY_PLOT 2 COAST
+COMMIT
+BUY_DISTRICT 3 PLAINS
+BUILD F03 1 3
+USE F03 Pn
+COMMIT
+BUILD F04 -1 3
+COMMIT
+USE F04 GnGnGnGnGnGnGn
+COMMIT
+BUILD F05 0 2
+USE F05 FlFlFlFlFlFlFlCoSwBrBr
+COMMIT
+BUILD G12 0 1
+COMMIT
+USE G12 BrBrBrPnCoCo
+COMMIT
+BUILD F08 2 2
+USE F08 PnGnWoSw
+BUY_PLOT 0 COAST
+COMMIT
+BUILD F11 -1 1
+COMMIT
+`
+  .trim()
+  .split('\n')
+  .map((l) => l.trim().split(' '))
+
+// Replay a command list, returning every in-play intermediate state. The
+// SETUP states before START (no frame/players yet) are dropped: control(),
+// completions() and scores() are never called during SETUP and would throw
+// (encode's SETUP path is covered by its own test below).
+const replay = (commands: string[][]): GameState[] => {
+  const states: GameState[] = []
+  let s = initialState
+  for (const cmd of commands) {
+    const next = reducer(s, cmd)
+    if (next === undefined) throw new Error(`reducer returned undefined at [${cmd.join(' ')}]`)
+    s = next
+    if (s.status !== GameStatusEnum.SETUP) states.push(s)
+  }
+  return states
+}
+
+const game4pStates = replay(game4pCommands)
+const soloStates = replay(soloCommands)
+
+// completions()/control().completion can only diverge by throwing differently,
+// so compare captured outcomes rather than letting a throw abort the suite.
+type Outcome = { ok: true; value: unknown } | { ok: false; error: string }
+const capture = (fn: () => unknown): Outcome => {
+  try {
+    return { ok: true, value: fn() }
+  } catch (e) {
+    return { ok: false, error: String(e) }
+  }
+}
+
+// Depth-bounded DFS over partials: append each single-token completion to the
+// partial and recurse, so command-specific match arms get exercised on real
+// states (multi-word coordinate tokens like '3 1' terminate a branch — they
+// are not valid partial prefixes pre-canonicalization).
+const assertPartialParity = (state: GameState, maxDepth = 3, maxNodes = 120): void => {
+  const budget = { nodes: maxNodes }
+  const visit = (partial: string[], depth: number): void => {
+    const fast = capture(() => completions(state, partial))
+    const slow = capture(() => control(state, partial).completion)
+    expect(fast).toStrictEqual(slow)
+    if (depth >= maxDepth || !fast.ok || !Array.isArray(fast.value)) return
+    for (const tok of fast.value as string[]) {
+      if (budget.nodes <= 0) return
+      if (typeof tok !== 'string' || tok.includes(' ')) continue
+      budget.nodes -= 1
+      visit([...partial, tok], depth + 1)
+    }
+  }
+  visit([], 0)
+}
+
+const expectFloatArraysEqual = (a: Float32Array, b: Float32Array): void => {
+  expect(a.length).toBe(b.length)
+  let firstMismatch = -1
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) {
+      firstMismatch = i
+      break
+    }
+  }
+  expect(firstMismatch).toBe(-1)
+}
+
+describe('fast paths: completions() parity with control().completion', () => {
+  it('matches control() at every state of a 4-player game (top level)', () => {
+    for (const state of game4pStates) {
+      expect(completions(state, [])).toStrictEqual(control(state, []).completion)
+    }
+  })
+
+  it('matches control() at every state of a solo game (top level)', () => {
+    for (const state of soloStates) {
+      expect(completions(state, [])).toStrictEqual(control(state, []).completion)
+    }
+  })
+
+  it('matches control() over drilled-down partials (command-specific arms)', () => {
+    // Sample states across the games so the deeper DFS stays fast.
+    for (let i = 0; i < game4pStates.length; i += 9) assertPartialParity(game4pStates[i])
+    for (let i = 0; i < soloStates.length; i += 5) assertPartialParity(soloStates[i])
+  })
+
+  it('defaults partial to [] like the undefined-head arm', () => {
+    const state = game4pStates[2]
+    expect(completions(state)).toStrictEqual(completions(state, []))
+  })
+
+  it('returns [] for an unknown command head (the .otherwise arm)', () => {
+    expect(completions(game4pStates[2], ['NOT_A_COMMAND'])).toStrictEqual([])
+  })
+
+  it('short-circuits to [] only for an undefined head on a FINISHED state', () => {
+    const finished = game4pStates[game4pStates.length - 1]
+    expect(finished.status).toBe(GameStatusEnum.FINISHED)
+    expect(completions(finished, [])).toStrictEqual([])
+    // a command head still delegates on FINISHED — not short-circuited
+    expect(completions(finished, ['USE'])).toStrictEqual(control(finished, ['USE']).completion)
+  })
+})
+
+describe('fast paths: scores() parity with control().score', () => {
+  it('matches control() at every 4-player state', () => {
+    for (const state of game4pStates) {
+      expect(scores(state)).toStrictEqual(control(state, []).score)
+    }
+  })
+
+  it('matches control() at every solo state and slices off the neutral player', () => {
+    for (const state of soloStates) {
+      const s = scores(state)
+      expect(s).toStrictEqual(control(state, []).score)
+      expect(s.length).toBe(state.config!.players) // 1, though players[] holds a neutral too
+    }
+  })
+})
+
+describe('fast paths: encodeInto() parity with encode()', () => {
+  const perspectivesFor = (state: GameState): (number | undefined)[] => [
+    undefined,
+    ...Array.from({ length: state.players!.length }, (_, i) => i),
+  ]
+
+  it('equals encode() byte-for-byte into a fresh buffer, every perspective', () => {
+    for (let i = 0; i < game4pStates.length; i += 7) {
+      const state = game4pStates[i]
+      for (const p of perspectivesFor(state)) {
+        const out = new Float32Array(FEATURE_LEN)
+        encodeInto(state, p, out)
+        expectFloatArraysEqual(out, encode(state, p))
+      }
+    }
+  })
+
+  it('clears a NaN-poisoned scratch buffer (proves the fill(0))', () => {
+    const state = game4pStates[120]
+    const out = new Float32Array(FEATURE_LEN).fill(NaN)
+    encodeInto(state, 0, out)
+    expectFloatArraysEqual(out, encode(state, 0))
+  })
+
+  it('writes exactly [offset, offset + FEATURE_LEN) and nothing outside', () => {
+    const state = game4pStates[120]
+    const offset = 37
+    const pad = 11
+    const buf = new Float32Array(offset + FEATURE_LEN + pad).fill(NaN)
+    encodeInto(state, undefined, buf, offset)
+    // window equals a standalone encode
+    expectFloatArraysEqual(buf.slice(offset, offset + FEATURE_LEN), encode(state))
+    // bytes before and after the window are untouched (still NaN)
+    for (let i = 0; i < offset; i++) expect(Number.isNaN(buf[i])).toBe(true)
+    for (let i = offset + FEATURE_LEN; i < buf.length; i++) expect(Number.isNaN(buf[i])).toBe(true)
+  })
+
+  it('throws RangeError when the buffer is too small for the offset', () => {
+    const state = game4pStates[10]
+    expect(() => encodeInto(state, undefined, new Float32Array(FEATURE_LEN), 1)).toThrow()
+    expect(() => encodeInto(state, undefined, new Float32Array(FEATURE_LEN - 1))).toThrow()
+  })
+
+  it('zero-fills a SETUP state', () => {
+    const setup = { status: GameStatusEnum.SETUP } as GameState
+    const out = new Float32Array(FEATURE_LEN).fill(NaN)
+    encodeInto(setup, undefined, out)
+    expect(out.every((v) => v === 0)).toBe(true)
+  })
+})
+
+describe('fast paths: erectionId Map matches the old indexOf implementation', () => {
+  it('matches for every BuildingEnum value', () => {
+    for (const b of BUILDINGS) expect(erectionId(b)).toBe(oldErectionId(b))
+  })
+  it('matches for every SettlementEnum value', () => {
+    for (const s of SETTLEMENTS) expect(erectionId(s)).toBe(oldErectionId(s))
+  })
+  it('falls back to 0 for an unknown erection (like indexOf −1 + 1)', () => {
+    expect(erectionId('NOT_AN_ERECTION' as BuildingEnum)).toBe(0)
+    expect(oldErectionId('NOT_AN_ERECTION')).toBe(0)
+  })
+})
+
+describe('fast paths: featureSpec version and country capacity', () => {
+  it('reserves 8 country slots (14,670 -> 14,676) and bumps the version', () => {
+    expect(FEATURE_LEN).toBe(14676)
+    expect(featureSpec.featureLen).toBe(14676)
+    expect(featureSpec.version).toBe(2)
+    // countries vocab stays the source of truth for live ids (still 2)
+    expect(featureSpec.vocab.countries.length).toBe(2)
+  })
+})

--- a/game/src/control.ts
+++ b/game/src/control.ts
@@ -63,8 +63,12 @@ const computeFlow = (state: GameState) => {
   return flow
 }
 
-export const control = (state: GameState, partial: string[], player?: number): Controls => {
-  const completion = match(head(partial))
+// The completion enumeration extracted from control(). Move enumeration in the
+// agent hits this once per DFS node — hundreds of times per position — so it is
+// exposed on its own to skip the flow + score work control() also does.
+// control() is defined in terms of this (below), so parity is structural.
+export const completions = (state: GameState, partial: string[] = []): string[] =>
+  match(head(partial))
     .with(undefined, () =>
       state.status === GameStatusEnum.FINISHED
         ? []
@@ -100,7 +104,11 @@ export const control = (state: GameState, partial: string[], player?: number): C
     .with(GameCommandEnum.COMMIT, () => completeCommit(state)(partial))
     .otherwise(always([]))
 
-  const score = map(
+// Per-player scoring extracted from control(). engine.ts reads this every
+// rollout cutoff and terminal outcome, so it is exposed without the completion
+// enumeration control() otherwise pays for. Neutral player is sliced off.
+export const scores = (state: GameState): Score[] =>
+  map(
     pipe(
       (player: Tableau): Score => ({
         goods: goodsPoints(player) + 30 * player.wonders,
@@ -115,11 +123,11 @@ export const control = (state: GameState, partial: string[], player?: number): C
     ),
     state.players!.slice(0, state.config!.players) // this will remove neutral player
   )
-  return {
-    active: player === state.frame!.activePlayerIndex,
-    flow: computeFlow(state),
-    partial,
-    completion,
-    score,
-  }
-}
+
+export const control = (state: GameState, partial: string[], player?: number): Controls => ({
+  active: player === state.frame!.activePlayerIndex,
+  flow: computeFlow(state),
+  partial,
+  completion: completions(state, partial),
+  score: scores(state),
+})

--- a/game/src/encode.ts
+++ b/game/src/encode.ts
@@ -92,8 +92,6 @@ const RESOURCES: (keyof Required<Cost>)[] = [
 // so color is fully redundant with which player's grid the tile is in. We
 // collapse it. Country variants (F03 vs I03) stay DISTINCT — they are
 // different buildings, not colors.
-const SETTLEMENT_SET = new Set<string>(SETTLEMENTS)
-
 const genericBuildingKey = (b: BuildingEnum): string => {
   const m = /^L([RGBW])([123])$/.exec(b)
   if (m) return ['', 'ClayMound', 'FarmYard', 'CloisterOffice'][Number(m[2])]
@@ -119,12 +117,18 @@ BUILDINGS.forEach((b) => buildingMaskIndex.set(b, GENERIC_BUILDINGS.indexOf(gene
 const settlementHandIndex = new Map<SettlementEnum, number>()
 SETTLEMENTS.forEach((s) => settlementHandIndex.set(s, SETTLEMENT_TYPES.indexOf(settlementTypeKey(s))))
 
-// erection id: 1..ERECTION_VOCAB.length (0 reserved for empty)
-const erectionId = (e: ErectionEnum): number => {
-  if (SETTLEMENT_SET.has(e))
-    return GENERIC_BUILDINGS.length + SETTLEMENT_TYPES.indexOf(settlementTypeKey(e as SettlementEnum)) + 1
-  return GENERIC_BUILDINGS.indexOf(genericBuildingKey(e as BuildingEnum)) + 1
-}
+// erection id: 1..ERECTION_VOCAB.length (0 reserved for empty). Runs per
+// occupied tile per encode, so it uses a precomputed Map (same pattern as the
+// two mask indexes above) rather than an indexOf chain. Buildings map to their
+// generic-vocab slot + 1; settlements sit after the buildings; any enum value
+// not in the table (should never happen) falls back to 0, matching the old
+// indexOf's −1 + 1.
+const erectionIdMap = new Map<ErectionEnum, number>()
+BUILDINGS.forEach((b) => erectionIdMap.set(b, GENERIC_BUILDINGS.indexOf(genericBuildingKey(b)) + 1))
+SETTLEMENTS.forEach((s) =>
+  erectionIdMap.set(s, GENERIC_BUILDINGS.length + SETTLEMENT_TYPES.indexOf(settlementTypeKey(s)) + 1)
+)
+export const erectionId = (e: ErectionEnum): number => erectionIdMap.get(e) ?? 0
 
 // --- Dimensions -----------------------------------------------------------
 // Grid is anchored: a player's logical row 0 always lands at output row
@@ -140,6 +144,13 @@ const MAX_RONDEL_YIELD = 10 // armValues cap; normalizes yields into [0, 1]
 // Reserved capacity for every building/settlement-vocab feature, so new
 // expansion buildings never change FEATURE_LEN.
 const VOCAB_CAPACITY = 256
+
+// Reserved capacity for the config country one-hot. Only `ireland`/`france`
+// exist today, but more countries are a stated plan; reserving slots now (same
+// append-only idea as VOCAB_CAPACITY) means adding one never changes
+// FEATURE_LEN and strands trained weights. `featureSpec.vocab.countries` stays
+// the source of truth for which slot each live country id occupies.
+const COUNTRY_CAPACITY = 8
 
 const LAND_LEN = LANDS.length // 6
 const ERECT_ID_LEN = 1 // categorical
@@ -174,11 +185,16 @@ const SHARED_LEN =
   1 + // wonders remaining
   MAX_PLAYERS + // config.players one-hot
   LENGTHS.length + // config.length one-hot
-  COUNTRIES.length // config.country one-hot
+  COUNTRY_CAPACITY // config.country one-hot (reserved capacity for future countries)
 
 export const FEATURE_LEN = MAX_PLAYERS * PLAYER_BLOCK + FRAME_LEN + SHARED_LEN
 
 export type FeatureSpec = {
+  // Bumped whenever the layout changes shape; guards every downstream artifact
+  // (shard meta, ckpt, spec.json, ONNX evaluator) — see docs/trainer/schemas.md.
+  // v1 was the 14,670-float layout; v2 widens the country one-hot to
+  // COUNTRY_CAPACITY (14,676), the last free FEATURE_LEN change before weights ship.
+  version: number
   featureLen: number
   height: number
   width: number
@@ -222,6 +238,7 @@ export type FeatureSpec = {
 }
 
 export const featureSpec: FeatureSpec = {
+  version: 2,
   featureLen: FEATURE_LEN,
   height: H,
   width: W,
@@ -387,20 +404,34 @@ const writeShared = (w: Writer, state: GameState): void => {
   w.put(state.wonders!)
   w.hot(MAX_PLAYERS, config.players - 1)
   w.hot(LENGTHS.length, LENGTHS.indexOf(config.length))
-  w.hot(COUNTRIES.length, COUNTRIES.indexOf(config.country))
+  w.hot(COUNTRY_CAPACITY, COUNTRIES.indexOf(config.country))
 }
 
-export const encode = (state: GameState, perspective?: number): Float32Array => {
-  const buf = new Float32Array(FEATURE_LEN)
-  if (state.status === GameStatusEnum.SETUP) return buf
+// Encode straight into a caller-supplied buffer at `offset`, writing exactly
+// FEATURE_LEN floats in [offset, offset + FEATURE_LEN). Lets the shard exporter
+// pack many states into one big buffer without a per-state allocation.
+export const encodeInto = (state: GameState, perspective: number | undefined, out: Float32Array, offset = 0): void => {
+  if (out.length < offset + FEATURE_LEN)
+    throw new RangeError(`encodeInto: buffer too small (need ${offset + FEATURE_LEN}, have ${out.length})`)
+  // The Writer only ever sets 1s (one-hots/masks) and explicit puts; skipped
+  // player blocks and one-hot gaps rely on zeroed memory, so a reused scratch
+  // buffer must be cleared or stale values leak through.
+  out.fill(0, offset, offset + FEATURE_LEN)
+  if (state.status === GameStatusEnum.SETUP) return
   const p = perspective ?? state.frame!.currentPlayerIndex
   const order = rotateOrder(state.players!.length, p)
-  const w = new Writer(buf)
+  const w = new Writer(out)
+  w.pos = offset
   order.forEach((idx, slot) => {
     if (idx === undefined) w.skip(PLAYER_BLOCK)
     else writeTableau(w, state.players![idx], slot === 0, state.config!)
   })
   writeFrame(w, state.frame!, order)
   writeShared(w, state)
+}
+
+export const encode = (state: GameState, perspective?: number): Float32Array => {
+  const buf = new Float32Array(FEATURE_LEN)
+  encodeInto(state, perspective, buf)
   return buf
 }

--- a/game/src/index.ts
+++ b/game/src/index.ts
@@ -1,16 +1,19 @@
 export { reducer } from './reducer'
-export { control } from './control'
+export { control, completions, scores } from './control'
 export { initialState } from './state'
-export { encode, featureSpec, FEATURE_LEN } from './encode'
+export { encode, encodeInto, erectionId, featureSpec, FEATURE_LEN } from './encode'
 export type { FeatureSpec } from './encode'
+export { parseResourceParam } from './board/resource'
 
 // runtime enums (values), needed by consumers that branch on game state
 export { GameStatusEnum } from './types'
 export { GameCommandEnum } from './types'
 export { PlayerColor } from './types'
+export { ResourceEnum } from './types'
 
 export type { Controls } from './types'
 export type { Score } from './types'
+export type { Cost } from './types'
 export type { GameConfigPlayers } from './types'
 export type { GameConfigLength } from './types'
 export type { GameConfigCountry } from './types'


### PR DESCRIPTION
Project **07 — Engine fast paths** from the offline-trainer plan (`docs/trainer/07-engine-fast-paths.md`, milestone M1). Splits the per-simulation hot paths out of `control()`/`encode()` so the agent stops paying for work it discards, and reserves the last free `FEATURE_LEN` change before any trained weights exist.

## What changed (all in `game/`, additive except the `FEATURE_LEN` bump)

- **`completions(state, partial)`** and **`scores(state)`** are extracted from `control()`, which is now *defined* in terms of them — no behavior change, parity is structural. Move enumeration can call `completions()` without recomputing `flow` + `score` on every DFS node; engine scoring can call `scores()` without a full top-level completion enumeration.
- **`encodeInto(state, perspective, out, offset?)`** writes straight into a caller-supplied buffer (throws `RangeError` if too small; clears its `[offset, offset+FEATURE_LEN)` window first, so a reused/NaN scratch buffer is safe). `encode()` is now a thin wrapper over it.
- **`erectionId()`** switched from `indexOf` chains to a precomputed `Map` (same pattern as the existing mask indexes). Output is identical for every enum value, including the unknown → `0` fallback. Now exported.
- **Country one-hot** widened to a reserved `COUNTRY_CAPACITY = 8` (`FEATURE_LEN` 14,670 → **14,676**), plus **`featureSpec.version = 2`**. Future countries never reshape the tensor again.
- **Additive exports** from the package: `completions`, `scores`, `encodeInto`, `erectionId`, `parseResourceParam`, and the `Cost` / `ResourceEnum` types.
- **Version bump** `0.21.2` → **`0.22.0`** (additive; `control()`/`encode()` outputs bit-identical apart from the country widening).

`control()` keeps its exact signature/output, so the web UI and MCP tools are untouched.

## Tests

New parity suite `game/src/__tests__/fastPaths.test.ts` replays a full 4-player France/long game and a solo game, and asserts:

- `completions(state, [])` ≡ `control(state, []).completion` and `scores(state)` ≡ `control(state, []).score` at every in-play state, plus a capped DFS over partials so command-specific arms are exercised;
- the `undefined`-head `FINISHED → []` short-circuit and the `.otherwise` (unknown command) arm;
- `encodeInto()` equals `encode()` byte-for-byte across every perspective, into fresh, NaN-poisoned, and offset buffers (window-only writes; `RangeError` on undersized buffers; SETUP zero-fill);
- `erectionId` matches the old `indexOf` implementation over every `BuildingEnum`/`SettlementEnum` value and the unknown fallback;
- `FEATURE_LEN === 14,676` and `featureSpec.version === 2`.

`pnpm --dir game test` → 1388 pass / 0 fail; `pnpm --dir game lint` and `build` clean.

## Docs

`docs/trainer/README.md` and `07-engine-fast-paths.md` mark project 07 done; `schemas.md` updated so 14,676 / v2 is the current encoder shape. Agent call-site migration (`moves.ts` → `completions`, `engine.ts` → `scores`) lands with projects 08/09 as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27)_