### PR TITLE
feat(web): render player landscape as an isometric SVG tile grid

### DIFF
--- a/web/src/components/player/iso/iso.module.css
+++ b/web/src/components/player/iso/iso.module.css
@@ -1,0 +1,27 @@
+.scroll {
+  overflow-x: auto;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:hover .top {
+  filter: brightness(1.06);
+}
+
+.pulse {
+  animation: pulse 1.3s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    stroke-opacity: 1;
+    fill-opacity: 0.35;
+  }
+  50% {
+    stroke-opacity: 0.4;
+    fill-opacity: 0.1;
+  }
+}

--- a/web/src/components/player/iso/isoLandscape.tsx
+++ b/web/src/components/player/iso/isoLandscape.tsx
@@ -1,0 +1,191 @@
+import { useInstanceContext } from '@/context/InstanceContext'
+import { head } from 'ramda'
+import { Tile } from 'hathora-et-labora-game'
+import { Clergy, ErectionEnum, LandEnum } from 'hathora-et-labora-game/dist/types'
+import { match } from 'ts-pattern'
+import { buildingName } from '@/components/buildingName'
+import { ErectionModal } from '@/components/erection/'
+import styles from './iso.module.css'
+import { HALF_H, HALF_W, TILE_H, diamond, groundTransform, tallDiamond, toScreen } from './projection'
+
+interface Props {
+  landscape: Tile[][]
+  offset: number
+  active: boolean
+}
+
+const landToColor = (land: LandEnum | undefined) =>
+  match(land)
+    .with(LandEnum.Hillside, () => '#ffffb3')
+    .with(LandEnum.Plains, () => '#ccebc5')
+    .with(LandEnum.Coast, () => '#ffffb3')
+    .with(LandEnum.Water, () => '#80b1d3')
+    .with(LandEnum.Mountain, () => '#d9d9d9')
+    .with(LandEnum.BelowMountain, () => '#d9d9d9')
+    .otherwise(() => '')
+
+const clergyFill = { R: '#fb8072', G: '#b3de69', B: '#80b1d3', W: '#d9d9d9' }
+const clergyStroke = { R: '#ad574d', G: '#87a74f', B: '#5f849e', W: '#b1b1b1' }
+const clergyColor = (id: Clergy): 'R' | 'G' | 'B' | 'W' => {
+  const c = id.substring(3)
+  return (['R', 'G', 'B', 'W'].includes(c) ? c : 'W') as 'R' | 'G' | 'B' | 'W'
+}
+
+// two lines fit on a tile; one word rarely needs wrapping
+const labelLines = (name: string): string[] => {
+  const words = name.split(' ')
+  if (words.length <= 1) return words
+  const mid = Math.ceil(words.length / 2)
+  return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')]
+}
+
+type CellInfo = {
+  row: number
+  col: number
+  land: LandEnum
+  building?: ErectionEnum
+  clergy?: Clergy
+  tall: boolean
+}
+
+const PAD = 6
+
+export const IsoLandscape = ({ landscape, offset, active }: Props) => {
+  const { controls, addPartial } = useInstanceContext()
+  const partial = controls?.partial ?? []
+  const command = head(partial) ?? ''
+  const completion = controls?.completion ?? []
+
+  const cells: CellInfo[] = []
+  landscape.forEach((tiles, rowIndex) =>
+    tiles.forEach((tile, colIndex) => {
+      if (tile.length === 0) return
+      const [land, building, clergy] = tile
+      // BelowMountain is covered by the two-row mountain face above it
+      if (land === undefined || land === LandEnum.BelowMountain) return
+      cells.push({ row: rowIndex, col: colIndex, land, building, clergy, tall: land === LandEnum.Mountain })
+    })
+  )
+  if (cells.length === 0) return null
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  cells.forEach(({ row, col, tall }) => {
+    const [x, y] = toScreen(col, row)
+    minX = Math.min(minX, x - HALF_W)
+    maxX = Math.max(maxX, x + (tall ? TILE_H + HALF_W : HALF_W))
+    minY = Math.min(minY, y)
+    maxY = Math.max(maxY, y + (tall ? TILE_H + HALF_H : TILE_H))
+  })
+  const width = maxX - minX + 2 * PAD
+  const height = maxY - minY + 2 * PAD
+
+  // matches the modal-trigger rule in the Erection card component: the modal
+  // stays up while the USE command still needs parameters
+  const commandComplete = completion.length === 1 && completion[0] === ''
+  const usedBuildings = cells
+    .map(({ building }) => building)
+    .filter((building) => building !== undefined)
+    .filter((building) => partial.slice(0, 2).join(' ') === `USE ${building}` && !commandComplete)
+
+  return (
+    <div className={styles.scroll}>
+      <svg
+        width={width}
+        height={height}
+        viewBox={`${minX - PAD} ${minY - PAD} ${width} ${height}`}
+        role="img"
+        aria-label="player landscape"
+      >
+        {cells.map(({ row, col, land, building, clergy, tall }) => {
+          const [x, y] = toScreen(col, row)
+          const rowId = row - offset
+          const key = `${col - 2} ${rowId}`
+          const selectable = (active && completion.includes(key)) || completion.includes(building as string)
+
+          const handleClick = () => {
+            if (completion.includes(key)) {
+              addPartial(`${key}`)
+            }
+            if (completion.includes(building as string)) {
+              addPartial(`${building}`)
+            }
+          }
+
+          const primary =
+            (command === 'FELL_TREES' && active && building === 'LFO') ||
+            (command === 'CUT_PEAT' && active && building === 'LMO') ||
+            (command === 'USE' && active && !['LFO', 'LMO'].includes(building as string)) ||
+            (command === 'WORK_CONTRACT' && !active && !['LFO', 'LMO'].includes(building as string)) ||
+            completion.includes(building as string)
+
+          const points = tall ? tallDiamond(x, y) : diamond(x, y)
+          // center of the face, where labels and markers sit
+          const cx = tall ? x + HALF_W / 2 : x
+          const cy = tall ? y + TILE_H * 0.75 : y + HALF_H
+          const name = building && (buildingName(building) ?? building)
+
+          return (
+            <g
+              key={`${rowId}:${col}`}
+              className={selectable ? styles.clickable : undefined}
+              onClick={selectable ? handleClick : undefined}
+            >
+              <title>{`${key} ${land}${building ? ` ${building}` : ''}`}</title>
+              <polygon className={styles.top} points={points} fill={landToColor(land)} stroke="#555" strokeWidth={1} />
+              {name && (
+                <text
+                  transform={groundTransform(cx, clergy ? cy - 8 : cy)}
+                  textAnchor="middle"
+                  fontSize={15}
+                  fontWeight={primary && selectable ? 700 : 400}
+                  fill="#333"
+                  stroke="#ffffff"
+                  strokeWidth={3}
+                  paintOrder="stroke"
+                >
+                  {labelLines(name).map((line, i, lines) => (
+                    <tspan key={line} x={0} y={(i - (lines.length - 1) / 2) * 16 + 5}>
+                      {line}
+                    </tspan>
+                  ))}
+                </text>
+              )}
+              {clergy && (
+                <g transform={groundTransform(cx, cy + 14)}>
+                  <circle
+                    r={10}
+                    fill={clergyFill[clergyColor(clergy)]}
+                    stroke={clergyStroke[clergyColor(clergy)]}
+                    strokeWidth={2}
+                  />
+                  {clergy.substring(0, 3) === 'PRI' && (
+                    <>
+                      <rect x={-5} y={-1.5} width={10} height={3} fill={clergyStroke[clergyColor(clergy)]} />
+                      <rect x={-1.5} y={-5} width={3} height={10} fill={clergyStroke[clergyColor(clergy)]} />
+                    </>
+                  )}
+                </g>
+              )}
+              {selectable && (
+                <polygon
+                  className={styles.pulse}
+                  points={points}
+                  fill="#ffd23f"
+                  fillOpacity={0.25}
+                  stroke="#e0a933"
+                  strokeWidth={3}
+                />
+              )}
+            </g>
+          )
+        })}
+      </svg>
+      {usedBuildings.map((building) => (
+        <ErectionModal key={building} id={building} />
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/player/iso/projection.ts
+++ b/web/src/components/player/iso/projection.ts
@@ -1,0 +1,29 @@
+// Dimetric 2:1 projection. Columns run toward the upper-right and rows toward
+// the lower-right, so the water/coast columns (low col) fall to the bottom-left
+// of the screen and the mountain columns (high col) to the top-right.
+export const TILE_W = 160
+export const TILE_H = 80
+export const HALF_W = TILE_W / 2
+export const HALF_H = TILE_H / 2
+
+// screen position of the top corner of the (col, row) diamond
+export const toScreen = (col: number, row: number): [number, number] => [(col + row) * HALF_W, (row - col) * HALF_H]
+
+// SVG points string for the face of a tile whose top corner is at (x, y)
+export const diamond = (x: number, y: number): string =>
+  [`${x},${y}`, `${x + HALF_W},${y + HALF_H}`, `${x},${y + TILE_H}`, `${x - HALF_W},${y + HALF_H}`].join(' ')
+
+// mountains occupy two grid rows; their face is the union of both diamonds
+export const tallDiamond = (x: number, y: number): string =>
+  [
+    `${x},${y}`,
+    `${x + HALF_W},${y + HALF_H}`,
+    `${x + TILE_W},${y + TILE_H}`,
+    `${x + HALF_W},${y + TILE_H + HALF_H}`,
+    `${x},${y + TILE_H}`,
+    `${x - HALF_W},${y + HALF_H}`,
+  ].join(' ')
+
+// lays flat content (text, markers) onto the ground plane: baseline climbs to
+// the upper-right at 30° and glyph verticals lean down-right to match
+export const groundTransform = (cx: number, cy: number): string => `translate(${cx} ${cy}) rotate(-30) skewX(30)`

--- a/web/src/components/player/playerLandscape.tsx
+++ b/web/src/components/player/playerLandscape.tsx
@@ -1,10 +1,5 @@
-import { useInstanceContext } from '@/context/InstanceContext'
-import { head } from 'ramda'
-import { Erection } from '../erection'
-import { Clergy } from '../clergy'
 import { Tile } from 'hathora-et-labora-game'
-import { LandEnum } from 'hathora-et-labora-game/dist/types'
-import { match } from 'ts-pattern'
+import { IsoLandscape } from './iso/isoLandscape'
 
 interface Props {
   landscape: Tile[][]
@@ -12,100 +7,6 @@ interface Props {
   active: boolean
 }
 
-const landToColor = (land: LandEnum | undefined) =>
-  match(land)
-    .with(LandEnum.Hillside, () => '#ffffb3')
-    .with(LandEnum.Plains, () => '#ccebc5')
-    .with(LandEnum.Coast, () => '#ffffb3')
-    .with(LandEnum.Water, () => '#80b1d3')
-    .with(LandEnum.Mountain, () => '#d9d9d9')
-    .with(LandEnum.BelowMountain, () => '#d9d9d9')
-    .otherwise(() => '')
-
-export const PlayerLandscape = ({ landscape, offset, active }: Props) => {
-  const { controls, addPartial } = useInstanceContext()
-  const partial = controls?.partial ?? []
-  const command = head(partial) ?? ''
-  const completion = controls?.completion ?? []
-
-  return (
-    <table style={{ borderCollapse: 'collapse' }}>
-      <tbody>
-        {landscape.map((row, rowIndex) => {
-          const rowId = rowIndex - offset
-          return (
-            <tr key={`${rowId}:${JSON.stringify(row)}`}>
-              {row.map((tile, colIndex) => {
-                if (tile.length === 0) return <td key={`${rowId}:${colIndex}`} />
-                const [land, building, clergy] = tile
-                const key = `${colIndex - 2} ${rowId}`
-                const selectable = (active && completion?.includes(key)) || completion?.includes(building as string)
-
-                const handleClick = () => {
-                  if (completion?.includes(key)) {
-                    addPartial(`${key}`)
-                  }
-                  if (completion?.includes(building as string)) {
-                    addPartial(`${building}`)
-                  }
-                }
-
-                const primary =
-                  (command === 'FELL_TREES' && active && building === 'LFO') ||
-                  (command === 'CUT_PEAT' && active && building === 'LMO') ||
-                  (command === 'USE' && active && !['LFO', 'LMO'].includes(building as string)) ||
-                  (command === 'WORK_CONTRACT' && !active && !['LFO', 'LMO'].includes(building as string)) ||
-                  completion?.includes(building as string)
-
-                if (land === '.') return null
-                return (
-                  <td
-                    style={{
-                      border: 1,
-                      height: 205,
-                      borderStyle: 'solid',
-                      borderColor: '#555',
-                      textAlign: 'center',
-                      backgroundColor: landToColor(land),
-                    }}
-                    key={`${rowId}:${colIndex}`}
-                    rowSpan={land === 'M' ? 2 : 1}
-                  >
-                    {building && (
-                      <Erection
-                        primary={primary || (active && completion.includes(key))}
-                        key={building}
-                        id={building}
-                        disabled={!selectable}
-                        onClick={handleClick}
-                      />
-                    )}
-                    <div
-                      style={{
-                        width: 137,
-                      }}
-                    ></div>
-                    {!building && selectable && (
-                      <>
-                        <br />
-                        <button type="button" onClick={handleClick} className={`primary`}>
-                          {land}
-                        </button>
-                      </>
-                    )}
-                    {clergy && (
-                      <>
-                        <br />
-                        <Clergy id={clergy} />
-                      </>
-                    )}
-                  </td>
-                )
-              })}
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-  )
-}
+export const PlayerLandscape = ({ landscape, offset, active }: Props) => (
+  <IsoLandscape landscape={landscape} offset={offset} active={active} />
+)


### PR DESCRIPTION
## What

Replaces the HTML `<table>` in `PlayerLandscape` with an isometric (dimetric 2:1) SVG tile grid:

- **Orientation**: columns run toward the upper-right and rows toward the lower-right, so the mountain columns land at the top-right of the screen and the water/coast columns at the bottom-left.
- **Tiles**: flat SVG diamonds filled with the existing terrain palette. Mountains keep their two-row footprint and render as a single double-length face over the `BelowMountain` cell.
- **Artwork placeholder**: building names are plain text labels laid onto the ground plane — `rotate(-30) skewX(30)` so the baseline climbs up-to-the-right at 30° and glyphs lean with the ground perspective. Real art (pixel-art style) can replace these later without touching the interaction layer.
- **Clergy**: rendered as small ground-plane disks in the player color (priors get a plus mark).

## Interaction preserved

All completion-driven behavior from the table version carries over:

- Tiles/buildings in `controls.completion` are clickable (gold pulsing highlight) and dispatch the same `addPartial` coordinate (`"col row"`) or building id.
- `FELL_TREES` / `CUT_PEAT` / `USE` / `WORK_CONTRACT` primary highlighting logic is unchanged.
- The USE-command parameter modal (`ErectionModal`) still opens while a `USE <building>` command is awaiting parameters.

## Preview

Server-rendered sample (heartland + coast plot + mountain plot, red player):

water/coast at bottom-left, two-row mountain at top-right, skewed labels on each occupied tile.

## Verification

- `tsc --noEmit` clean, `next build` succeeds (with dummy Supabase env), `pnpm test` 17/17 pass.
- Rendered via a `react-dom/server` harness and screenshotted in Chromium to confirm geometry, labels, and clergy markers.

## Notes

- `TinyLandscape` (used by the buy-plot/district modals) is still a table; converting it can follow.
- `next lint` is currently broken repo-wide on Next 16 (`Invalid project directory ... web/lint`), unrelated to this change; lint-staged eslint passed on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H4vW2UHisesvKsiv482A9

---
_Generated by [Claude Code](https://claude.ai/code/session_019H4vW2UHisesvKsiv482A9)_