### PR TITLE
feat(web): convert TinyLandscape to the isometric SVG view

### DIFF
--- a/web/src/components/sliders/tinyLandscape.tsx
+++ b/web/src/components/sliders/tinyLandscape.tsx
@@ -1,10 +1,11 @@
 import { useInstanceContext } from '@/context/InstanceContext'
 import { Tile } from 'hathora-et-labora-game'
 import { LandEnum } from 'hathora-et-labora-game/dist/types'
-import { includes, map, range } from 'ramda'
+import { map, range } from 'ramda'
 import { match } from 'ts-pattern'
-import { ItemList } from '../itemList'
 import { MoveHorizontal } from 'lucide-react'
+import styles from '../player/iso/iso.module.css'
+import { HALF_H, HALF_W, TILE_H, TILE_W, diamond, tallDiamond, toScreen } from '../player/iso/projection'
 
 interface Props {
   landscape: Tile[][]
@@ -24,15 +25,26 @@ const landToColor = (land: LandEnum | undefined) =>
     .with(LandEnum.BelowMountain, () => '#d9d9d9')
     .otherwise(() => '')
 
-type ThisRowButtonProps = {
-  onClick: () => void
+// same projection as the player landscape, rendered at 40%
+const SCALE = 0.4
+const PAD = 8
+
+// rows outside the current landscape are sketched as a ghost heartland strip
+const GHOST_COLS = range(2, 7)
+
+type CellInfo = {
+  col: number
+  land?: LandEnum
+  building?: string
+  tall: boolean
+  ghost: boolean
 }
-const ThisRowButton = ({ onClick }: ThisRowButtonProps) => {
-  return (
-    <button className="primary" onClick={onClick}>
-      <MoveHorizontal size={16} />
-    </button>
-  )
+
+type RowInfo = {
+  rowIndex: number
+  rowId: number
+  selectable: boolean
+  cells: CellInfo[]
 }
 
 export const TinyLandscape = ({ landscape, offset = 0, rowMin, rowMax, showTerrain = false }: Props) => {
@@ -48,77 +60,116 @@ export const TinyLandscape = ({ landscape, offset = 0, rowMin, rowMax, showTerra
     (rowMax ?? Math.max(...map((s: string) => Number.parseInt(s, 10), completions)) + offset) + 1
   )
 
+  const rows: RowInfo[] = rowsCovered.map((rowIndex) => {
+    const row = landscape[rowIndex] as Tile[] | undefined
+    const rowId = rowIndex - offset
+    const selectable = completions.includes(`${rowId}`)
+    const cells: CellInfo[] =
+      row === undefined || row.every((tile) => tile.length === 0)
+        ? GHOST_COLS.map((col) => ({ col, tall: false, ghost: true }))
+        : row.flatMap((tile, col) => {
+            if (tile.length === 0) return []
+            const [land, building] = tile
+            // BelowMountain is covered by the two-row mountain face above it
+            if (land === undefined || land === LandEnum.BelowMountain) return []
+            return [{ col, land, building, tall: land === LandEnum.Mountain, ghost: false }]
+          })
+    return { rowIndex, rowId, selectable, cells }
+  })
+  if (rows.every(({ cells }) => cells.length === 0)) return null
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  rows.forEach(({ rowIndex, selectable, cells }) => {
+    cells.forEach(({ col, tall }) => {
+      const [x, y] = toScreen(col, rowIndex)
+      minX = Math.min(minX, x - HALF_W)
+      maxX = Math.max(maxX, x + (tall ? TILE_H + HALF_W : HALF_W))
+      minY = Math.min(minY, y)
+      maxY = Math.max(maxY, y + (tall ? TILE_H + HALF_H : TILE_H))
+    })
+    if (selectable && cells.length > 0) {
+      // leave room for the row button past the last tile
+      const lastCol = Math.max(...cells.map(({ col }) => col))
+      const [bx, by] = toScreen(lastCol + 1, rowIndex)
+      maxX = Math.max(maxX, bx + HALF_W)
+      minY = Math.min(minY, by)
+      maxY = Math.max(maxY, by + TILE_H)
+    }
+  })
+  const width = maxX - minX + 2 * PAD
+  const height = maxY - minY + 2 * PAD
+
   return (
-    <table style={{ borderCollapse: 'collapse' }}>
-      <tbody>
-        {map((rowIndex) => {
-          const row = landscape[rowIndex]
-          const rowId = rowIndex - offset
-          return match<Tile[] | undefined>(row)
-            .with(undefined, () => (
-              <tr key={`${rowId}:${JSON.stringify(row)}`}>
-                <td colSpan={4} />
-                <td
-                  style={{
-                    width: 50,
-                    height: 50,
-                  }}
-                >
-                  {includes(`${rowId}`, completions) && ( //
-                    <ThisRowButton onClick={handleClick(`${rowId}`)} />
+    <svg
+      width={width * SCALE}
+      height={height * SCALE}
+      viewBox={`${minX - PAD} ${minY - PAD} ${width} ${height}`}
+      role="img"
+      aria-label="landscape rows"
+    >
+      {rows.map(({ rowIndex, rowId, selectable, cells }) => {
+        const lastCol = Math.max(...cells.map(({ col }) => col))
+        const [bx, by] = toScreen(lastCol + 1, rowIndex)
+        return (
+          <g
+            key={rowId}
+            className={selectable ? styles.clickable : undefined}
+            onClick={selectable ? handleClick(`${rowId}`) : undefined}
+          >
+            {cells.map(({ col, land, building, tall, ghost }) => {
+              const [x, y] = toScreen(col, rowIndex)
+              const points = tall ? tallDiamond(x, y) : diamond(x, y)
+              const cx = tall ? x + HALF_W / 2 : x
+              const cy = tall ? y + TILE_H * 0.75 : y + HALF_H
+              return (
+                <g key={`${rowId}:${col}`}>
+                  {ghost ? (
+                    <polygon points={points} fill="#f4f4f4" stroke="#999" strokeWidth={2} strokeDasharray="8 6" />
+                  ) : (
+                    <polygon
+                      className={styles.top}
+                      points={points}
+                      fill={landToColor(land)}
+                      stroke="#555"
+                      strokeWidth={1}
+                    />
                   )}
-                </td>
-              </tr>
-            ))
-            .otherwise(() => (
-              <tr key={`${rowId}:${JSON.stringify(row)}`}>
-                {row.map((tile, colIndex) => {
-                  const [land, building] = tile
-
-                  // so long as the mountain is always at the end
-                  // and a '.' is under it, this will work
-                  if (land === '.') return
-                  const rowSpan = land === 'M' ? 2 : 1
-
-                  return (
-                    <td
-                      style={{
-                        border: tile.length !== 0 ? 1 : 0,
-                        borderStyle: 'solid',
-                        borderColor: '#555',
-                        textAlign: 'center',
-                        backgroundColor: landToColor(land),
-                      }}
-                      key={`${rowId}:${colIndex}`}
-                      rowSpan={rowSpan}
-                    >
-                      <div
-                        style={{
-                          width: 60,
-                          height: 60,
-                        }}
-                      >
-                        {showTerrain && building === 'LMO' && (
-                          <div style={{ padding: 11 }}>
-                            <ItemList items="Pt" />
-                          </div>
-                        )}
-                        {showTerrain && building === 'LFO' && (
-                          <div style={{ padding: 11 }}>
-                            <ItemList items="Wo" />
-                          </div>
-                        )}
-                        {colIndex === 4 && completions.includes(`${rowId}`) && (
-                          <ThisRowButton onClick={handleClick(`${rowId}`)} />
-                        )}
-                      </div>
-                    </td>
-                  )
-                })}
-              </tr>
-            ))
-        }, rowsCovered)}
-      </tbody>
-    </table>
+                  {showTerrain && ['LMO', 'LFO'].includes(building as string) && (
+                    <image
+                      href={`https://hathora-et-labora.s3-us-west-2.amazonaws.com/${building === 'LMO' ? 'Pt' : 'Wo'}.jpg`}
+                      x={cx - 22}
+                      y={cy - 22}
+                      width={44}
+                      height={44}
+                    />
+                  )}
+                  {selectable && (
+                    <polygon
+                      className={styles.pulse}
+                      points={points}
+                      fill="#ffd23f"
+                      fillOpacity={0.15}
+                      stroke="#e0a933"
+                      strokeWidth={3}
+                    />
+                  )}
+                </g>
+              )
+            })}
+            {selectable && (
+              <g>
+                <circle cx={bx} cy={by + HALF_H} r={30} fill="#007AFF" />
+                <g transform={`translate(${bx - 20}, ${by + HALF_H - 20})`}>
+                  <MoveHorizontal size={40} color="#ffffff" />
+                </g>
+              </g>
+            )}
+          </g>
+        )
+      })}
+    </svg>
   )
 }


### PR DESCRIPTION
## What

Follow-up to #1872: the buy-plot / buy-district row picker and the static plot/district previews (`TinyLandscape`) now use the same isometric projection as the player landscape, so the modals match the board.

- Reuses `projection.ts` (2:1 dimetric, mountains up-right / water down-left) rendered at 40% scale via the SVG `viewBox`.
- **Row picker**: every selectable row is clickable across the whole row (gold pulsing highlight) and shows a `MoveHorizontal` button drawn in SVG at the row's end; clicking dispatches the same `addPartial(rowId)` as before.
- **Ghost rows**: rows outside the current landscape — or rows padded with all-empty tiles after an expansion — render as a dashed ghost heartland strip (cols 2–6) so "add a district above/below" has a visible target. The old table showed only a floating button.
- **Previews**: coast/mountain plots keep their two-row shape (the mountain renders as the two-row tall face); `showTerrain` draws the peat/wood token images from S3 on moor/forest tiles, replacing the HTML `ItemList` overlay.

## Verification

- `tsc --noEmit` clean, `next build` succeeds (dummy Supabase env), `pnpm test` 17/17.
- Server-rendered all four usages (row picker with ghost rows + selectable highlights, coast plot, mountain plot, district with `showTerrain`) via a `react-dom/server` harness with a mocked instance context, and screenshotted in Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H4vW2UHisesvKsiv482A9

---
_Generated by [Claude Code](https://claude.ai/code/session_019H4vW2UHisesvKsiv482A9)_