### PR TITLE
Fix isometric ground transform angle to match tile slope

### DIFF
--- a/web/src/components/player/iso/projection.ts
+++ b/web/src/components/player/iso/projection.ts
@@ -24,6 +24,16 @@ export const tallDiamond = (x: number, y: number): string =>
     `${x - HALF_W},${y + HALF_H}`,
   ].join(' ')
 
-// lays flat content (text, markers) onto the ground plane: baseline climbs to
-// the upper-right at 30° and glyph verticals lean down-right to match
-export const groundTransform = (cx: number, cy: number): string => `translate(${cx} ${cy}) rotate(-30) skewX(30)`
+// unit vectors along the diamond's own edges (the col axis climbs to the
+// upper-right, the row axis descends to the lower-right), so flat content
+// mapped through these lies exactly parallel to the tile's actual 2:1 slope
+// (atan(HALF_H / HALF_W) ≈ 26.565°) rather than a generic 30°
+const GROUND_LEN = Math.hypot(HALF_W, HALF_H)
+const GROUND_UX = HALF_W / GROUND_LEN
+const GROUND_UY = -HALF_H / GROUND_LEN
+const GROUND_VX = HALF_W / GROUND_LEN
+const GROUND_VY = HALF_H / GROUND_LEN
+
+// lays flat content (text, markers, card art) onto the ground plane
+export const groundTransform = (cx: number, cy: number): string =>
+  `matrix(${GROUND_UX} ${GROUND_UY} ${GROUND_VX} ${GROUND_VY} ${cx} ${cy})`


### PR DESCRIPTION
## Summary

Follow-up to #1874. After that PR merged, the building card art looked visibly tilted relative to the landscape's diamond grid lines.

- `groundTransform` (the SVG transform that lays flat content — text, clergy markers, and now card art — onto a tile's ground plane) used a hardcoded `rotate(-30) skewX(30)`.
- The board's diamond tiles are a 2:1 dimetric grid (`TILE_W=160`, `TILE_H=80`), whose edges actually sit at `atan(0.5) ≈ 26.565°` — vertex angles of 126.87°/53.13°, not the 120°/60° a true 30°-edge isometric grid would have.
- That ~3.4° mismatch was subtle for a small centered text label but became obvious once a full rectangular card image was skewed onto the tile, since its edges no longer ran parallel to the diamond's grid lines.
- `groundTransform` now derives its transform directly from the tile's own edge vectors (`HALF_W`, `±HALF_H`), so text, markers, and card art always align exactly with the diamond regardless of the tile ratio.

## Test plan

- [x] `tsc --noEmit` passes for the web project
- [x] `eslint` passes on the changed file
- [x] Verified locally (SVG mockup with real card art) that card edges now run parallel to the diamond's grid lines, correcting the previously visible ~3.4° tilt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GndQovvpTLx6tAbrfpSPpz)_