### PR TITLE
docs(trainer): reconcile M7–M9 docs (25–28) with the shipped adapter and schemas

### DIFF
--- a/docs/trainer/25-rocm-runbook.md
+++ b/docs/trainer/25-rocm-runbook.md
@@ -31,8 +31,11 @@ alternate.
    repurposed from Windows), stock kernel. Note the kernel version
    (`uname -r`) in this doc once installed — ROCm's dkms module is
    kernel-sensitive.
-2. **ROCm 6.x** via the `amdgpu-install` bootstrap (verify the latest 6.x
-   point release and exact URL against the ROCm install docs first):
+2. **ROCm 6.x** via the `amdgpu-install` bootstrap (verify the latest
+   point release and exact URL against the ROCm install docs first — this
+   doc was written against the 6.x era; if a newer major series is current
+   at install time the procedure is identical, but re-verify the gfx1101
+   and Ubuntu support matrix and the torch wheel index for it):
 
    ```sh
    wget https://repo.radeon.com/amdgpu-install/<6.x.y>/ubuntu/noble/amdgpu-install_<...>_all.deb

--- a/docs/trainer/28-second-game-onboarding.md
+++ b/docs/trainer/28-second-game-onboarding.md
@@ -4,8 +4,8 @@
 | --- | --- |
 | Status | planned |
 | Package | `agent/` + the new game's engine package |
-| Depends on | [09](09-game-adapter.md)–[22](22-arena-gating.md) |
-| Milestone | M9 (new) |
+| Depends on | [09](09-game-adapter.md)–[24](24-smoke-e2e.md) |
+| Milestone | M9 |
 
 ## Goal
 
@@ -55,7 +55,10 @@ thresholds in adapter config, the binary rate stays the reported metric).
 
 Implement `agent/src/game/<game>.ts` item by item, each with its OeL lesson:
 
-- `name`, `initial(cfg, seed)` — replay the opening; a bad opening throws.
+- `name`, `opening(cfg, seed)`, `initial(cfg, seed)` — `initial` replays the
+  opening; a bad opening throws. `opening` is a separate method so a generic
+  harness can log a fully replayable command list (JSONL v2 lines start with
+  the opening — schemas.md §2).
 - `apply` — reducer + throw→`undefined`; never partially mutates.
 - `isTerminal` / `playerToMove` / `numPlayers` — trivial delegations, but
   `playerToMove` must be right during sub-turns (see above).
@@ -68,9 +71,10 @@ Implement `agent/src/game/<game>.ts` item by item, each with its OeL lesson:
   policy mass and wastes curation budget. Write the game's `canonicalize` +
   in-DFS seen-set first; prove it with the never-merge-distinct-states
   property over a state corpus.
-- `moveKey(move)` — canonical serialization that **round-trips**
-  (`parseMoveKey(moveKey(m))` reapplies identically) and contains **no
-  whitespace inside a token**, so join-with-space/`split(' ')` is unambiguous.
+- `moveKey(move)` — canonical serialization that **round-trips** (re-parsing
+  `moveKey(m)` — for token-list games just `key.split(' ')` — yields a move
+  that reapplies identically) and contains **no whitespace inside a token**,
+  so join-with-space/`split(' ')` is unambiguous.
   This key is the JSONL v2 and shard identity
   ([14](14-selfplay-v2.md)/[16](16-shard-exporter.md)).
 - `sampleMove(state, rng)` — **cheap**: a random completion walk or

--- a/docs/trainer/schemas.md
+++ b/docs/trainer/schemas.md
@@ -6,11 +6,10 @@ about a shape, this doc wins.** Each contract: who writes / who reads / what
 version-bumps it, a typed definition, then validator invariants.
 
 Corrections canonicalized here (see "Change procedure" for how to evolve):
-`moveFeatureLen` is **91** (doc 11; doc 16's "≈90" and doc 20's `[131, 90]`
-example are stale); the Dirichlet config key is **`alphaScale`** (docs 13/14;
-the `"alpha": 0.5` in docs 24/26 example configs should read
-`"alphaScale": 10`); `STATE` is written **only by the orchestrator** (doc 23;
-stage docs saying "STATE → x" mean "the orchestrator advances STATE after me").
+`moveFeatureLen` is **91** and the Dirichlet config key is **`alphaScale`**
+(docs 11/13/14; the project docs' examples now match); `STATE` is written
+**only by the orchestrator** (doc 23; stage docs saying "STATE → x" mean
+"the orchestrator advances STATE after me").
 
 ---
 
@@ -43,7 +42,7 @@ type RunConfig = {
     gen0: { evaluator: 'rollout'; sims: number; rolloutDepth: number } // used until first promotion
     baseSeed: number                             // game seed = baseSeed + gameIndex (default gen * 1_000_000)
   }
-  solo: { target: number; scale: number }        // value mapping σ((score − target)/scale); defaults { target: 500, scale: 100 }
+  solo?: { target: number; scale: number }       // value mapping σ((score − target)/scale); default { target: 500, scale: 100 } — docs 24/26's example configs omit it
   train: {
     device: 'auto'|'cpu'|'cuda'
     window: number                               // K generations of shards (doc 19: 5)


### PR DESCRIPTION
Audit of the M7–M9 design docs (projects 25–28) against the current codebase. All repo references those docs make were verified — `append_command(p_instance_id, p_expected_count, p_command)`, the `instance:<id>` broadcast trigger, `web/src/mcp/tools/makeMove.ts`, `maxDuration = 60`, and the arena CLI's `[games] [short|long] [policyA] [policyB]` shape all check out. What follows fixes the places that drifted:

**28 — second-game onboarding**
- Depends-on range said 09–22, but the README's project table says 09–24 and the doc's own acceptance ladder uses 08's benchmark harness and 24's smoke loop. Now 09–24.
- The adapter checklist predated project 09's merge and omitted `opening(cfg, seed)`, which the shipped `GameAdapter` requires (it's how a generic harness logs replayable JSONL). A second-game implementer following the checklist would have missed a required method.
- The `moveKey` round-trip was phrased via `parseMoveKey(...)`, a function no contract defines; now phrased in terms of schemas.md §2's split-on-space grammar.
- Dropped the stale "(new)" milestone tag.

**schemas.md**
- The "corrections canonicalized here" note claimed docs 16/20/24/26 still carried stale values (`≈90`, `[131, 90]`, `"alpha": 0.5`) — all four docs already read the corrected values, so the note now says so instead of instructing a fix that's already landed.
- `config.json`'s `solo` block is now marked optional with its stated defaults, matching the "in full" example configs in docs 24/26, which omit it. (schemas.md wins on conflicts, so this is the one-place fix rather than editing both examples.)

**25 — ROCm runbook**
- The runbook pins "latest 6.x"; added a note that a newer major series current at install time follows the same procedure with the gfx1101/Ubuntu support matrix and torch wheel index re-verified — consistent with the doc's own verify-on-the-box philosophy.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM5LmrN1erST5718MC1af3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM5LmrN1erST5718MC1af3)_