### PR TITLE
refactor(agent): use pcg's PCG32 generator, not mulberry32

### DIFF
--- a/agent/src/__tests__/arena.test.ts
+++ b/agent/src/__tests__/arena.test.ts
@@ -4,11 +4,11 @@ import { playGame, runMatch, CONFIG_2P_SHORT } from '../arena'
 import { oel } from '../game/oel'
 import { randomPolicy } from '../policies/random'
 import { greedyPolicy } from '../policies/greedy'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 
 describe('arena + baselines', () => {
   it('plays a full random-vs-random game and reports a result', async () => {
-    const res = await playGame(oel, [randomPolicy(oel), randomPolicy(oel)], CONFIG_2P_SHORT, 5, mulberry32(5))
+    const res = await playGame(oel, [randomPolicy(oel), randomPolicy(oel)], CONFIG_2P_SHORT, 5, pcg32(5))
     assert.equal(res.totals.length, 2)
     assert.equal(res.outcome.length, 2)
     assert.ok(res.steps > 10)

--- a/agent/src/__tests__/golden.test.ts
+++ b/agent/src/__tests__/golden.test.ts
@@ -4,36 +4,33 @@ import { playGame, CONFIG_2P_SHORT } from '../arena'
 import { selfPlayGame } from '../selfplay'
 import { oel } from '../game/oel'
 import { randomPolicy } from '../policies/random'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 
-// Golden regression for the project-09 game-agnostic refactor (threading a
-// GameAdapter through search/arena/selfplay + making Policy.pick async). These
-// hashes were captured from the pre-refactor synchronous code; awaiting
-// already-resolved promises reorders no rng draws, so the same seeds must still
-// produce the same command lists. (djb2 over the JSON of the command list.)
-//
-// Captured in isolation but verified stable under heavy prior apply/enumerate
-// work, so test order in the shared runner does not perturb them.
+// Golden regression: seeded games are fully deterministic. These djb2 hashes of
+// the command lists are pinned so any accidental change to the rng (pcg32),
+// move ordering, or the game loop is caught. Captured in isolation but verified
+// stable under heavy prior apply/enumerate work, so shared-runner test order
+// does not perturb them.
 const djb2 = (s: string): number => {
   let h = 5381
   for (let i = 0; i < s.length; i++) h = ((h * 33) ^ s.charCodeAt(i)) >>> 0
   return h
 }
-const rng = (seed: number) => mulberry32(seed * 7919 + 1)
+const rng = (seed: number) => pcg32(seed * 7919 + 1)
 const randoms = () => [randomPolicy(oel), randomPolicy(oel)]
 
-describe('golden: seeded behavior survives the adapter/async refactor', () => {
-  it('random-vs-random 2p short games are unchanged (seeds 1, 2)', async () => {
+describe('golden: seeded games are deterministic (pcg32 rng)', () => {
+  it('random-vs-random 2p short games (seeds 1, 2)', async () => {
     const g1 = await playGame(oel, randoms(), CONFIG_2P_SHORT, 1, rng(1))
-    assert.equal(g1.commands.length, 759)
-    assert.equal(djb2(JSON.stringify(g1.commands)), 3387465242)
+    assert.equal(g1.commands.length, 644)
+    assert.equal(djb2(JSON.stringify(g1.commands)), 1889008079)
 
     const g2 = await playGame(oel, randoms(), CONFIG_2P_SHORT, 2, rng(2))
-    assert.equal(g2.commands.length, 446)
-    assert.equal(djb2(JSON.stringify(g2.commands)), 1563751463)
+    assert.equal(g2.commands.length, 613)
+    assert.equal(djb2(JSON.stringify(g2.commands)), 3891132861)
   })
 
-  it('a bounded self-play game is unchanged (seed 3, sims 8, 20 steps)', async () => {
+  it('a bounded self-play game (seed 3, sims 8, 20 steps)', async () => {
     const sp = await selfPlayGame(oel, CONFIG_2P_SHORT, 3, rng(3), { sims: 8 }, 20)
     assert.equal(sp.commands.length, 22)
     assert.equal(sp.decisions.length, 20)

--- a/agent/src/__tests__/mcts.test.ts
+++ b/agent/src/__tests__/mcts.test.ts
@@ -5,7 +5,7 @@ import type { Move } from '../engine'
 import { search } from '../mcts/search'
 import { mctsPolicy } from '../policies/mcts'
 import { oel } from '../game/oel'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 
 const OPENING: Move[] = [
   ['CONFIG', '2', 'france', 'long'],
@@ -15,7 +15,7 @@ const OPENING: Move[] = [
 describe('mcts', () => {
   it('search returns a legal best move and a visit distribution', () => {
     const s = replay(OPENING)!
-    const r = search(oel, s, mulberry32(1), { sims: 24, rolloutDepth: 10 })
+    const r = search(oel, s, pcg32(1), { sims: 24, rolloutDepth: 10 })
     assert.ok(r.best)
     assert.notEqual(apply(s, r.best!), undefined)
     const totalVisits = r.visits.reduce((a, v) => a + v.n, 0)
@@ -25,14 +25,14 @@ describe('mcts', () => {
 
   it('is deterministic for a fixed seed', () => {
     const s = replay(OPENING)!
-    const a = search(oel, s, mulberry32(9), { sims: 24, rolloutDepth: 10 }).best
-    const b = search(oel, s, mulberry32(9), { sims: 24, rolloutDepth: 10 }).best
+    const a = search(oel, s, pcg32(9), { sims: 24, rolloutDepth: 10 }).best
+    const b = search(oel, s, pcg32(9), { sims: 24, rolloutDepth: 10 }).best
     assert.deepEqual(a, b)
   })
 
   it('mctsPolicy returns a legal move', async () => {
     const s = replay(OPENING)!
-    const m = await mctsPolicy(oel, { sims: 16, rolloutDepth: 8 }).pick(s, mulberry32(2))
+    const m = await mctsPolicy(oel, { sims: 16, rolloutDepth: 8 }).pick(s, pcg32(2))
     assert.ok(m)
     assert.notEqual(apply(s, m!), undefined)
   })

--- a/agent/src/__tests__/moves.test.ts
+++ b/agent/src/__tests__/moves.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { replay, apply } from '../engine'
 import type { Move } from '../engine'
 import { enumerateMoves, enumerateMovesInfo, sampleMove } from '../moves'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 
 const OPENING: Move[] = [
   ['CONFIG', '2', 'france', 'long'],
@@ -38,8 +38,8 @@ describe('move generation', () => {
 
   it('sampleMove returns a legal move and is deterministic for a fixed seed', () => {
     const s = replay(OPENING)!
-    const a = sampleMove(s, mulberry32(123))
-    const b = sampleMove(s, mulberry32(123))
+    const a = sampleMove(s, pcg32(123))
+    const b = sampleMove(s, pcg32(123))
     assert.ok(a)
     assert.notEqual(apply(s, a!), undefined)
     assert.deepEqual(a, b) // same seed → same move
@@ -47,7 +47,7 @@ describe('move generation', () => {
 
   it('sampleMove can drive a full game to a terminal state', () => {
     let s = replay(OPENING)!
-    const rng = mulberry32(7)
+    const rng = pcg32(7)
     let steps = 0
     while (s.status === 'PLAYING' && steps < 5000) {
       const m = sampleMove(s, rng)

--- a/agent/src/arena.ts
+++ b/agent/src/arena.ts
@@ -5,7 +5,7 @@
 import { sum } from 'ramda'
 import type { GameAdapter } from './game/adapter'
 import type { Policy } from './policy'
-import { mulberry32, type Rng } from './rng'
+import { pcg32, type Rng } from './rng'
 
 // GameConfig / opening / the 2p presets moved to the OeL adapter (project 09);
 // re-exported here so existing importers keep working.
@@ -88,7 +88,7 @@ export const runMatch = async <TState, TMove, TCfg>(
   for (let g = 0; g < opts.games; g++) {
     const swap = g % 2 === 1 // alternate which policy sits at seat 0
     const seed = baseSeed + g
-    const res = await playGame(adapter, swap ? [b, a] : [a, b], opts.cfg, seed, mulberry32(seed * 7919 + 1))
+    const res = await playGame(adapter, swap ? [b, a] : [a, b], opts.cfg, seed, pcg32(seed * 7919 + 1))
     const ao = res.outcome[swap ? 1 : 0] ?? 0
     const bo = res.outcome[swap ? 0 : 1] ?? 0
     results.push({ winner: ao > bo ? 'a' : bo > ao ? 'b' : 'draw', steps: res.steps, finished: res.finished })

--- a/agent/src/bench/bench.ts
+++ b/agent/src/bench/bench.ts
@@ -8,7 +8,7 @@
 import type { GameState } from 'hathora-et-labora-game'
 import { control, completions, scores, encode, encodeInto, FEATURE_LEN } from 'hathora-et-labora-game'
 import { enumerateMoves, sampleMove } from '../moves'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 import type { Corpus } from './corpus'
 
 // The search's per-node enumeration caps (DEFAULTS in mcts/search.ts).
@@ -71,7 +71,7 @@ const OPS: Op[] = [
   { name: 'scores(state)', reps: 20, det: true, run: (s) => scores(s).length },
   { name: 'enumerateMoves (capped 24/128)', reps: 4, det: false, run: (s) => enumerateMoves(s, CURATION).length },
   { name: 'enumerateMoves (uncapped)', reps: 1, det: false, run: (s) => enumerateMoves(s).length },
-  { name: 'sampleMove', reps: 6, det: false, run: (s, i) => sampleMove(s, mulberry32(i + 1))?.length ?? 0 },
+  { name: 'sampleMove', reps: 6, det: false, run: (s, i) => sampleMove(s, pcg32(i + 1))?.length ?? 0 },
   { name: 'encode', reps: 6, det: true, run: (s) => encode(s)[0]! },
   {
     name: 'encodeInto (reused scratch)',

--- a/agent/src/bench/corpus.ts
+++ b/agent/src/bench/corpus.ts
@@ -22,7 +22,7 @@ import { oel } from '../game/oel'
 import type { Policy } from '../policy'
 import { greedyPolicy } from '../policies/greedy'
 import { randomPolicy } from '../policies/random'
-import { mulberry32, type Rng } from '../rng'
+import { pcg32, type Rng } from '../rng'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 
@@ -53,15 +53,20 @@ const replayCollect = (commands: Move[]): ReplayResult => {
 // isn't only the two hand-authored fixtures. Random games are cheap and finish;
 // one greedy game adds enumeration-heavy late states.
 const generatedGames = async (): Promise<{ name: string; commands: Move[] }[]> => {
-  const specs: { name: string; cfg: GameConfig; seed: number; policies: Policy<GameState, Move>[] }[] = [
-    { name: 'gen:2p-random', cfg: cfg(2), seed: 101, policies: [randomPolicy(oel), randomPolicy(oel)] },
-    { name: 'gen:3p-random', cfg: cfg(3), seed: 202, policies: [randomPolicy(oel), randomPolicy(oel), randomPolicy(oel)] },
-    { name: 'gen:2p-greedy', cfg: cfg(2), seed: 303, policies: [greedyPolicy(oel), randomPolicy(oel)] },
-  ]
+  // maxSteps bounds the greedy game: greedy enumerates + scores every step, so a
+  // full game is slow; a few hundred steps already reach enumeration-heavy
+  // mid/late states, which is all the corpus needs. Random games are cheap
+  // (no enumeration) and run to their natural end.
+  const specs: { name: string; cfg: GameConfig; seed: number; policies: Policy<GameState, Move>[]; maxSteps?: number }[] =
+    [
+      { name: 'gen:2p-random', cfg: cfg(2), seed: 101, policies: [randomPolicy(oel), randomPolicy(oel)] },
+      { name: 'gen:3p-random', cfg: cfg(3), seed: 202, policies: [randomPolicy(oel), randomPolicy(oel), randomPolicy(oel)] },
+      { name: 'gen:2p-greedy', cfg: cfg(2), seed: 303, policies: [greedyPolicy(oel), randomPolicy(oel)], maxSteps: 250 },
+    ]
   // Sequential (not Promise.all): deterministic order for a stable corpus.
   const out: { name: string; commands: Move[] }[] = []
-  for (const { name, cfg: gcfg, seed, policies } of specs) {
-    const { commands } = await playGame(oel, policies, gcfg, seed, mulberry32(seed * 7919 + 1))
+  for (const { name, cfg: gcfg, seed, policies, maxSteps } of specs) {
+    const { commands } = await playGame(oel, policies, gcfg, seed, pcg32(seed * 7919 + 1), maxSteps)
     out.push({ name, commands })
   }
   return out
@@ -117,7 +122,7 @@ export const buildCorpus = async (opts: { size: number; seed: number; gamesPath?
     applyNs.push(...ns)
   }
 
-  const shuffled = seededShuffle(allStates, mulberry32(opts.seed))
+  const shuffled = seededShuffle(allStates, pcg32(opts.seed))
   return {
     states: shuffled.slice(0, opts.size),
     applyNs,

--- a/agent/src/cli/selfplay.ts
+++ b/agent/src/cli/selfplay.ts
@@ -11,7 +11,7 @@ import { range } from 'ramda'
 import { selfPlayGame } from '../selfplay'
 import { CONFIG_2P_LONG, CONFIG_2P_SHORT } from '../arena'
 import { oel } from '../game/oel'
-import { mulberry32 } from '../rng'
+import { pcg32 } from '../rng'
 
 const games = Number.parseInt(process.argv[2] ?? '1', 10)
 const cfg = process.argv[3] === 'long' ? CONFIG_2P_LONG : CONFIG_2P_SHORT
@@ -24,7 +24,7 @@ const out = `${dir}/games-${cfg.length}-sims${sims}.jsonl`
 console.log(`Self-play: ${games} games, 2p ${cfg.country} ${cfg.length}, mcts sims=${sims} → ${out}`)
 for (const g of range(0, games)) {
   const seed = 1000 + g
-  const rng = mulberry32(seed * 7919 + 3)
+  const rng = pcg32(seed * 7919 + 3)
   const t0 = Date.now()
   const game = await selfPlayGame(oel, cfg, seed, rng, { sims })
   appendFileSync(out, JSON.stringify(game) + '\n')

--- a/agent/src/policies/greedy.ts
+++ b/agent/src/policies/greedy.ts
@@ -2,9 +2,17 @@ import type { GameAdapter, Caps } from '../game/adapter'
 import type { Policy } from '../policy'
 import { choice } from '../rng'
 
-// 1-ply greedy: among (curated) legal moves, play the one that maximizes my own
-// heuristic (score total) in the resulting state. Ties broken randomly. A weak
-// but non-trivial baseline — it always grabs immediate points before COMMITting.
+// 1-ply greedy: play the move that most improves my own heuristic (score total).
+// If NO legal move strictly improves my score, the turn has nothing left to
+// gain, so restrict the choice to turn-ending moves. Ties broken randomly.
+//
+// Without the "must strictly improve, else end the turn" rule, greedy loops
+// forever on value-neutral turn-keeping moves: e.g. penny↔nickel CONVERTs score
+// identically under `goodsPoints`, and each ties the current best while COMMIT
+// (which advances the game) scores *lower* in a myopic 1-ply view — so greedy
+// keeps converting and never commits, and whether a game terminates depends on
+// the rng. This keeps termination rng-independent and stays game-agnostic (it
+// never names a command; it just watches `playerToMove`).
 export const greedyPolicy = <TState, TMove>(
   adapter: GameAdapter<TState, TMove>,
   caps: Caps = { maxPerLevel: 12, maxMoves: 64 }
@@ -12,15 +20,25 @@ export const greedyPolicy = <TState, TMove>(
   name: 'greedy',
   pick: async (state, rng) => {
     const me = adapter.playerToMove(state)
+    const current = adapter.heuristic?.(state)?.[me] ?? -Infinity
     const scored = adapter.legalMoves(state, caps).map((move) => {
       const next = adapter.apply(state, move)
-      return { move, total: next ? (adapter.heuristic?.(next)?.[me] ?? -Infinity) : -Infinity }
+      return { move, next, total: next ? (adapter.heuristic?.(next)?.[me] ?? -Infinity) : -Infinity }
     })
     if (scored.length === 0) return undefined
-    const best = Math.max(...scored.map((s) => s.total))
+
+    const endsTurn = (s: (typeof scored)[number]): boolean =>
+      s.next === undefined || adapter.isTerminal(s.next) || adapter.playerToMove(s.next) !== me
+    const improving = scored.filter((s) => s.total > current)
+    const endMoves = scored.filter(endsTurn)
+    // Grab points if any move improves; otherwise end the turn (fall back to all
+    // moves only if somehow no move ends it — should not happen mid-game).
+    const pool = improving.length > 0 ? improving : endMoves.length > 0 ? endMoves : scored
+
+    const best = Math.max(...pool.map((s) => s.total))
     return choice(
       rng,
-      scored.filter((s) => s.total === best).map((s) => s.move)
+      pool.filter((s) => s.total === best).map((s) => s.move)
     )
   },
 })

--- a/agent/src/rng.ts
+++ b/agent/src/rng.ts
@@ -1,21 +1,22 @@
-// Tiny seeded PRNG (mulberry32) for reproducible self-play, rollouts, and
-// arena scheduling. Deterministic given a seed — same seed, same games.
+// Tiny seeded PRNG for reproducible self-play, rollouts, and arena scheduling.
+// Deterministic given a seed — same seed, same games.
 //
-// Delegates to the `pcg` library's mulberry32 (the same generator the game
-// engine's START shuffle uses) rather than hand-rolling the algorithm. `pcg`'s
-// API is immutable (state-threading); we wrap it in the mutable `() => number`
-// closure this codebase expects. `getOutput` then `nextState` reproduces the
-// canonical mulberry32 sequence bit-for-bit (verified against the previous
-// hand-rolled implementation), so seeded behavior is unchanged.
+// Uses the pcg library's PCG32 generator (the same family the game engine's
+// START shuffle uses). pcg's API is immutable (state-threading); we wrap it in
+// the mutable `() => number` closure this codebase expects — `getOutput` reads
+// the current output, `nextState` advances. The stream id is fixed, so the seed
+// alone selects the sequence (its starting point within the one periodic series).
 
-import { createMulberry32, getOutput, nextState } from 'pcg'
+import { createPcg32, getOutput, nextState } from 'pcg'
 
 export type Rng = () => number // returns a float in [0, 1)
 
 const UINT32 = 0x1_0000_0000 // 2^32
+// Fixed stream id — distinct seeds give distinct sequences within this series.
+const STREAM_ID = 0xda3e39cb
 
-export const mulberry32 = (seed: number): Rng => {
-  let state = createMulberry32(seed)
+export const pcg32 = (seed: number): Rng => {
+  let state = createPcg32({}, seed, STREAM_ID)
   return () => {
     const value = getOutput(state)
     state = nextState(state)

--- a/docs/trainer/02-engine-adapter.md
+++ b/docs/trainer/02-engine-adapter.md
@@ -64,13 +64,14 @@ outcome(state): number[]                    // per-player value in [0, 1]
 
 ```ts
 export type Rng = () => number              // float in [0, 1)
-mulberry32(seed: number): Rng
+pcg32(seed: number): Rng
 randInt(rng, n): number
 choice<T>(rng, xs: readonly T[]): T
 ```
 
-mulberry32 is a 32-bit state PRNG: one add, two `Math.imul` mixes, a few
-shifts per draw. Everything downstream (rollouts, arena scheduling, self-play)
+`pcg32` is the `pcg` library's PCG32 generator (the same family the engine
+already uses for game setup), wrapped in the mutable `() => number` closure this
+codebase expects. Everything downstream (rollouts, arena scheduling, self-play)
 takes an `Rng` parameter and never touches `Math.random`, so a seed fully
 determines a game.
 
@@ -105,12 +106,13 @@ a SETUP state is a caller bug; `replay` gives no diagnostics on failure.
   Cost: throws away margin information (a 1-point win equals a 40-point win),
   which weakens the rollout-cutoff signal in lopsided positions — accepted,
   and revisited only if value targets prove noisy.
-- **mulberry32 vs PCG (or xoshiro).** Chosen: mulberry32. ~5 integer ops per
-  draw, 32-bit state, trivially embeddable, and statistically far better than
-  needed for move sampling; the engine itself already uses PCG internally for
-  game setup, where stream quality matters more. Cost: small state/period and
-  no stream splitting — mitigated by deriving independent seeds per game
-  (`seed * 7919 + k` in the arena/self-play CLIs).
+- **PCG32 vs mulberry32 vs xoshiro.** Chosen: PCG32, via the `pcg` library the
+  engine already depends on for game setup — one generator across the codebase,
+  no hand-rolled PRNG to maintain, and better stream quality than the original
+  mulberry32. A fixed stream id makes the seed alone select the sequence, and
+  independent seeds per game (`seed * 7919 + k` in the arena/self-play CLIs)
+  keep games decorrelated. The `Rng` interface (a mutable `() => number`) is
+  unchanged — only the generator behind it.
 - **Wrapping the engine at all vs calling it directly.** One place to
   normalize errors and semantics (`activePlayerIndex`, `config.players`) and
   a surface small enough that [09](09-game-adapter.md) can later swap the

--- a/docs/trainer/04-baselines-arena.md
+++ b/docs/trainer/04-baselines-arena.md
@@ -60,7 +60,7 @@ runMatch(a: Policy, b: Policy, opts: MatchOptions): MatchResult
   `(policies, cfg, seed, rng seed)`.
 - **`runMatch`** plays `opts.games` games (default cfg `CONFIG_2P_LONG`,
   default `baseSeed = 1`). Game `g` uses board seed `baseSeed + g` and policy
-  rng `mulberry32(seed * 7919 + 1)`; odd games swap which policy takes seat 0
+  rng `pcg32(seed * 7919 + 1)`; odd games swap which policy takes seat 0
   so first-mover/turn-order advantage cancels over an even count. Winners are
   decided by comparing `outcome` components (rank-based, from
   [02](02-engine-adapter.md)) — equal outcomes count as a draw. Result:

--- a/docs/trainer/06-selfplay-v1.md
+++ b/docs/trainer/06-selfplay-v1.md
@@ -59,7 +59,7 @@ a game is a pure function of `(cfg, seed, rng seed, options)`.
 
 `pnpm --dir agent selfplay [games] [short|long] [sims]` — defaults
 `1 short 64`. Game `g` uses board seed `1000 + g` and rng
-`mulberry32(seed * 7919 + 3)` (a different stream than the arena's `+1`).
+`pcg32(seed * 7919 + 3)` (a different stream than the arena's `+1`).
 Each finished game is `JSON.stringify`-ed and **appended** as one line to
 `selfplay-data/games-{length}-sims{N}.jsonl` (directory auto-created), with a
 per-game progress line (steps, finished flag, outcome, seconds) on stdout.

--- a/docs/trainer/14-selfplay-v2.md
+++ b/docs/trainer/14-selfplay-v2.md
@@ -37,7 +37,7 @@ selfPlayGame(adapter, evaluator, cfg, seed, rng, opts): Promise<SelfPlayGameV2>
   sample the move (below); `apply`; push onto `commands`. Stops on terminal,
   `maxSteps`, or `best === undefined` (engine stall ⇒ `finished: false`).
   Per-game `rng` derivation stays a pure function of `seed` (v1 uses
-  `mulberry32(seed * 7919 + 3)`), so a game is reproducible from its JSONL
+  `pcg32(seed * 7919 + 3)`), so a game is reproducible from its JSONL
   line alone, independent of worker assignment.
 - **Temperature schedule**: for the first `tempMoves = 30` *decisions*,
   sample `π(a) ∝ visits(a)^(1/τ)` with τ = 1 (i.e. sample proportional to

--- a/docs/trainer/22-arena-gating.md
+++ b/docs/trainer/22-arena-gating.md
@@ -74,7 +74,7 @@ advance STATE → gated either way
 
 **Seat/seed schedule.** `runMatch` already alternates which policy takes
 seat 0 (`swap = g % 2 === 1`) and derives per-game determinism from
-`seed = baseSeed + g` with `mulberry32(seed * 7919 + 1)` — the gate reuses
+`seed = baseSeed + g` with `pcg32(seed * 7919 + 1)` — the gate reuses
 this unchanged. The per-generation `baseSeed` offset means no two gates
 replay the identical opening set (which would correlate outcomes across
 generations), while any gate is exactly reproducible from `config.json`.

--- a/docs/trainer/schemas.md
+++ b/docs/trainer/schemas.md
@@ -91,7 +91,7 @@ type SelfPlayGameV2 = {
   v: 2                          // first field — cheap to sniff
   gameId: string                // "g" + seed; stable across resumes
   cfg: GameConfig               // { players, country, length, colors } — full, incl. colors
-  seed: number                  // opening seed AND rng derivation: mulberry32(seed*7919+3)
+  seed: number                  // opening seed AND rng derivation: pcg32(seed*7919+3)
   netId: string                 // evaluator.id: "rollout" | "gen-NNN"
   search: { sims: number; cPuct: number
             dirichlet: { epsilon: number; alphaScale: number } | null


### PR DESCRIPTION
Swap the agent's rng from the `pcg` library's **mulberry32** to its **PCG32** generator, per request.

## What changed

- **`agent/src/rng.ts`** — `pcg32(seed)` now wraps `createPcg32` + `getOutput`/`nextState` (fixed stream id) instead of `createMulberry32`. The `Rng` interface (a mutable `() => number` closure) is unchanged; only the generator behind it — the same family the game engine already uses for `START`. Renamed `mulberry32` → `pcg32` across the call sites (arena, selfplay, bench, tests).
- **`agent/src/__tests__/golden.test.ts`** — PCG32 is a different sequence than mulberry32, so seeded games differ; the golden hashes are **re-captured under pcg32** (verified deterministic, and `getOutput`→`nextState` matches pcg's own `randomInt`).

## Latent greedy bug the rng change surfaced (fixed here)

Switching the rng made the greedy baseline **loop forever**: at states where nothing improves its score, the tied-best moves are value-neutral, turn-*keeping* `CONVERT`s (penny↔nickel, which `goodsPoints` scores identically), while `COMMIT` scores *lower* in greedy's myopic 1-ply view — so greedy kept converting and never committed. Whether a game terminated depended on the rng (mulberry32 happened to pick COMMIT; pcg32 didn't). A greedy that doesn't terminate is broken regardless of the rng.

**Fix (`agent/src/policies/greedy.ts`):** greedy now takes a move only if it **strictly improves** its score; if nothing improves, it **ends the turn**. Game-agnostic — it watches `playerToMove`, never names a command. This is also just better greedy play (it stops wasting actions). The bench corpus's slow 2p-long greedy game is bounded to 250 steps (`bench/corpus.ts`) — a few hundred steps already reach the enumeration-heavy states the corpus needs.

## Verification

- `pnpm --dir agent typecheck` clean; **25/25 agent tests pass in ~80s** (previously the greedy dither ran games to `maxSteps` and hung the suite).
- Golden regression green under pcg32; greedy still beats random (arena win-rate = 1.0).

## Docs

Updated to match reality: `02-engine-adapter.md` (rng section + the PCG-vs-mulberry design note, now reversed), and the `pcg32(seed*7919+k)` rng-derivation references in `04`/`06`/`14`/`22` and the canonical `schemas.md`.

CI note: `agent/**` + `docs/**` only, so no GitHub Actions (game.yml is `game/**`-scoped); Vercel (web) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGGijvjP8i5yQmG6V39C27)_