### PR TITLE
feat(agent): GameAdapter conformance harness (M9 groundwork) + two engine bugs it caught

### DIFF
--- a/agent/src/__tests__/conformance.test.ts
+++ b/agent/src/__tests__/conformance.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { checkConformance } from '../game/conformance'
+import { oel, CONFIG_2P_SHORT, CONFIG_2P_LONG } from '../game/oel'
+import type { GameConfig } from '../game/oel'
+import { mulberry32 } from '../rng'
+
+const CONFIG_SOLO: GameConfig = { players: 1, country: 'france', length: 'short', colors: ['R'] }
+
+// strictMoveKeys stays off for OeL until project 10 lands: raw enumeration
+// still emits joined "col row" coordinate tokens (docs/trainer/
+// 10-move-canonicalization.md). Flip it on in the same PR that adds
+// canonicalize — it is the acceptance check for exactly that change.
+const OEL_STRICT = { strictMoveKeys: false }
+
+describe('oel adapter conformance (docs/trainer/28 gate 1)', () => {
+  it('2p short: every contract holds over seeded random walks', () => {
+    const violations = checkConformance(oel, CONFIG_2P_SHORT, {
+      seeds: [11, 22],
+      rng: mulberry32,
+      maxSteps: 30,
+      ...OEL_STRICT,
+    })
+    assert.deepEqual(violations, [])
+  })
+
+  it('2p long: every contract holds over a seeded random walk', () => {
+    const violations = checkConformance(oel, CONFIG_2P_LONG, {
+      seeds: [7],
+      rng: mulberry32,
+      maxSteps: 30,
+      ...OEL_STRICT,
+    })
+    assert.deepEqual(violations, [])
+  })
+
+  it('solo: outcome is squashed into [0,1] mid-game', () => {
+    const violations = checkConformance(oel, CONFIG_SOLO, {
+      seeds: [5],
+      rng: mulberry32,
+      maxSteps: 30,
+      ...OEL_STRICT,
+    })
+    assert.deepEqual(violations, [])
+  })
+
+  it('a full random game reaches terminal and keeps the outcome contract there', () => {
+    const violations = checkConformance(oel, CONFIG_2P_SHORT, {
+      seeds: [3],
+      rng: mulberry32,
+      maxSteps: 2000,
+      checkStride: 50, // cheap walk; contract sampling only
+      requireTerminal: true,
+      ...OEL_STRICT,
+    })
+    assert.deepEqual(violations, [])
+  })
+})

--- a/agent/src/__tests__/golden.test.ts
+++ b/agent/src/__tests__/golden.test.ts
@@ -12,6 +12,11 @@ import { mulberry32 } from '../rng'
 // already-resolved promises reorders no rng draws, so the same seeds must still
 // produce the same command lists. (djb2 over the JSON of the command list.)
 //
+// Seed-1 recaptured after the engine's bare-USE fixes (cloisterCourtyard /
+// forgersWorkshop): 'USE G02' now applies instead of forcing a sampleMove
+// retry, so that walk's rng consumption legitimately changed (759 -> 715
+// commands). Seeds 2/3 never hit the affected paths and are unchanged.
+//
 // Captured in isolation but verified stable under heavy prior apply/enumerate
 // work, so test order in the shared runner does not perturb them.
 const djb2 = (s: string): number => {
@@ -25,8 +30,8 @@ const randoms = () => [randomPolicy(oel), randomPolicy(oel)]
 describe('golden: seeded behavior survives the adapter/async refactor', () => {
   it('random-vs-random 2p short games are unchanged (seeds 1, 2)', async () => {
     const g1 = await playGame(oel, randoms(), CONFIG_2P_SHORT, 1, rng(1))
-    assert.equal(g1.commands.length, 759)
-    assert.equal(djb2(JSON.stringify(g1.commands)), 3387465242)
+    assert.equal(g1.commands.length, 715)
+    assert.equal(djb2(JSON.stringify(g1.commands)), 1526401044)
 
     const g2 = await playGame(oel, randoms(), CONFIG_2P_SHORT, 2, rng(2))
     assert.equal(g2.commands.length, 446)

--- a/agent/src/game/conformance.ts
+++ b/agent/src/game/conformance.ts
@@ -1,0 +1,186 @@
+// Game-agnostic GameAdapter conformance checks — the reusable form of the
+// second-game acceptance ladder's gate 1 (docs/trainer/28-second-game-onboarding.md):
+// every enumerated move applies, keys are unique, outcome/playerToMove hold
+// their contracts mid-game, encoding is finite, and a seed replays to the
+// same game. A new game's adapter runs these over its own configs before any
+// search or self-play is pointed at it; the OeL adapter runs them in
+// __tests__/conformance.test.ts so the checks themselves stay honest.
+//
+// Framework-free by design: instead of asserting, checks collect Violations
+// and the caller asserts the list is empty — a failing adapter reports every
+// broken invariant in one run, not just the first.
+
+import type { Caps, GameAdapter, Rng } from './adapter'
+
+export type ConformanceOpts = {
+  seeds: number[] // one seeded random-play walk per entry
+  rng: (seed: number) => Rng // seeded rng factory (e.g. mulberry32)
+  maxSteps?: number // walk length before giving up (default 40)
+  caps?: Caps // enumeration caps (default { maxPerLevel: 24, maxMoves: 64 })
+  // Run the expensive per-state checks (enumerate + apply-all + encode) only
+  // every Nth step (default 1 = every state). Terminal-reaching walks pass a
+  // large stride so the walk itself stays cheap.
+  checkStride?: number
+  // Walks must reach a terminal state within maxSteps (default false). Use
+  // with a generous maxSteps to prove the terminal predicate + terminal
+  // outcome contract on a real finished game.
+  requireTerminal?: boolean
+  // moveKey grammar checks from docs/trainer/schemas.md §2: no whitespace
+  // inside a token. Default true — a new adapter must pass; OeL opts out
+  // until project 10 (move canonicalization) truncates joined "col row"
+  // tokens (docs/trainer/10-move-canonicalization.md).
+  strictMoveKeys?: boolean
+}
+
+export type Violation = { seed: number; step: number; check: string; detail: string }
+
+const MAX_VIOLATIONS = 25
+const DEFAULT_CAPS: Caps = { maxPerLevel: 24, maxMoves: 64 }
+
+export const checkConformance = <TState, TMove, TCfg>(
+  adapter: GameAdapter<TState, TMove, TCfg>,
+  cfg: TCfg,
+  opts: ConformanceOpts
+): Violation[] => {
+  const out: Violation[] = []
+  const caps = opts.caps ?? DEFAULT_CAPS
+  const maxSteps = opts.maxSteps ?? 40
+  const stride = opts.checkStride ?? 1
+  const strict = opts.strictMoveKeys ?? true
+  const report = (seed: number, step: number, check: string, detail: string): void => {
+    if (out.length < MAX_VIOLATIONS) out.push({ seed, step, check, detail })
+  }
+
+  // Per-state contract checks. All read-only on `state`; none consume rng, so
+  // running them cannot perturb the walk they're embedded in.
+  const checkState = (seed: number, step: number, state: TState): void => {
+    const players = adapter.numPlayers(state)
+    const mover = adapter.playerToMove(state)
+    if (!Number.isInteger(mover) || mover < 0 || mover >= players)
+      report(seed, step, 'player-to-move', `playerToMove ${mover} outside [0, ${players})`)
+
+    // outcome is defined MID-GAME too (rollout cutoff / gen-0 contract)
+    const outcome = adapter.outcome(state)
+    if (outcome.length !== players) report(seed, step, 'outcome-length', `${outcome.length} values for ${players} players`)
+    outcome.forEach((v, p) => {
+      if (!Number.isFinite(v) || v < 0 || v > 1) report(seed, step, 'outcome-range', `player ${p} outcome ${v} outside [0, 1]`)
+    })
+
+    if (adapter.heuristic !== undefined) {
+      const h = adapter.heuristic(state)
+      if (h.length !== players) report(seed, step, 'heuristic-length', `${h.length} values for ${players} players`)
+      h.forEach((v, p) => {
+        if (!Number.isFinite(v)) report(seed, step, 'heuristic-finite', `player ${p} heuristic ${v}`)
+      })
+    }
+
+    const buf = new Float32Array(adapter.featureSpec.featureLen)
+    for (let p = 0; p < players; p++) {
+      buf.fill(0)
+      adapter.encodeState(state, p, buf)
+      for (let i = 0; i < buf.length; i++) {
+        if (!Number.isFinite(buf[i]!)) {
+          report(seed, step, 'encode-finite', `perspective ${p}: non-finite at feature ${i}`)
+          break
+        }
+      }
+    }
+
+    const moves = adapter.legalMoves(state, caps)
+    if (moves.length === 0) {
+      report(seed, step, 'no-legal-moves', 'non-terminal state enumerated zero moves')
+      return
+    }
+    const keys = moves.map((m) => adapter.moveKey(m))
+    const seen = new Set<string>()
+    keys.forEach((k) => {
+      if (seen.has(k)) report(seed, step, 'duplicate-key', `two enumerated moves share key '${k}'`)
+      seen.add(k)
+      if (k.length === 0 || k.split(' ').includes(''))
+        report(seed, step, 'key-spacing', `key '${k}' is empty or has leading/trailing/double spaces`)
+      if (strict && /[^\S ]/.test(k)) report(seed, step, 'key-token-whitespace', `key '${k}' contains non-space whitespace`)
+    })
+    if (strict) {
+      // schemas.md §2: tokens contain no whitespace, so the number of
+      // space-separated fields equals the move's token count. A joined
+      // "col row" token inflates the split — the k² duplicate precedent.
+      moves.forEach((m, i) => {
+        if (Array.isArray(m) && keys[i]!.split(' ').length !== m.length)
+          report(seed, step, 'key-token-whitespace', `key '${keys[i]!}' splits to ${keys[i]!.split(' ').length} fields for a ${m.length}-token move`)
+      })
+    }
+
+    // enumeration is a pure function of (state, caps)
+    const again = adapter.legalMoves(state, caps).map((m) => adapter.moveKey(m))
+    if (again.join('\n') !== keys.join('\n'))
+      report(seed, step, 'enumeration-deterministic', 'two legalMoves calls disagree in content or order')
+
+    // every enumerated move applies
+    for (let i = 0; i < moves.length; i++) {
+      if (adapter.apply(state, moves[i]!) === undefined) {
+        report(seed, step, 'move-applies', `enumerated move '${keys[i]!}' does not apply`)
+        break
+      }
+    }
+  }
+
+  // Random-play walk via sampleMove; returns the moveKey trace.
+  const walk = (seed: number, withChecks: boolean): string[] => {
+    const rng = opts.rng(seed)
+    const trace: string[] = []
+    let state = adapter.initial(cfg, seed)
+    for (let step = 0; step < maxSteps; step++) {
+      if (adapter.isTerminal(state)) {
+        if (withChecks) checkTerminal(seed, step, state)
+        return trace
+      }
+      if (withChecks && step % stride === 0) checkState(seed, step, state)
+      const move = adapter.sampleMove(state, rng)
+      if (move === undefined) {
+        if (withChecks) report(seed, step, 'sample-move', 'sampleMove undefined on a non-terminal state')
+        return trace
+      }
+      const next = adapter.apply(state, move)
+      if (next === undefined) {
+        if (withChecks) report(seed, step, 'sample-applies', `sampled move '${adapter.moveKey(move)}' does not apply`)
+        return trace
+      }
+      trace.push(adapter.moveKey(move))
+      state = next
+    }
+    if (withChecks && opts.requireTerminal === true && !adapter.isTerminal(state))
+      report(seed, maxSteps, 'terminal-reached', `no terminal state within ${maxSteps} steps`)
+    return trace
+  }
+
+  const checkTerminal = (seed: number, step: number, state: TState): void => {
+    const players = adapter.numPlayers(state)
+    const outcome = adapter.outcome(state)
+    if (outcome.length !== players) report(seed, step, 'terminal-outcome-length', `${outcome.length} values for ${players} players`)
+    outcome.forEach((v, p) => {
+      if (!Number.isFinite(v) || v < 0 || v > 1) report(seed, step, 'terminal-outcome-range', `player ${p} outcome ${v} outside [0, 1]`)
+    })
+  }
+
+  for (const seed of opts.seeds) {
+    // initial: constructible, deterministic, not terminal
+    let initial: TState
+    try {
+      initial = adapter.initial(cfg, seed)
+    } catch (e) {
+      report(seed, -1, 'initial-throws', String(e))
+      continue
+    }
+    if (JSON.stringify(initial) !== JSON.stringify(adapter.initial(cfg, seed)))
+      report(seed, -1, 'initial-deterministic', 'two initial() calls produce different states')
+    if (adapter.isTerminal(initial)) report(seed, -1, 'initial-terminal', 'initial state is already terminal')
+
+    // seeded determinism: the same seed replays the same game
+    const first = walk(seed, true)
+    const second = walk(seed, false)
+    if (first.join('\n') !== second.join('\n'))
+      report(seed, -1, 'walk-deterministic', `same seed diverged: [${first.slice(0, 3).join(', ')}…] vs [${second.slice(0, 3).join(', ')}…]`)
+  }
+
+  return out
+}

--- a/game/src/buildings/__tests__/cloisterCourtyard.test.ts
+++ b/game/src/buildings/__tests__/cloisterCourtyard.test.ts
@@ -84,6 +84,11 @@ describe('buildings/cloisterCourtyard', () => {
       const s1 = cloisterCourtyard()(s0)
       expect(s1).toBeUndefined()
     })
+    it('using it and converting nothing is a legal no-op', () => {
+      // complete([]) offers the bare form; the reducer must accept it
+      const s1 = cloisterCourtyard()(s0)
+      expect(s1).toBe(s0)
+    })
     it('goes through a happy path', () => {
       const s1 = cloisterCourtyard('ClWoGn', 'Sh')(s0)!
       expect(s1.players![0]).toMatchObject({

--- a/game/src/buildings/__tests__/forgersWorkshop.test.ts
+++ b/game/src/buildings/__tests__/forgersWorkshop.test.ts
@@ -92,6 +92,18 @@ describe('buildings/forgersWorkshop', () => {
       expect(s1).toBeUndefined()
     })
 
+    it('bare use is a legal no-op, never a negative reliquary', () => {
+      // complete([]) offers '' even for a broke player; the reducer must
+      // accept it without granting floor((0-5)/10) = -1 reliquaries
+      const s1 = forgersWorkshop()(s0)
+      expect(s1).toBe(s0)
+    })
+
+    it('rejects paying 1-4 coins (buys nothing)', () => {
+      const s1 = forgersWorkshop('Pn')(s0)
+      expect(s1).toBeUndefined()
+    })
+
     it('can do both things', () => {
       const s1 = forgersWorkshop('NiNiNi')(s0)!
       expect(s1.players![0]).toMatchObject({

--- a/game/src/buildings/cloisterCourtyard.ts
+++ b/game/src/buildings/cloisterCourtyard.ts
@@ -1,4 +1,4 @@
-import { addIndex, always, curry, filter, join, keys, map, pipe, reduce, view } from 'ramda'
+import { addIndex, always, curry, filter, identity, join, keys, map, pipe, reduce, view } from 'ramda'
 import { P, match } from 'ts-pattern'
 import { activeLens, getCost, payCost, withActivePlayer } from '../board/player'
 import {
@@ -18,6 +18,9 @@ const ALLOWED_OUTPUT: (keyof Cost)[] = ['peat', 'clay', 'wood', 'sheep', 'grain'
 export const cloisterCourtyard = (input = '', output = '') => {
   const inputs = parseResourceParam(input)
   const outputs = parseResourceParam(output)
+  // using the building and converting nothing is legal (complete() offers the
+  // bare form), same as druidsHouse/shippingCompany's no-op convention
+  if (totalGoods(inputs) === 0 && totalGoods(outputs) === 0) return identity
   if (totalGoods(inputs) !== 3) return () => undefined
   if (differentGoods(inputs) !== 3) return () => undefined
   if (totalGoods(maskGoods(ALLOWED_OUTPUT)(outputs)) !== 1 || differentGoods(outputs) !== 1) return () => undefined

--- a/game/src/buildings/forgersWorkshop.ts
+++ b/game/src/buildings/forgersWorkshop.ts
@@ -1,4 +1,4 @@
-import { always, curry, map, pipe, reverse, unnest, view } from 'ramda'
+import { always, curry, identity, map, pipe, reverse, unnest, view } from 'ramda'
 import { P, match } from 'ts-pattern'
 import { activeLens, getCost, payCost, withActivePlayer } from '../board/player'
 import { coinCostOptions, costMoney, parseResourceParam } from '../board/resource'
@@ -7,12 +7,17 @@ import { GameState } from '../types'
 export const forgersWorkshop = (param = '') => {
   const input = parseResourceParam(param)
   const coins = costMoney(input)
+  // 5 coins buy the 1st reliquary, 10 each additional (matching complete()'s
+  // tiers). Bare use is a legal no-op; paying 1-4 coins buys nothing and is
+  // rejected rather than granting floor((coins-5)/10) = -1 reliquaries.
+  const reliquaries = coins >= 5 ? 1 + Math.floor((coins - 5) / 10) : 0
+  if (coins === 0) return identity
+  if (reliquaries === 0) return () => undefined
   return withActivePlayer(
     pipe(
       //
       payCost(input),
-      getCost({ reliquary: coins >= 5 ? 1 : 0 }),
-      getCost({ reliquary: Math.floor((coins - 5) / 10) })
+      getCost({ reliquary: reliquaries })
     )
   )
 }


### PR DESCRIPTION
Project 28 (second-game onboarding, M9) gates a new game's adapter on a unit suite: every enumerated move applies, keys are unique, `outcome`/`playerToMove` hold their contracts mid-game, encoding is finite, and a seed replays the same game. That suite is implementable today against the shipped `GameAdapter`, so this lands it as a **reusable, game-agnostic harness** — it hardens the only adapter that exists now and is ready-made for the second game later.

**The harness** (`agent/src/game/conformance.ts`): `checkConformance(adapter, cfg, opts)` runs seeded random walks with per-state contract checks, collecting `Violation`s instead of asserting so one run reports every broken invariant. `strictMoveKeys` (the schemas.md §2 grammar: no whitespace inside a token) defaults on for new adapters; the OeL test opts out until project 10 canonicalizes the joined `"col row"` tokens — flipping that flag on is essentially project 10's acceptance check. The test runs it over 2p short/long, solo (the σ-squash stays in [0,1] mid-game), and a full random game to terminal.

**It immediately found two engine bugs**, both in the enumerated-but-unplayable class that `moves.ts` has hedged around in `sampleMove` all along ("the engine occasionally offers `''` on a not-yet-valid partial"):

1. **cloisterCourtyard (G02)** — `complete([])` offers the bare `USE G02`, but the builder statically rejected it (`totalGoods !== 3` → undefined). Every early-game MCTS node carried a phantom candidate that `search.ts`'s `next ?? node.state` guard silently turns into a self-loop child. Bare use is now the legal no-op its siblings (druidsHouse, shippingCompany, market) already implement.
2. **forgersWorkshop (F35)** — bare use (again offered by its own `complete()`) granted `floor((0−5)/10)` = **−1 reliquaries**, silently corrupting player state; the harness caught it 200 steps downstream when a `USE F08` enumeration offered the `Rq` the player didn't actually have. Bare use is now a no-op, paying 1–4 coins is rejected instead of granting a negative reliquary, and the ≥5-coin tiers are unchanged (5→1, 15→2, 25→3 — existing tests still pass).

**Golden fixture**: seed-1 recaptured (759 → 715 commands, new hash) — `USE G02` now applies instead of forcing a `sampleMove` retry, so that walk's rng consumption legitimately changed. Seeds 2/3 never hit the affected paths and are byte-identical; the fixture comment documents the recapture.

**Verification**: `game`: 1391 tests pass. `agent`: 29 tests (incl. the 4 new conformance tests) + typecheck pass. After #1910 landed and this branch was updated against fixed `main`, the full game.yml workflow (setup, lint, build, tests) and the Vercel preview both ran **green** on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM5LmrN1erST5718MC1af3