### PR TITLE
feat(agent): wall-clock budget (budgetMs/minSims) for MCTS search (M8 groundwork)

### DIFF
--- a/agent/src/__tests__/mcts.test.ts
+++ b/agent/src/__tests__/mcts.test.ts
@@ -30,6 +30,34 @@ describe('mcts', () => {
     assert.deepEqual(a, b)
   })
 
+  it('is bit-identical with no budget set (and reports sims run)', () => {
+    const s = replay(OPENING)!
+    const a = search(oel, s, mulberry32(9), { sims: 24, rolloutDepth: 10 })
+    const b = search(oel, s, mulberry32(9), { sims: 24, rolloutDepth: 10, budgetMs: undefined, minSims: undefined })
+    assert.deepEqual(a.visits, b.visits)
+    assert.equal(a.sims, 24)
+    assert.equal(b.sims, 24)
+  })
+
+  it('budgetMs stops the loop early; minSims floor holds', () => {
+    const s = replay(OPENING)!
+    // an already-expired budget: only the minSims floor keeps it going
+    const r = search(oel, s, mulberry32(9), { sims: 10_000, rolloutDepth: 10, budgetMs: 0, minSims: 5 })
+    assert.equal(r.sims, 5)
+    assert.ok(r.best)
+    assert.notEqual(apply(s, r.best!), undefined)
+    const totalVisits = r.visits.reduce((a, v) => a + v.n, 0)
+    assert.equal(totalVisits, 5)
+  })
+
+  it('a generous budget changes nothing', () => {
+    const s = replay(OPENING)!
+    const a = search(oel, s, mulberry32(4), { sims: 16, rolloutDepth: 8 })
+    const b = search(oel, s, mulberry32(4), { sims: 16, rolloutDepth: 8, budgetMs: 60_000, minSims: 1 })
+    assert.deepEqual(a.visits, b.visits)
+    assert.equal(b.sims, 16)
+  })
+
   it('mctsPolicy returns a legal move', async () => {
     const s = replay(OPENING)!
     const m = await mctsPolicy(oel, { sims: 16, rolloutDepth: 8 }).pick(s, mulberry32(2))

--- a/agent/src/mcts/search.ts
+++ b/agent/src/mcts/search.ts
@@ -22,6 +22,13 @@ export type MctsOptions = {
   c?: number // UCT exploration constant
   rolloutDepth?: number // max commands played in a rollout before cutoff
   curation?: Caps // caps on per-node move enumeration
+  // Wall-clock budget (docs/trainer/27-realtime-deployment.md): stop early
+  // once elapsed ≥ budgetMs, but never before minSims simulations, so a GC
+  // pause cannot reduce a move to noise. Unset ⇒ exactly `sims` simulations,
+  // bit-identical to before these options existed — arena and self-play stay
+  // reproducible by never setting a budget.
+  budgetMs?: number
+  minSims?: number // floor under budgetMs (default 1); ignored when budgetMs is unset
 }
 
 const DEFAULTS = {
@@ -88,6 +95,9 @@ export type SearchResult<TMove> = {
   best: TMove | undefined
   // visit distribution over root moves (for a future policy target)
   visits: { move: TMove; n: number; q: number }[]
+  // simulations actually run: equals options.sims unless a budget cut in
+  // (the realtime move log records it — strength stays auditable)
+  sims: number
 }
 
 export const search = <TState, TMove>(
@@ -103,7 +113,16 @@ export const search = <TState, TMove>(
 
   const root = new Node(adapter, state, curation)
 
+  // Budget bookkeeping only exists when asked for: the unset path takes no
+  // clock readings and runs the exact historical loop.
+  const budgetMs = options.budgetMs
+  const minSims = Math.min(options.minSims ?? 1, options.sims)
+  const deadline = budgetMs === undefined ? Infinity : performance.now() + budgetMs
+
+  let simsRun = 0
   for (let i = 0; i < options.sims; i++) {
+    if (budgetMs !== undefined && i >= minSims && performance.now() >= deadline) break
+    simsRun++
     let node = root
     const path: Edge<TState, TMove>[] = []
     const visited: Node<TState, TMove>[] = [root]
@@ -144,5 +163,5 @@ export const search = <TState, TMove>(
     .map((e) => ({ move: e.move, n: e.n, q: e.n > 0 ? e.w[root.mover]! / e.n : 0 }))
     .sort((x, y) => y.n - x.n)
 
-  return { best: visits[0]?.move, visits }
+  return { best: visits[0]?.move, visits, sims: simsRun }
 }

--- a/docs/trainer/27-realtime-deployment.md
+++ b/docs/trainer/27-realtime-deployment.md
@@ -149,7 +149,9 @@ scope for v1 — Ora et Labora ends by structure, not by resignation.
 1. `bot/package.json` + workspace entry in `pnpm-workspace.yaml` (deps:
    workspace `agent`, `@supabase/supabase-js`); `bot/src/config.ts`.
 2. `agent/src/mcts/puct.ts`: add `budgetMs`/`minSims` options (tested: budget
-   respected, floor holds, bit-identical when unset).
+   respected, floor holds, bit-identical when unset). The pure-UCT `search`
+   (`agent/src/mcts/search.ts`) already carries exactly these options and a
+   `sims`-run field in its result — mirror that shape.
 3. `bot/src/db.ts` — service client, `listSeatedGames()`, `fetchCommands()`,
    `appendCommand()` (CAS + zero-rows handling).
 4. `bot/src/turns.ts` — realtime subscriptions + slow poll, per-game queue.


### PR DESCRIPTION
Project 27 (real-time bot daemon, M8) needs searches bounded by **wall clock**, not simulation count: a human opponent cares about seconds, and a fixed-sims search on a slow position can stall a live game. `docs/trainer/27-realtime-deployment.md` specifies `budgetMs` alongside `sims` with a `minSims` floor so a GC pause can't reduce a move to noise.

This lands exactly that option surface on the pure-UCT `search` now:

- The sim loop stops when **either** `sims` is reached **or** `elapsed ≥ budgetMs`, never before `minSims`.
- `SearchResult` gains a `sims`-run field so the realtime move log can record how much search a budgeted move actually got — doc 27's strength-auditing requirement ("logging sims-reached preserves the strength signal fixed-sims used to give").
- **Unset budget takes no clock readings and runs the exact historical loop** — arena and self-play stay bit-identical and reproducible. Tested: no-budget runs produce deep-equal visit distributions; an expired budget stops at exactly `minSims`; a generous budget changes nothing. Golden fixtures pass byte-identical.

Doc 27's implementation plan now points `puct.ts` (project 13) at this shape to mirror, so the realtime daemon's budgeted-search contract is already proven on the search that exists today.

Verification: agent 32 tests + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM5LmrN1erST5718MC1af3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM5LmrN1erST5718MC1af3)_