### PR TITLE
fix(web): mark root layout dynamic so production build stops crashing on /_not-found

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,15 @@ import type { Metadata } from 'next'
 import './globals.css'
 import Header from './layout/header'
 import { SupabaseContextProvider } from '@/context/SupabaseContext'
+
+// The root layout renders <Header/>, which reads the auth cookie via
+// createClient() on every request, so nothing beneath this layout can be
+// statically prerendered. Marking the layout dynamic keeps `next build` from
+// attempting to statically generate framework pages like /_not-found and
+// /error — that attempt instantiates a Supabase client at build time and, when
+// the Supabase env vars aren't inlined into the build, crashes the whole build.
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: 'Kennerspiel',
   description: 'Digital Tabletop',


### PR DESCRIPTION
## Problem

The production build (`next build` in `web`) crashes during the static-generation phase:

```
Error occurred prerendering page "/_not-found".
Error: @supabase/ssr: Your project's URL and API key are required to create a Supabase client!
Export encountered an error on /_not-found/page: /_not-found, exiting the build.
⨯ Next.js build worker exited with code: 1
```

## Root cause

The root `app/layout.tsx` renders `<Header/>`, which calls `createClient()` and `supabase.auth.getUser()` on every request. Because that client construction reads the auth cookie, **no page beneath the layout can be statically rendered** — and in practice every app route already renders on demand (`ƒ`).

However, Next.js still attempts to statically generate the framework-provided pages `/_not-found` and `/error` during `next build`. That attempt instantiates a Supabase client at build time. When the Supabase env vars aren't inlined into the build, `@supabase/ssr` throws and the entire production build fails. There is no custom `not-found.tsx`/`error.tsx` to short-circuit this.

## Fix

Declare the root layout dynamic:

```ts
export const dynamic = 'force-dynamic'
```

This is honest about the layout's inherent dynamism (it reads cookies/auth every request) and prevents `next build` from trying to statically prerender `/_not-found` and `/error`. Every route already rendered on demand due to the shared layout, so this is **not a runtime regression** — it only removes the fragile build-time static-generation attempt.

## Verification

`next build` was run in `web` **without** any Supabase env vars set:

- Before: build exits with code 1 on `/_not-found` prerender error.
- After: `✓ Compiled successfully`, `✓ Generating static pages`, `/_not-found` reported as `ƒ` (dynamic), exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019cbdFb3jY1tvmDjieZewfB)_